### PR TITLE
Applying quick adjustments on File Annotation Streamlit apps

### DIFF
--- a/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/client_factory.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/client_factory.py
@@ -7,7 +7,7 @@ from cognite.client.credentials import OAuthClientCredentials
 
 class CogniteClientFactory:
     @staticmethod
-    def create_from_env(debug: bool = False) -> Optional[CogniteClient]:
+    def create_from_env(cluster_prefix: str = "", debug: bool = False) -> Optional[CogniteClient]:
         project = os.getenv("CDF_PROJECT")
         cluster = os.getenv("CDF_CLUSTER")
         tenant_id = os.getenv("IDP_TENANT_ID")
@@ -28,7 +28,7 @@ class CogniteClientFactory:
         cnf = ClientConfig(
             client_name="DEV_Working",
             project=project,
-            base_url=f"https://p001.plink.{cluster}.cognitedata.com",
+            base_url=f"https://{cluster_prefix}{cluster}.cognitedata.com",
             credentials=creds,
             debug=debug,
         )

--- a/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/components.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/components.py
@@ -843,33 +843,42 @@ class PatternCatalogComponent(Component):
             manual_patterns_editor_key = st.session_state.manual_patterns_editor_key
 
             if manual_df is None or manual_df.empty:
-                st.info("No manual patterns available.")
+                columns = list(manual_column_config.keys())
+                display_df = pd.DataFrame(columns=columns)
+
+                st.metric(
+                    "Manual patterns help",
+                    "Hover for instructions",
+                    help=(
+                        "Add, edit or remove patterns here. "
+                        "Use 'Reset changes' to revert in-memory edits or 'Save changes' to persist changes to the raw table."
+                    ),
+                )
             else:
                 columns = [c for c in list(manual_column_config.keys()) if c in manual_df.columns]
-
                 display_df = manual_df.loc[:, columns]
-                
-                capture_handler = DataEditorChangeCaptureFactory.make_change_capture_handler(display_df, manual_patterns_editor_key, FieldNames.PATTERN_SCOPE_SNAKE_CASE, "manual_patterns_changes")
 
-                edited = st.data_editor(
-                    display_df,
-                    key=manual_patterns_editor_key,
-                    column_config=manual_column_config,
-                    width="stretch",
-                    hide_index=True,
-                    num_rows="dynamic",
-                    on_change=capture_handler,
-                )
+            capture_handler = DataEditorChangeCaptureFactory.make_change_capture_handler(display_df, manual_patterns_editor_key, FieldNames.PATTERN_SCOPE_SNAKE_CASE, "manual_patterns_changes")
 
-                col_save, col_reset = st.columns([1, 1])
+            edited = st.data_editor(
+                display_df,
+                key=manual_patterns_editor_key,
+                column_config=manual_column_config,
+                width="stretch",
+                hide_index=True,
+                num_rows="dynamic",
+                on_change=capture_handler,
+            )
 
-                with col_save:
-                    if st.button("Save changes", key="manual_patterns_save_btn"):
-                        self._save_manual_pattern_changes(edited)
-                        st.session_state["manual_patterns_changes"] = set()
-                with col_reset:
-                    if st.button("Reset changes", key="manual_patterns_reset_btn"):
-                        self._reset_manual_pattern_changes()
+            col_save, col_reset = st.columns([1, 1])
+
+            with col_save:
+                if st.button("Save changes", key="manual_patterns_save_btn"):
+                    self._save_manual_pattern_changes(edited)
+                    st.session_state["manual_patterns_changes"] = set()
+            with col_reset:
+                if st.button("Reset changes", key="manual_patterns_reset_btn"):
+                    self._reset_manual_pattern_changes()
 
         with right:
             st.subheader("Automatic Patterns")

--- a/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/ui.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/ui.py
@@ -60,15 +60,21 @@ class AnnotationQualityUI:
             files_metadata = DataFetcher.fetch_entities_metadata(self.client, extraction_pipeline_cfg=extraction_pipeline_cfg, entity_type=FieldNames.FILE_TITLE_CASE)
             annotation_frames = DataProcessor.enrich_annotation_frames_with_files_metadata(annotation_frames, files_metadata)
 
-        overall_tab, per_file_tab, pattern_management_tab = st.tabs(["Overall Quality Metrics", "Per-File Analysis", "Pattern Management"])
+        tab_options = ["Overall Quality Metrics", "Per-File Analysis", "Pattern Management"]
 
-        with overall_tab:
+        if "annotation_quality_tab_selector" not in st.session_state:
+            st.session_state["annotation_quality_tab_selector"] = tab_options[0]
+
+        try:
+            index = tab_options.index(st.session_state.get("annotation_quality_tab_selector", tab_options[0]))
+        except ValueError:
+            index = 0
+
+        selected_tab = st.radio("Tabs", tab_options, index=index, horizontal=True, key="annotation_quality_tab_selector")
+
+        if selected_tab == "Overall Quality Metrics":
             OverallTab().render(self.client, extraction_pipeline_cfg, actual_df=annotation_frames.actual_df, potential_df=annotation_frames.potential_df)
-        with per_file_tab:
+        elif selected_tab == "Per-File Analysis":
             PerFileTab().render(self.client, extraction_pipeline_cfg, actual_df=annotation_frames.actual_df, potential_df=annotation_frames.potential_df)
-        with pattern_management_tab:
+        elif selected_tab == "Pattern Management":
             PatternManagementTab().render(self.client, extraction_pipeline_cfg)
-
-        if "initial_rerun_done" not in st.session_state:
-            st.session_state.initial_rerun_done = True
-            st.rerun()

--- a/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_pipeline_health/client_factory.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_pipeline_health/client_factory.py
@@ -7,7 +7,7 @@ from cognite.client.credentials import OAuthClientCredentials
 
 class CogniteClientFactory:
     @staticmethod
-    def create_from_env(debug: bool = False) -> Optional[CogniteClient]:
+    def create_from_env(cluster_prefix: str = "", debug: bool = False) -> Optional[CogniteClient]:
         project = os.getenv("CDF_PROJECT")
         cluster = os.getenv("CDF_CLUSTER")
         tenant_id = os.getenv("IDP_TENANT_ID")
@@ -28,7 +28,7 @@ class CogniteClientFactory:
         cnf = ClientConfig(
             client_name="DEV_Working",
             project=project,
-            base_url=f"https://p001.plink.{cluster}.cognitedata.com",
+            base_url=f"https://{cluster_prefix}{cluster}.cognitedata.com",
             credentials=creds,
             debug=debug,
         )

--- a/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_pipeline_health/ui.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_pipeline_health/ui.py
@@ -60,15 +60,21 @@ class PipelineHealthUI:
         with st.spinner(f"Fetching pipeline run history for '{selected_pipeline}'..."):
             pipeline_runs = DataFetcher.fetch_pipeline_run_history(self.client, selected_pipeline)
 
-        overview_tab, file_explorer_tab, run_history_tab = st.tabs(["Overview", "File Explorer", "Run History"])
+        tab_options = ["Overview", "File Explorer", "Run History"]
 
-        with overview_tab:
+        if "pipeline_health_tab_selector" not in st.session_state:
+            st.session_state["pipeline_health_tab_selector"] = tab_options[0]
+
+        try:
+            index = tab_options.index(st.session_state.get("pipeline_health_tab_selector", tab_options[0]))
+        except ValueError:
+            index = 0
+
+        selected_tab = st.radio("Tabs", tab_options, index=index, horizontal=True, key="pipeline_health_tab_selector")
+
+        if selected_tab == "Overview":
             OverviewTab(self.client, df_annotation_states).render()
-        with file_explorer_tab:
+        elif selected_tab == "File Explorer":
             FileExplorerTab(self.client, df_annotation_states, extraction_pipeline_cfg).render()
-        with run_history_tab:
+        elif selected_tab == "Run History":
             RunHistoryTab(self.client, pipeline_runs, df_annotation_states, extraction_pipeline_cfg).render()
-
-        if "initial_rerun_done" not in st.session_state:
-            st.session_state.initial_rerun_done = True
-            st.rerun()


### PR DESCRIPTION
- Replacing st.tabs by st.radio to avoid refreshing issues (first tab is always being selected when page reruns)
- Allowing user to edit manual patterns even if table is previously empty
- Handling with private clusters (cluster prefix when locally running allows user to pass a private cluster prefix)

