### PR TITLE
Add multi-view support and incremental finalize handling in cdf_file_annotation

### DIFF
--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ApplyService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ApplyService.py
@@ -105,6 +105,19 @@ class GeneralApplyService(IApplyService):
         file_id = file_node.as_id()
         source_id = cast(str, file_node.properties.get(self.file_view_id, {}).get("sourceId"))
 
+        # The Diagrams detect API can complete a job with per-file failures reported in the item payload
+        # (e.g. `errorMessage` for unsupported mime types). Treat those as per-file failures so the
+        # finalize retry/failed logic can handle them, rather than silently "succeeding" with 0 annotations.
+        regular_error = regular_item.get("errorMessage") if regular_item else None
+        pattern_error = pattern_item.get("errorMessage") if pattern_item else None
+        if regular_error or pattern_error:
+            parts = []
+            if regular_error:
+                parts.append(f"regular item error: {regular_error}")
+            if pattern_error:
+                parts.append(f"pattern item error: {pattern_error}")
+            raise RuntimeError(f"Diagram detect returned an error for file {file_id.as_tuple()}: " + " | ".join(parts))
+
         if clean_old:
             deleted_counts = self._delete_annotations_for_file(file_id)
             self.logger.info(

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/FinalizeService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/FinalizeService.py
@@ -1,9 +1,11 @@
 import abc
 import time
 from datetime import datetime, timezone
-from typing import Literal, cast
+from enum import Enum
+from typing import Any, Literal, cast
 
 from cognite.client import CogniteClient
+from cognite.client.data_classes import RowWrite
 from cognite.client.data_classes.data_modeling import (
     Node,
     NodeApply,
@@ -56,6 +58,7 @@ class GeneralFinalizeService(AbstractFinalizeService):
     """
     Implementation of the FinalizeService.
     """
+    FINALIZED_FILES_RAW_TABLE = "annotation_finalize_processed_files"
 
     def __init__(
         self,
@@ -83,6 +86,8 @@ class GeneralFinalizeService(AbstractFinalizeService):
         self.clean_old_annotations: bool = config.finalize_function.clean_old_annotations
         self.function_id: int | None = function_call_info.get("function_id")
         self.call_id: int | None = function_call_info.get("call_id")
+        self.raw_db: str = config.raw_tables.raw_db
+        self.finalized_files_raw_table: str = self.FINALIZED_FILES_RAW_TABLE
 
     def run(self) -> Literal["Done"] | None:
         """
@@ -150,15 +155,9 @@ class GeneralFinalizeService(AbstractFinalizeService):
             )
             return
 
-        # A job is considered complete if:
-        # 1. The main job is finished, AND
-        # 2. EITHER pattern mode was not enabled (no pattern job ID)
-        #    OR pattern mode was enabled AND its job is also finished.
-        jobs_complete: bool = job_results is not None and (not pattern_mode_job or pattern_mode_job_results is not None)
-
-        if not jobs_complete:
+        if job_results is None:
             self.logger.info(
-                message=f"Unfinalizing {len(file_to_state_map.keys())} files - job {regular_job} and/or pattern id {pattern_mode_job} not complete",
+                message=f"Unfinalizing {len(file_to_state_map.keys())} files - unable to retrieve regular job payload for {regular_job}",
                 section="BOTH",
             )
             self._update_batch_state(
@@ -169,30 +168,63 @@ class GeneralFinalizeService(AbstractFinalizeService):
             time.sleep(30)
             return
 
+        regular_items_map = self._index_items_by_file(job_results)
+        pattern_items_map = self._index_items_by_file(pattern_mode_job_results) if pattern_mode_job_results else {}
+
+        merged_results: dict[tuple[str, str], dict[str, dict | None]] = {}
+        pending_nodes: list[Node] = []
+        pending_external_ids: list[str] = []
+        ready_external_ids: list[str] = []
+
+        for file_id, state_node in file_to_state_map.items():
+            key = file_id.as_tuple()
+            regular_item = regular_items_map.get(key)
+            pattern_item = pattern_items_map.get(key) if pattern_mode_job else None
+            regular_done = self._is_item_terminal(regular_item)
+            pattern_done = True if not pattern_mode_job else self._is_item_terminal(pattern_item)
+
+            if regular_done and pattern_done:
+                merged_results[key] = {"regular": regular_item, "pattern": pattern_item}
+                ready_external_ids.append(file_id.external_id)
+            else:
+                pending_nodes.append(state_node)
+                pending_external_ids.append(file_id.external_id)
+
+        if not merged_results:
+            self.logger.info(
+                message=(
+                    f"No terminal file items yet for claimed batch. "
+                    f"regular_job={regular_job}, pattern_job={pattern_mode_job}, pending_files={len(pending_external_ids)}"
+                ),
+                section="BOTH",
+            )
+            if pending_external_ids:
+                self.logger.info(
+                    message=f"Pending file externalIds: {', '.join(pending_external_ids)}",
+                    section="END",
+                )
+            self._update_batch_state(
+                batch=BatchOfNodes(nodes=pending_nodes),
+                status=AnnotationStatus.PROCESSING,
+            )
+            self.logger.info(message="Sleeping for 30 seconds")
+            time.sleep(30)
+            return
+
         self.logger.info(
-            f"Both jobs {regular_job} and {pattern_mode_job} complete. Applying all annotations.",
+            message=(
+                f"Finalizing {len(ready_external_ids)} files with terminal detect results. "
+                f"externalIds: {', '.join(ready_external_ids)}"
+            ),
             section="END",
         )
-
-        merged_results = {
-            (item["fileInstanceId"]["space"], item["fileInstanceId"]["externalId"]): {"regular": item}
-            for item in job_results["items"]
-        }
-        if pattern_mode_job_results:
-            for item in pattern_mode_job_results["items"]:
-                key = (
-                    item["fileInstanceId"]["space"],
-                    item["fileInstanceId"]["externalId"],
-                )
-                if key in merged_results:
-                    merged_results[key]["pattern"] = item
-                else:
-                    merged_results[key] = {"pattern": item}
 
         count_retry, count_failed, count_success = 0, 0, 0
         annotation_state_node_applies: list[NodeApply] = []
         file_node_applies: list[NodeApply] = []
 
+        finalized_external_ids: list[str] = []
+        finalized_records: list[dict[str, Any]] = []
         for (space, external_id), results in merged_results.items():
             file_id = NodeId(space, external_id)
             file_node = self.client.data_modeling.instances.retrieve_nodes(
@@ -201,7 +233,10 @@ class GeneralFinalizeService(AbstractFinalizeService):
             if not file_node:
                 continue
 
-            annotation_state_node = file_to_state_map[file_id]
+            annotation_state_node = file_to_state_map.get(file_id)
+            if not annotation_state_node:
+                self.logger.warning(f"Missing annotation state for finalized file {file_id.external_id}. Skipping.")
+                continue
             current_attempt = cast(
                 int,
                 annotation_state_node.properties[self.annotation_state_view.as_view_id()]["attemptCount"],
@@ -247,6 +282,7 @@ class GeneralFinalizeService(AbstractFinalizeService):
                         annotation_msg,
                         pattern_msg,
                     )
+                    final_status: str | AnnotationStatus = AnnotationStatus.ANNOTATED
                     count_success += 1
                 else:
                     job_node_to_update = self._process_annotation_state(
@@ -258,6 +294,7 @@ class GeneralFinalizeService(AbstractFinalizeService):
                         "Processed page batch, more pages remaining",
                         pattern_msg,
                     )
+                    final_status = AnnotationStatus.NEW
                     count_success += 1  # Still a success for this batch
 
             except Exception as e:
@@ -280,6 +317,7 @@ class GeneralFinalizeService(AbstractFinalizeService):
                         annotation_message=str(e),
                         pattern_mode_message=str(e),
                     )
+                    final_status = AnnotationStatus.FAILED
                     count_failed += 1
                 else:
                     job_node_to_update = self._process_annotation_state(
@@ -289,9 +327,27 @@ class GeneralFinalizeService(AbstractFinalizeService):
                         annotation_message=str(e),
                         pattern_mode_message=str(e),
                     )
+                    final_status = AnnotationStatus.RETRY
                     count_retry += 1
 
             annotation_state_node_applies.append(job_node_to_update)
+            finalized_external_ids.append(file_id.external_id)
+            finalized_records.append(
+                {
+                    "fileSpace": file_id.space,
+                    "fileExternalId": file_id.external_id,
+                    "annotationStatus": self._enum_to_value(final_status),
+                    "regularJobId": regular_job[0] if regular_job else None,
+                    "patternModeJobId": pattern_mode_job[0] if pattern_mode_job else None,
+                    "regularItemStatus": (results.get("regular") or {}).get("status"),
+                    "patternItemStatus": (results.get("pattern") or {}).get("status"),
+                    "regularItemError": (results.get("regular") or {}).get("errorMessage"),
+                    "patternItemError": (results.get("pattern") or {}).get("errorMessage"),
+                    "functionId": self.function_id,
+                    "functionCallId": self.call_id,
+                    "finalizedAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+                }
+            )
 
         # Batch update the state nodes at the end
         if annotation_state_node_applies or file_node_applies:
@@ -311,8 +367,102 @@ class GeneralFinalizeService(AbstractFinalizeService):
                     section="END",
                 )
 
+        if finalized_external_ids:
+            self.logger.info(
+                message=(
+                    f"Finalized files in this cycle ({len(finalized_external_ids)}): "
+                    f"{', '.join(finalized_external_ids)}"
+                ),
+                section="BOTH",
+            )
+            self._write_finalized_files_rows(finalized_records)
+
+        if pending_nodes:
+            self.logger.info(
+                message=(
+                    f"Keeping {len(pending_nodes)} files in Processing for next finalize poll. "
+                    f"externalIds: {', '.join(pending_external_ids)}"
+                ),
+                section="END",
+            )
+            self._update_batch_state(
+                batch=BatchOfNodes(nodes=pending_nodes),
+                status=AnnotationStatus.PROCESSING,
+            )
+            # Keep the polling cadence moderate when there are still pending items.
+            self.logger.info(message="Sleeping for 30 seconds")
+            time.sleep(30)
+
         self.tracker.add_files(success=count_success, failed=(count_failed + count_retry))
         return None
+
+    def _write_finalized_files_rows(self, finalized_records: list[dict[str, Any]]) -> None:
+        if not finalized_records:
+            return
+
+        base_ts = int(time.time() * 1000)
+        rows: list[RowWrite] = []
+        for idx, record in enumerate(finalized_records):
+            key = (
+                f"{base_ts}_{idx}_{record['fileSpace']}_{record['fileExternalId']}"
+                f"_{record.get('functionCallId') or 'na'}"
+            )
+            rows.append(RowWrite(key=key, columns=record))
+
+        try:
+            self.client.raw.rows.insert(
+                db_name=self.raw_db,
+                table_name=self.finalized_files_raw_table,
+                row=rows,
+                ensure_parent=True,
+            )
+            self.logger.info(
+                message=(
+                    f"Wrote {len(rows)} finalized file records to RAW "
+                    f"{self.raw_db}.{self.finalized_files_raw_table}"
+                ),
+                section="BOTH",
+            )
+        except Exception as e:
+            self.logger.error(
+                message=(
+                    f"Failed writing finalized file records to RAW "
+                    f"{self.raw_db}.{self.finalized_files_raw_table}"
+                ),
+                error=e,
+                section="END",
+            )
+
+    @staticmethod
+    def _enum_to_value(value: Any) -> Any:
+        if isinstance(value, Enum):
+            return value.value
+        return value
+
+    def _index_items_by_file(self, job_results: dict | None) -> dict[tuple[str, str], dict]:
+        if not job_results:
+            return {}
+        indexed: dict[tuple[str, str], dict] = {}
+        for item in cast(list[dict], job_results.get("items", [])):
+            file_instance = cast(dict, item.get("fileInstanceId", {}))
+            space = file_instance.get("space")
+            external_id = file_instance.get("externalId")
+            if space and external_id:
+                indexed[(space, external_id)] = item
+        return indexed
+
+    def _is_item_terminal(self, item: dict | None) -> bool:
+        if item is None:
+            return False
+        status = str(item.get("status", "")).strip().lower()
+        if status in {"completed", "failed", "cancelled", "canceled"}:
+            return True
+        if item.get("errorMessage"):
+            return True
+        # Defensive fallback for payloads where status may be omitted on completed items.
+        if status == "" and ("annotations" in item or "pageCount" in item):
+            return True
+        return False
 
     def _process_annotation_state(
         self,

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/RetrieveService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/RetrieveService.py
@@ -59,17 +59,17 @@ class GeneralRetrieveService(IRetrieveService):
         """
         Retrieves the results of a diagram detection job by job ID.
 
-        Polls the diagram detect API to check if a job has completed and returns the results
-        if available.
+        Polls the diagram detect API and returns the latest payload.
+        The payload is returned even while the job is still running, allowing callers
+        to process terminal file items incrementally instead of waiting for full job completion.
 
         Args:
             job_id: The diagram detection job ID to retrieve results for.
 
         Returns:
-            Dictionary containing job results if completed, None if still processing or failed.
+            Dictionary containing job results payload when request succeeds, None if request fails.
         """
         url = f"{self.job_api}/{job_id}"
-        result = None
         response = self.client.get(url, headers={"X-Job-Token": job_token})
         if response.status_code == 200:
             job_results: dict = response.json()
@@ -79,11 +79,10 @@ class GeneralRetrieveService(IRetrieveService):
             if job_results.get("status") == "Completed":
                 self.logger.info(f"Job complete - {status_count} - {job_id}")
                 self.logger.debug(f"Below is the full response:\n{response.text}")
-                result = job_results
-                return result
             else:
                 self.logger.info(f"Job not complete - {status_count} - {job_id}")
                 self.logger.debug(f"Below is the full response:\n{response.text}")
+            return job_results
         else:
             self.logger.info(f"Request to get the job results failed - {response.url}")
             self.logger.info(f"Below is the full response:\n{response.text}")

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/CacheService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/CacheService.py
@@ -64,7 +64,7 @@ class GeneralCacheService(ICacheService):
         self.cache_time_limit: int = config.launch_function.cache_service.cache_time_limit  # in hours
 
         self.file_view: ViewPropertyConfig = config.data_model_views.file_view
-        self.target_entities_view: ViewPropertyConfig = config.data_model_views.target_entities_view
+        self.target_entities_views: list[ViewPropertyConfig] = config.data_model_views.get_target_entity_views()
 
     def get_entities(
         self,
@@ -195,7 +195,7 @@ class GeneralCacheService(ICacheService):
         return True
 
     def _convert_instances_to_entities(
-        self, asset_instances: NodeList, file_instances: NodeList
+        self, asset_instances: list[Node], file_instances: NodeList
     ) -> tuple[list[dict], list[dict]]:
         """
         Transforms data model node instances into entity dictionaries for diagram detection.
@@ -212,25 +212,75 @@ class GeneralCacheService(ICacheService):
                 - List of target entity dictionaries (typically assets).
                 - List of file entity dictionaries.
         """
+        def _normalize_search_property(
+            raw_value: Any, fallback_value: str | None, entity_external_id: str, entity_kind: str
+        ) -> list[str]:
+            """Ensure diagram-detect search_property is list[str]."""
+            normalized: list[str] = []
+
+            if isinstance(raw_value, str):
+                value = raw_value.strip()
+                if value:
+                    normalized.append(value)
+            elif isinstance(raw_value, (list, tuple, set)):
+                for item in raw_value:
+                    if isinstance(item, str):
+                        value = item.strip()
+                        if value:
+                            normalized.append(value)
+                    elif isinstance(item, (int, float, bool)):
+                        normalized.append(str(item))
+            elif isinstance(raw_value, (int, float, bool)):
+                normalized.append(str(raw_value))
+
+            normalized = list(dict.fromkeys(normalized))
+            if not normalized and fallback_value:
+                fallback = str(fallback_value).strip()
+                if fallback:
+                    normalized = [fallback]
+                    self.logger.debug(
+                        f"{entity_kind} '{entity_external_id}' has invalid/empty search_property; "
+                        "using fallback name."
+                    )
+            return normalized
+
         target_entities_resource_type: str | None = self.config.launch_function.target_entities_resource_property
         target_entities_search_property: str = self.config.launch_function.target_entities_search_property
         target_entities: list[dict] = []
 
         for instance in asset_instances:
-            instance_properties = instance.properties.get(self.target_entities_view.as_view_id())
+            matched_view: ViewPropertyConfig | None = None
+            instance_properties: dict[str, Any] | None = None
+            for candidate_view in self.target_entities_views:
+                candidate_props = instance.properties.get(candidate_view.as_view_id())
+                if candidate_props is not None:
+                    matched_view = candidate_view
+                    instance_properties = candidate_props
+                    break
+            if not matched_view or instance_properties is None:
+                self.logger.warning(
+                    f"Skipping target entity {instance.space}/{instance.external_id}: unable to resolve source view"
+                )
+                continue
             asset_resource_type: str = (
                 instance_properties.get(target_entities_resource_type)
                 if target_entities_resource_type
-                else self.target_entities_view.external_id
+                else matched_view.external_id
             )
             if target_entities_search_property in instance_properties:
+                search_property = _normalize_search_property(
+                    raw_value=instance_properties.get(target_entities_search_property),
+                    fallback_value=instance_properties.get("name"),
+                    entity_external_id=instance.external_id,
+                    entity_kind="Target entity",
+                )
                 asset_entity = entity(
                     external_id=instance.external_id,
                     name=instance_properties.get("name"),
                     space=instance.space,
-                    annotation_type=self.target_entities_view.annotation_type,
+                    annotation_type=matched_view.annotation_type,
                     resource_type=asset_resource_type,
-                    search_property=instance_properties.get(target_entities_search_property),
+                    search_property=search_property,
                 )
                 target_entities.append(asset_entity.to_dict())
             else:
@@ -239,7 +289,7 @@ class GeneralCacheService(ICacheService):
                     external_id=instance.external_id,
                     name=instance_properties.get("name"),
                     space=instance.space,
-                    annotation_type=self.target_entities_view.annotation_type,
+                    annotation_type=matched_view.annotation_type,
                     resource_type=asset_resource_type,
                     search_property=search_value,
                 )
@@ -253,8 +303,14 @@ class GeneralCacheService(ICacheService):
             instance_properties = instance.properties.get(self.file_view.as_view_id())
             file_entity_resource_type: str = (
                 instance_properties[file_resource_type_prop]
-                if target_entities_resource_type
+                if file_resource_type_prop
                 else self.file_view.external_id
+            )
+            search_property = _normalize_search_property(
+                raw_value=instance_properties.get(file_search_property),
+                fallback_value=instance_properties.get("name"),
+                entity_external_id=instance.external_id,
+                entity_kind="File entity",
             )
             file_entity = entity(
                 external_id=instance.external_id,
@@ -262,7 +318,7 @@ class GeneralCacheService(ICacheService):
                 space=instance.space,
                 annotation_type=self.file_view.annotation_type,
                 resource_type=file_entity_resource_type,
-                search_property=instance_properties.get(file_search_property),
+                search_property=search_property,
             )
             file_entities.append(file_entity.to_dict())
 

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/ConfigService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/ConfigService.py
@@ -299,7 +299,18 @@ class DataModelViews(BaseModel, alias_generator=to_camel):
     core_annotation_view: ViewPropertyConfig
     annotation_state_view: ViewPropertyConfig
     file_view: ViewPropertyConfig
-    target_entities_view: ViewPropertyConfig
+    target_entities_view: Optional[ViewPropertyConfig] = None
+    target_entities_views: Optional[list[ViewPropertyConfig]] = None
+
+    def get_target_entity_views(self) -> list[ViewPropertyConfig]:
+        # Backward-compatible config handling:
+        # - New format: targetEntitiesViews (list)
+        # - Legacy format: targetEntitiesView (single)
+        if self.target_entities_views:
+            return self.target_entities_views
+        if self.target_entities_view:
+            return [self.target_entities_view]
+        raise ValueError("Configuration must define either targetEntitiesView or targetEntitiesViews")
 
 
 class Config(BaseModel, alias_generator=to_camel):

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/DataModelService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/DataModelService.py
@@ -19,6 +19,7 @@ from cognite.client.data_classes.filters import (
 )
 from services.ConfigService import (
     Config,
+    QueryConfig,
     ViewPropertyConfig,
     build_filter_from_query,
     get_limit_from_query,
@@ -63,7 +64,7 @@ class IDataModelService(abc.ABC):
     @abc.abstractmethod
     def get_instances_entities(
         self, primary_scope_value: str, secondary_scope_value: str | None
-    ) -> tuple[NodeList, NodeList]:
+    ) -> tuple[list[Node], NodeList]:
         pass
 
 
@@ -79,7 +80,7 @@ class GeneralDataModelService(IDataModelService):
 
         self.annotation_state_view: ViewPropertyConfig = config.data_model_views.annotation_state_view
         self.file_view: ViewPropertyConfig = config.data_model_views.file_view
-        self.target_entities_view: ViewPropertyConfig = config.data_model_views.target_entities_view
+        self.target_entities_views: list[ViewPropertyConfig] = config.data_model_views.get_target_entity_views()
 
         self.get_files_to_annotate_retrieve_limit: int | None = get_limit_from_query(
             config.prepare_function.get_files_to_annotate_query
@@ -94,11 +95,12 @@ class GeneralDataModelService(IDataModelService):
         self.filter_files_to_process: Filter = build_filter_from_query(
             config.launch_function.data_model_service.get_files_to_process_query
         )
-        self.filter_target_entities: Filter = build_filter_from_query(
-            config.launch_function.data_model_service.get_target_entities_query
-        )
         self.filter_file_entities: Filter = build_filter_from_query(
             config.launch_function.data_model_service.get_file_entities_query
+        )
+        raw_target_queries = config.launch_function.data_model_service.get_target_entities_query
+        self.target_entity_query_configs: list[QueryConfig] = (
+            raw_target_queries if isinstance(raw_target_queries, list) else [raw_target_queries]
         )
 
     def get_files_for_annotation_reset(self) -> NodeList | None:
@@ -270,7 +272,7 @@ class GeneralDataModelService(IDataModelService):
 
     def get_instances_entities(
         self, primary_scope_value: str, secondary_scope_value: str | None
-    ) -> tuple[NodeList, NodeList]:
+    ) -> tuple[list[Node], NodeList]:
         """
         Retrieves target entities and file entities for use in diagram detection.
 
@@ -289,16 +291,34 @@ class GeneralDataModelService(IDataModelService):
         NOTE: 1. grab assets that meet the filter requirement
         NOTE: 2. grab files that meet the filter requirement
         """
-        target_filter: Filter = self._get_target_entities_filter(primary_scope_value, secondary_scope_value)
         file_filter: Filter = self._get_file_entities_filter(primary_scope_value, secondary_scope_value)
+        target_entities_by_id: dict[tuple[str, str], Node] = {}
+        for query_cfg in self.target_entity_query_configs:
+            target_filter: Filter = self._get_target_entities_filter(
+                query_cfg, primary_scope_value, secondary_scope_value
+            )
+            target_view = query_cfg.target_view
+            target_instance_space = target_view.instance_space
+            if target_instance_space is None:
+                for v in self.target_entities_views:
+                    if (
+                        v.schema_space == target_view.schema_space
+                        and v.external_id == target_view.external_id
+                        and v.version == target_view.version
+                    ):
+                        target_instance_space = v.instance_space
+                        break
+            target_entities_for_view: NodeList = self.client.data_modeling.instances.list(
+                instance_type="node",
+                sources=target_view.as_view_id(),
+                space=target_instance_space,
+                filter=target_filter,
+                limit=-1,  # keep unlimited to ensure complete entity context
+            )
+            for node in target_entities_for_view:
+                target_entities_by_id[(node.space, node.external_id)] = node
 
-        target_entities: NodeList = self.client.data_modeling.instances.list(
-            instance_type="node",
-            sources=self.target_entities_view.as_view_id(),
-            space=self.target_entities_view.instance_space,
-            filter=target_filter,
-            limit=-1,  # NOTE: this should always be kept at -1 so that all entities are retrieved
-        )
+        target_entities: list[Node] = list(target_entities_by_id.values())
         file_entities: NodeList = self.client.data_modeling.instances.list(
             instance_type="node",
             sources=self.file_view.as_view_id(),
@@ -308,7 +328,9 @@ class GeneralDataModelService(IDataModelService):
         )
         return target_entities, file_entities
 
-    def _get_target_entities_filter(self, primary_scope_value: str, secondary_scope_value: str | None) -> Filter:
+    def _get_target_entities_filter(
+        self, query_cfg: QueryConfig, primary_scope_value: str, secondary_scope_value: str | None
+    ) -> Filter:
         """
         Builds a filter for target entities (assets) based on scope and configuration.
 
@@ -326,21 +348,22 @@ class GeneralDataModelService(IDataModelService):
             or
             - grabs assets in the primary_scope_value with ScopeWideDetect in the tags property (hard coded) -> provides an option to include entities outside of the secondary_scope_value
         """
+        target_view = query_cfg.target_view
         filter_primary_scope: Filter = Equals(
-            property=self.target_entities_view.as_property_ref(self.config.launch_function.primary_scope_property),
+            property=target_view.as_property_ref(self.config.launch_function.primary_scope_property),
             value=primary_scope_value,
         )
-        filter_entities: Filter = self.filter_target_entities
+        filter_entities: Filter = query_cfg.build_filter()
         # NOTE: ScopeWideDetect is an optional string that allows annotating across scopes
         filter_scope_wide: Filter = In(
-            property=self.target_entities_view.as_property_ref("tags"),
+            property=target_view.as_property_ref("tags"),
             values=["ScopeWideDetect"],
         )
         if not primary_scope_value:
             target_filter = filter_entities | filter_scope_wide
         elif secondary_scope_value:
             filter_secondary_scope: Filter = Equals(
-                property=self.target_entities_view.as_property_ref(
+                property=target_view.as_property_ref(
                     self.config.launch_function.secondary_scope_property
                 ),
                 value=secondary_scope_value,
@@ -376,9 +399,17 @@ class GeneralDataModelService(IDataModelService):
             value=primary_scope_value,
         )
         filter_entities: Filter = self.filter_file_entities
-        filter_search_property_exists: Filter = Exists(
-            property=self.file_view.as_property_ref(self.config.launch_function.file_search_property),
-        )
+        file_search_property = self.config.launch_function.file_search_property
+        file_search_properties: list[str] = file_search_property if isinstance(file_search_property, list) else [file_search_property]
+        file_search_properties = [prop for prop in file_search_properties if isinstance(prop, str) and prop.strip()]
+        if not file_search_properties:
+            file_search_properties = ["aliases"]
+        search_property_exists_filters: list[Filter] = [
+            Exists(property=self.file_view.as_property_ref(prop_name)) for prop_name in file_search_properties
+        ]
+        filter_search_property_exists: Filter = search_property_exists_filters[0]
+        for f in search_property_exists_filters[1:]:
+            filter_search_property_exists = filter_search_property_exists | f
         # NOTE: ScopeWideDetect is an optional string that allows annotating across scopes
         filter_scope_wide: Filter = In(
             property=self.file_view.as_property_ref("tags"),

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_prepare/services/ConfigService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_prepare/services/ConfigService.py
@@ -13,7 +13,7 @@ from cognite.client.data_classes.contextualization import (
 from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.data_classes.filters import Filter
 from cognite.client.exceptions import CogniteAPIError
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from pydantic.alias_generators import to_camel
 from utils.DataStructures import AnnotationStatus, FilterOperator
 
@@ -299,7 +299,27 @@ class DataModelViews(BaseModel, alias_generator=to_camel):
     core_annotation_view: ViewPropertyConfig
     annotation_state_view: ViewPropertyConfig
     file_view: ViewPropertyConfig
-    target_entities_view: ViewPropertyConfig
+    # Backward compatible: accept legacy singular or new multi-view config
+    target_entities_view: Optional[ViewPropertyConfig] = None
+    target_entities_views: Optional[list[ViewPropertyConfig]] = None
+
+    @model_validator(mode="after")
+    def _require_target_entities_view(self) -> "DataModelViews":
+        if self.target_entities_views:
+            return self
+        if self.target_entities_view is not None:
+            return self
+        raise ValueError(
+            "Configuration must define either targetEntitiesView or targetEntitiesViews"
+        )
+
+    def get_target_entity_views(self) -> list[ViewPropertyConfig]:
+        if self.target_entities_views:
+            return self.target_entities_views
+        if self.target_entities_view is not None:
+            return [self.target_entities_view]
+        # Guarded by validator, but keep a safe fallback.
+        return []
 
 
 class Config(BaseModel, alias_generator=to_camel):

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_prepare/services/DataModelService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_prepare/services/DataModelService.py
@@ -79,7 +79,12 @@ class GeneralDataModelService(IDataModelService):
 
         self.annotation_state_view: ViewPropertyConfig = config.data_model_views.annotation_state_view
         self.file_view: ViewPropertyConfig = config.data_model_views.file_view
-        self.target_entities_view: ViewPropertyConfig = config.data_model_views.target_entities_view
+        self.target_entities_views: list[ViewPropertyConfig] = (
+            config.data_model_views.get_target_entity_views()
+        )
+        # Prepare currently operates on a single target view in its filtering logic.
+        # When multi-view config is provided, use the first view for backward compatibility.
+        self.target_entities_view: ViewPropertyConfig = self.target_entities_views[0]
 
         self.get_files_to_annotate_retrieve_limit: int | None = get_limit_from_query(
             config.prepare_function.get_files_to_annotate_query

--- a/modules/contextualization/key_extraction_aliasing
+++ b/modules/contextualization/key_extraction_aliasing
@@ -1,1 +1,0 @@
-/Users/darren.downtain@cognitedata.com/Documents/GitHub/library/modules/accelerators/contextualization/key_extraction_aliasing_jonluca


### PR DESCRIPTION
## Summary
- Add backward-compatible multi-view target-entity configuration support (`targetEntitiesViews` + legacy `targetEntitiesView`) in launch/prepare flows.
- Update launch data retrieval and cache conversion to handle entities across multiple target views, normalize search properties, and deduplicate entity nodes.
- Improve finalize processing to handle terminal file-level detect items incrementally and write finalized-file processing records to RAW for traceability.

## Test plan
- [ ] Run unit tests for modified `cdf_file_annotation` services.
- [ ] Trigger a file-annotation run in a non-prod environment and validate multi-view entity resolution.
- [ ] Verify finalize cycle updates statuses correctly for mixed terminal/pending file items.
- [ ] Confirm RAW table `annotation_finalize_processed_files` receives expected rows for finalized files.

Made with [Cursor](https://cursor.com)