### PR TITLE
Clean old annotations bug

### DIFF
--- a/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/FinalizeService.py
+++ b/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/FinalizeService.py
@@ -240,7 +240,8 @@ class GeneralFinalizeService(AbstractFinalizeService):
                         # This should only run once, so we tie it to the regular annotation processing
                         doc_delete, tag_delete = self.apply_service.delete_annotations_for_file(file_id)
                         self.report_service.delete_annotations(doc_delete, tag_delete)
-
+                        self.logger.info(f"\t- Deleted {len(doc_delete)} doc and {len(tag_delete)} tag annotations.")
+                    
                     doc_add, tag_add = self.apply_service.apply_annotations(regular_item, file_node)
                     self.report_service.add_annotations(doc_rows=doc_add, tag_rows=tag_add)
                     annotation_msg: str = f"Applied {len(doc_add)} doc and {len(tag_add)} tag annotations."


### PR DESCRIPTION
When clean old annotations is set to true and I'm annotating files with more than the page range set in the config, it'll delete the old annotations in the first chunk before applying annotations to the next chunk of pages.

This poses a problem for multi-page documents that are larger than the page range set in the ep config file.

As an example, if my page range is 50 and I have a file with 75 pages.

It'll delete annotations for a file on the pages 1-50 then annotate those files.

On the next run it will delete all annotations on the file again and annotate pages 51-75.

Effectively deleting the annotations captured on runs 1-50. 