### PR TITLE
Add CODEOWNERS for Library owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Owned by the Library owners team (cognitedata/terraform github/teams/team_library_owners.tf)
+* @cognitedata/library-owners


### PR DESCRIPTION
## Summary
Adds `.github/CODEOWNERS` so all paths are owned by `@cognitedata/library-owners`, matching the Library owners team in `cognitedata/terraform` (`github/teams/team_library_owners.tf`).

Team members: `@charanraju15`, `@BergsethCognite`, `@ronpal`, `@valnaumova`.

## Note on enforcement
CODEOWNERS review requests are **advisory** until branch protection requires code owner reviews. That is configured separately in `cognitedata/terraform` `github/apps/` (branch protection for `library` is defined there but may still need an Atlantis apply on `main`).

## Test plan
- [ ] Merge PR and confirm GitHub shows Library owners as code owners on a sample PR