### PR TITLE
Remove report service

### DIFF
--- a/modules/contextualization/cdf_file_annotation/extraction_pipelines/ep_file_annotation.config.yaml
+++ b/modules/contextualization/cdf_file_annotation/extraction_pipelines/ep_file_annotation.config.yaml
@@ -120,14 +120,13 @@ config:
             operator: Exists
             targetProperty: diagramDetectJobId
     applyService:
+      autoApprovalThreshold: 1.0
+      autoSuggestThreshold: 1.0
       sinkNode:
           space: {{ patternModeInstanceSpace }}
           externalId: {{patternDetectSink}}
-      autoApprovalThreshold: 1.0
-      autoSuggestThreshold: 1.0
-    reportService:
       rawDb: {{ rawDb }}
       rawTableDocTag: {{ rawTableDocTag }}
       rawTableDocDoc: {{ rawTableDocDoc }}
       rawTableDocPattern: {{ rawTableDocPattern }}
-      rawBatchSize: 1000
+

--- a/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ApplyService.py
+++ b/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ApplyService.py
@@ -110,25 +110,25 @@ class GeneralApplyService(IApplyService):
 
         # Step 4: Apply all data model and RAW changes
         self.update_instances(list_node_apply=node_apply, list_edge_apply=regular_edges + pattern_edges)
-        db_name = self.config.finalize_function.report_service.raw_db
+        db_name = self.config.finalize_function.apply_service.raw_db
         if doc_rows:
             self.client.raw.rows.insert(
                 db_name=db_name,
-                table_name=self.config.finalize_function.report_service.raw_table_doc_doc,
+                table_name=self.config.finalize_function.apply_service.raw_table_doc_doc,
                 row=doc_rows,
                 ensure_parent=True,
             )
         if tag_rows:
             self.client.raw.rows.insert(
                 db_name=db_name,
-                table_name=self.config.finalize_function.report_service.raw_table_doc_tag,
+                table_name=self.config.finalize_function.apply_service.raw_table_doc_tag,
                 row=tag_rows,
                 ensure_parent=True,
             )
         if pattern_rows:
             self.client.raw.rows.insert(
                 db_name=db_name,
-                table_name=self.config.finalize_function.report_service.raw_table_doc_pattern,
+                table_name=self.config.finalize_function.apply_service.raw_table_doc_pattern,
                 row=pattern_rows,
                 ensure_parent=True,
             )
@@ -160,14 +160,14 @@ class GeneralApplyService(IApplyService):
                 self.client.data_modeling.instances.delete(edges=edge_ids)
             if doc_keys:
                 self.client.raw.rows.delete(
-                    db_name=self.config.finalize_function.report_service.raw_db,
-                    table_name=self.config.finalize_function.report_service.raw_table_doc_doc,
+                    db_name=self.config.finalize_function.apply_service.raw_db,
+                    table_name=self.config.finalize_function.apply_service.raw_table_doc_doc,
                     key=doc_keys,
                 )
             if tag_keys:
                 self.client.raw.rows.delete(
-                    db_name=self.config.finalize_function.report_service.raw_db,
-                    table_name=self.config.finalize_function.report_service.raw_table_doc_tag,
+                    db_name=self.config.finalize_function.apply_service.raw_db,
+                    table_name=self.config.finalize_function.apply_service.raw_table_doc_tag,
                     key=tag_keys,
                 )
             counts["doc"], counts["tag"] = len(doc_keys), len(tag_keys)
@@ -182,8 +182,8 @@ class GeneralApplyService(IApplyService):
                 self.client.data_modeling.instances.delete(edges=edge_ids)
             if row_keys:
                 self.client.raw.rows.delete(
-                    db_name=self.config.finalize_function.report_service.raw_db,
-                    table_name=self.config.finalize_function.report_service.raw_table_doc_pattern,
+                    db_name=self.config.finalize_function.apply_service.raw_db,
+                    table_name=self.config.finalize_function.apply_service.raw_table_doc_pattern,
                     key=row_keys,
                 )
             counts["pattern"] = len(row_keys)

--- a/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ConfigService.py
+++ b/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ConfigService.py
@@ -204,17 +204,13 @@ class RetrieveServiceConfig(BaseModel, alias_generator=to_camel):
 
 
 class ApplyServiceConfig(BaseModel, alias_generator=to_camel):
-    sink_node: NodeId
     auto_approval_threshold: float = Field(gt=0.0, le=1.0)
     auto_suggest_threshold: float = Field(gt=0.0, le=1.0)
-
-
-class ReportServiceConfig(BaseModel, alias_generator=to_camel):
+    sink_node: NodeId
     raw_db: str
     raw_table_doc_tag: str
     raw_table_doc_doc: str
     raw_table_doc_pattern: str
-    raw_batch_size: int
 
 
 class FinalizeFunction(BaseModel, alias_generator=to_camel):
@@ -222,7 +218,6 @@ class FinalizeFunction(BaseModel, alias_generator=to_camel):
     max_retry_attempts: int
     retrieve_service: RetrieveServiceConfig
     apply_service: ApplyServiceConfig
-    report_service: ReportServiceConfig
 
 
 class DataModelViews(BaseModel, alias_generator=to_camel):

--- a/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/ConfigService.py
+++ b/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/ConfigService.py
@@ -204,17 +204,13 @@ class RetrieveServiceConfig(BaseModel, alias_generator=to_camel):
 
 
 class ApplyServiceConfig(BaseModel, alias_generator=to_camel):
-    sink_node: NodeId
     auto_approval_threshold: float = Field(gt=0.0, le=1.0)
     auto_suggest_threshold: float = Field(gt=0.0, le=1.0)
-
-
-class ReportServiceConfig(BaseModel, alias_generator=to_camel):
+    sink_node: NodeId
     raw_db: str
     raw_table_doc_tag: str
     raw_table_doc_doc: str
     raw_table_doc_pattern: str
-    raw_batch_size: int
 
 
 class FinalizeFunction(BaseModel, alias_generator=to_camel):
@@ -222,7 +218,6 @@ class FinalizeFunction(BaseModel, alias_generator=to_camel):
     max_retry_attempts: int
     retrieve_service: RetrieveServiceConfig
     apply_service: ApplyServiceConfig
-    report_service: ReportServiceConfig
 
 
 class DataModelViews(BaseModel, alias_generator=to_camel):


### PR DESCRIPTION
Report service has been deprecated in favor of a simpler transaction system, where the upload of diagram detect results to RAW will be uploaded at the same time as the edges are created.

This means we no longer need the report service.