### PR TITLE
chore(ci): enable F401 for ruff [AT-25]

### DIFF
--- a/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/config.py
+++ b/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/config.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any
 
 import yaml
 from cognite.client import CogniteClient
 from cognite.client import data_modeling as dm
 from cognite.client.exceptions import CogniteAPIError
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel
 from pydantic.alias_generators import to_camel
 
 

--- a/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/logger.py
+++ b/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/logger.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Literal
 
 
 # Logger using print

--- a/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/metadata_optimizations.py
+++ b/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/metadata_optimizations.py
@@ -5,15 +5,13 @@ This module provides optimization utilities for metadata update functions to imp
 performance, reduce memory usage, and enhance reliability.
 """
 
-import concurrent.futures
 import gc
 import re
 import time
-from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import psutil
 from cognite.client import CogniteClient

--- a/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/pipeline.py
+++ b/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/pipeline.py
@@ -5,23 +5,20 @@ This module provides optimized metadata update functionality for timeseries and 
 with improved performance, caching, batch processing, and error handling.
 """
 
-import gc
 import sys
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional
 
 from cognite.client import CogniteClient
 from cognite.client import data_modeling as dm
-from cognite.client.data_classes import ExtractionPipelineRun, Row
+from cognite.client.data_classes import ExtractionPipelineRun
 from cognite.client.data_classes.data_modeling import (
     Node,
-    NodeApply,
     NodeList,
-    NodeOrEdgeData,
     ViewId,
 )
-from cognite.client.data_classes.filters import Equals, HasData, In
+from cognite.client.data_classes.filters import Equals, HasData
 from cognite.client.exceptions import CogniteAPIError
 from cognite.client.utils._text import shorten
 from config import Config, ViewPropertyConfig

--- a/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/test_metadata_optimizations.py
+++ b/modules/accelerators/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/test_metadata_optimizations.py
@@ -10,8 +10,7 @@ import sys
 import time
 import unittest
 from pathlib import Path
-from typing import Any, Dict, List
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock
 
 # Add current directory to path
 sys.path.append(str(Path(__file__).parent))

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ApplyService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/ApplyService.py
@@ -17,10 +17,10 @@ from cognite.client.data_classes.data_modeling import (
     NodeOrEdgeData,
     ViewId,
 )
-from cognite.client.data_classes.filters import Equals, In
+from cognite.client.data_classes.filters import Equals
 from services.ConfigService import Config
 from services.LoggerService import CogniteFunctionLogger
-from utils.DataStructures import DiagramAnnotationStatus, remove_protected_properties
+from utils.DataStructures import DiagramAnnotationStatus
 
 
 class IApplyService(abc.ABC):

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/FinalizeService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/FinalizeService.py
@@ -8,7 +8,6 @@ from cognite.client.data_classes.data_modeling import (
     Node,
     NodeApply,
     NodeId,
-    NodeList,
     NodeOrEdgeData,
 )
 from cognite.client.exceptions import CogniteAPIError

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/RetrieveService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_finalize/services/RetrieveService.py
@@ -1,5 +1,4 @@
 import abc
-from typing import cast
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.data_modeling import (

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/CacheService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/CacheService.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Iterator, List, Set, cast
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Row, RowWrite
 from cognite.client.data_classes.data_modeling import (
-    Node,
     NodeList,
 )
 from cognite.client.exceptions import CogniteNotFoundError

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/LaunchService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/LaunchService.py
@@ -8,7 +8,6 @@ from cognite.client import CogniteClient
 from cognite.client.data_classes.contextualization import FileReference
 from cognite.client.data_classes.data_modeling import (
     Node,
-    NodeApply,
     NodeList,
 )
 from cognite.client.exceptions import CogniteAPIError

--- a/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_promote/services/CacheService.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/functions/fn_file_annotation_promote/services/CacheService.py
@@ -5,7 +5,6 @@ from typing import Any, Callable
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.data_modeling import Node, NodeList
-from cognite.client.data_classes.data_modeling.ids import ViewId
 from cognite.client.data_classes.raw import Row
 from services.ConfigService import Config, ViewPropertyConfig
 from services.LoggerService import CogniteFunctionLogger

--- a/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/data_fetcher.py
+++ b/modules/accelerators/contextualization/cdf_file_annotation/streamlit/file_annotation_dashboard_annotation_quality/data_fetcher.py
@@ -5,16 +5,13 @@ import pandas as pd
 import streamlit as st
 import yaml
 from cognite.client import CogniteClient
-from cognite.client.data_classes.data_modeling import filters
 from cognite.client.exceptions import CogniteAPIError
 from constants import FieldNames
 from data_processor import DataProcessor
 from data_structures import (
     AnnotationFrames,
     AnnotationStatus,
-    CallerType,
     ExtractionPipelineConfig,
-    ViewPropertyConfig,
 )
 
 

--- a/modules/accelerators/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_LOC_SOURCE_annotation/config.py
+++ b/modules/accelerators/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_LOC_SOURCE_annotation/config.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import yaml
 from cognite.client import CogniteClient
 from cognite.client import data_modeling as dm
 from cognite.client.exceptions import CogniteAPIError
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 from pydantic.alias_generators import to_camel
 
 

--- a/modules/accelerators/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_LOC_SOURCE_annotation/logger.py
+++ b/modules/accelerators/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_LOC_SOURCE_annotation/logger.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Literal
 
 
 # Logger using print

--- a/modules/accelerators/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_LOC_SOURCE_annotation/pipeline.py
+++ b/modules/accelerators/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_LOC_SOURCE_annotation/pipeline.py
@@ -26,14 +26,11 @@ from cognite.client.data_classes.data_modeling import (
     ViewId,
 )
 from cognite.client.data_classes.data_modeling.query import NodeResultSetExpression, Query, Select, SourceSelector
-from cognite.client.data_classes.filters import In, Or
 from cognite.client.exceptions import CogniteAPIError
-from cognite.client.utils._auxiliary import split_into_chunks
 from cognite.client.utils._text import shorten
 from cognite.extractorutils.uploader import RawUploadQueue
 from config import Config, ViewPropertyConfig
 from constants import (
-    ANNOTATE_BATCH_SIZE,
     BATCH_SIZE,
     EXTERNAL_ID_LIMIT,
     FILE_LINK_EXTERNAL_ID,

--- a/modules/atlas_ai/ai_extractor/functions/fn_ai_property_extractor/config.py
+++ b/modules/atlas_ai/ai_extractor/functions/fn_ai_property_extractor/config.py
@@ -6,7 +6,7 @@ Uses Pydantic for validation and parsing of extraction pipeline configuration.
 
 import json
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import yaml
 from cognite.client import CogniteClient

--- a/modules/atlas_ai/ai_extractor/functions/fn_ai_property_extractor/handler.py
+++ b/modules/atlas_ai/ai_extractor/functions/fn_ai_property_extractor/handler.py
@@ -20,7 +20,6 @@ from cognite.client.data_classes.data_modeling import NodeApply, NodeOrEdgeData
 # Add current directory to path for local imports
 sys.path.append(str(Path(__file__).parent))
 
-from datetime import datetime, timezone
 
 from config import Config, WriteMode, load_config
 from extractor import LLMPropertyExtractor
@@ -424,7 +423,6 @@ def query_instances(
         List of instances ready for extraction
     """
     from cognite.client import data_modeling as dm
-    from config import PropertyConfig
     
     filters: list[dm.filters.Filter] = []
     

--- a/modules/dashboards/classic_cdf_analysis/streamlit/classic_cdf_analysis_dashboard/analysis.py
+++ b/modules/dashboards/classic_cdf_analysis/streamlit/classic_cdf_analysis_dashboard/analysis.py
@@ -4,7 +4,6 @@ Port of the TypeScript analysis module for use with the Python Cognite SDK.
 """
 from __future__ import annotations
 
-import re
 from typing import Any, Optional
 
 CDF_FILTER_MAX_LEN = 64

--- a/modules/dashboards/classic_cdf_analysis/streamlit/classic_cdf_analysis_dashboard/app.py
+++ b/modules/dashboards/classic_cdf_analysis/streamlit/classic_cdf_analysis_dashboard/app.py
@@ -8,7 +8,6 @@ import asyncio
 import html
 import os
 import re
-import time
 import warnings
 
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="pandas")
@@ -27,7 +26,6 @@ import pandas as pd
 import streamlit as st
 from analysis import (
     ClientAdapter,
-    _aggregate_resource,
     _data_set_filter_aggregate,
     _documents_data_set_filter,
     _project_path,

--- a/modules/dashboards/context_quality/functions/context_quality_handler/metrics/timeseries.py
+++ b/modules/dashboards/context_quality/functions/context_quality_handler/metrics/timeseries.py
@@ -2,7 +2,6 @@
 Time Series processing and metrics computation.
 """
 
-from typing import Optional
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.data_modeling import NodeId, ViewId

--- a/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/common.py
+++ b/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/common.py
@@ -4,7 +4,6 @@ Common UI components and color functions for the dashboard.
 """
 
 import plotly.graph_objects as go
-import streamlit as st
 
 # ----------------------------------------------------
 # COLOR FUNCTIONS

--- a/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/file_annotation.py
+++ b/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/file_annotation.py
@@ -17,7 +17,6 @@ from .ai_summary import (
 from .common import (
     gauge,
     gauge_na,
-    get_status_color_hierarchy,
     metric_card,
 )
 

--- a/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/files.py
+++ b/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/files.py
@@ -13,7 +13,6 @@ from .ai_summary import (
 )
 from .common import (
     gauge,
-    gauge_na,
     get_status_color_files,
     metric_card,
 )

--- a/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/reports.py
+++ b/modules/dashboards/context_quality/streamlit/context_quality_dashboard/dashboards/reports.py
@@ -6,7 +6,6 @@ Generates downloadable PDF reports for each dashboard tab.
 Uses fpdf2 for lightweight, pure-Python PDF generation.
 """
 
-import io
 from datetime import datetime
 from typing import Optional
 

--- a/modules/dashboards/project_health/functions/project_health_handler/handler.py
+++ b/modules/dashboards/project_health/functions/project_health_handler/handler.py
@@ -16,7 +16,7 @@ import logging
 import os
 import tempfile
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Optional
 
 from cognite.client import CogniteClient
 from fetchers import (

--- a/modules/dashboards/project_health/streamlit/project_health_dashboard/main.py
+++ b/modules/dashboards/project_health/streamlit/project_health_dashboard/main.py
@@ -8,7 +8,6 @@ The dashboard loads that file and filters the view by your config: selected data
 """
 
 import json
-from datetime import datetime
 
 import streamlit as st
 

--- a/modules/tools/notebooks/cdf_transformation_jobs_metric_explorer/marimo-tsjm-analysis-ng.py
+++ b/modules/tools/notebooks/cdf_transformation_jobs_metric_explorer/marimo-tsjm-analysis-ng.py
@@ -1033,7 +1033,6 @@ def run_wfj_export(
     See COMMON_JSONL_FORMAT.md for format specification.
     """
 
-    import threading as _threading  # Local import, prefixed to avoid conflicts
     import traceback as _traceback  # Local import, prefixed to avoid conflicts
 
     # Check if client is ready (local variable, prefixed with _)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,9 @@ ignore = [
     "E701",  # multiple statements on one line (colon)
     "E722",  # bare except
     "E402",  # module level import not at top of file
-    "F401",  # imported but unused — address separately
     "F841",  # local variable assigned but never used
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "**/__init__.py" = ["F401"]
-"**/*.ipynb" = ["E741", "F402"]
+"**/*.ipynb" = ["E741", "F401", "F402"]


### PR DESCRIPTION
## Summary

- Remove `F401` from the global ruff ignore list
- Add `**/*.ipynb` to `per-file-ignores` for F401 (ruff cannot auto-fix imports inside notebook cells)
- Auto-fix 55 unused imports across Python source files (dead `typing` imports, unused SDK symbols, etc.)

## Test plan

- [ ] CI passes (`ruff check .` runs clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)