### PR TITLE
added quotes to url and checksum

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -64,8 +64,8 @@ jobs:
           ```
           cdf.toml:
           [library.deployment_packs]
-          url = https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/packages.zip
-          checksum = ${{ steps.checksum.outputs.checksum }}
+          url = "https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.version }}/packages.zip"
+          checksum = "${{ steps.checksum.outputs.checksum }}"
           ```
         files: packages.zip
         draft: false


### PR DESCRIPTION
# Problem
Copy and pasting the current text in the usage section will throw an error. End users will likely be confused on why an error is thrown when they copy and paste to the cdf.toml file.

<img width="1085" height="390" alt="image" src="https://github.com/user-attachments/assets/30fb4653-a55c-4243-a0d7-e62eac8db17f" />

# Solution

Adding quotes better aligns with the plug and play aspect of this library. Especially since there appears to be no official documentation on this alpha-feature.

i.e.) https://docs.cognite.com/cdf/deploy/cdf_toolkit/api/alpha_flags

<img width="1085" height="480" alt="image" src="https://github.com/user-attachments/assets/2ab627f7-defd-466d-931c-e55e222dc762" />

