### PR TITLE
Making canvas URL generation dynamic and environment-aware

### DIFF
--- a/modules/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard/helper.py
+++ b/modules/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard/helper.py
@@ -40,7 +40,7 @@ def generate_file_canvas(
     canvas_name = f"Annotation Quality Analysis - {file_node.external_id}"
 
     try:
-        domain = ep_config.get("streamlitDashboard", {}).get("industrialCanvasDomain", "cog-shadow-projects")
+        domain = os.getenv("COGNITE_ORGANIZATION", "cog-shadow-projects")
         project = client.config.project
         cluster = client.config.cdf_cluster
 

--- a/modules/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard/helper.py
+++ b/modules/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard/helper.py
@@ -40,7 +40,7 @@ def generate_file_canvas(
     canvas_name = f"Annotation Quality Analysis - {file_node.external_id}"
 
     try:
-        domain = os.getenv("COGNITE_ORGANIZATION", "cog-shadow-projects")
+        domain = os.getenv("COGNITE_ORGANIZATION")
         project = client.config.project
         cluster = client.config.cdf_cluster
 


### PR DESCRIPTION
Closes issue #48.

Making canvas URL generation dynamic and envvironment-aware by getting the org from the `COGNITE_ORGANIZATION` environment variable.
