### PR TITLE
Enhance Qualitizer: Integration with Health Dashboard

### DIFF
--- a/modules/tools/apps/qualitizer/package-lock.json
+++ b/modules/tools/apps/qualitizer/package-lock.json
@@ -95,7 +95,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -754,7 +753,6 @@
       "resolved": "https://registry.npmjs.org/@cognite/sdk/-/sdk-10.10.0.tgz",
       "integrity": "sha512-5X7vr7cyQImlfN2sk/wWzJIBUIQUCiI38DnCP3X+Kd7p+D27Hep1F1P1zvKu9uavkfM519JqIKqvtEJNFqzXrA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cognite/sdk-core": "^5.2.0",
         "@types/geojson": "^7946.0.14",
@@ -1687,7 +1685,6 @@
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz",
       "integrity": "sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mixpanel/rrdom": "^2.0.0-alpha.18",
         "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
@@ -1728,8 +1725,7 @@
       "version": "2.0.0-alpha.18.4",
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz",
       "integrity": "sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -1796,7 +1792,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2708,7 +2703,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2847,7 +2843,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2858,7 +2853,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3019,7 +3013,6 @@
       "integrity": "sha512-xBPy+43o1fgMLUDlufUXh7tlT/Es8uS5eiyBY2PyPfFYSGpApZskLw65DROoDz+rgYkPuAmb20Mv9Z9g1WQE7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.3",
         "fflate": "^0.8.2",
@@ -3372,7 +3365,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -3596,7 +3588,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4390,7 +4381,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dot-case": {
       "version": "2.1.1",
@@ -5460,7 +5452,6 @@
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -5531,7 +5522,6 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6521,6 +6511,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7268,7 +7259,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7318,6 +7308,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7333,6 +7324,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7509,7 +7501,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7519,7 +7510,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7532,7 +7522,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -9137,7 +9128,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9282,7 +9272,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9358,7 +9347,6 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -9802,7 +9790,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/modules/tools/apps/qualitizer/src/App.tsx
+++ b/modules/tools/apps/qualitizer/src/App.tsx
@@ -13,12 +13,6 @@ import { I18nProvider, useI18n } from "./shared/i18n";
 import { LimitsProvider } from "./shared/LimitsContext";
 import { NavigationProvider } from "./shared/NavigationContext";
 import { PrivateModeProvider, usePrivateMode } from "./shared/PrivateModeContext";
-import { DatasetFilterProvider, useDatasetFilter } from "./shared/dataset-filter-context";
-import {
-  TimeRangeProvider,
-  useTimeRange,
-  type TimeRangePreset,
-} from "./shared/time-range-context";
 import { loadNavState, saveNavState } from "./shared/nav-persistence";
 import { LruCacheStatsPanel } from "./shared/LruCacheStatsPanel";
 
@@ -116,8 +110,6 @@ function AppContent() {
   return (
     <div className="min-h-screen w-full px-6 py-10">
       <LimitsProvider>
-      <TimeRangeProvider>
-      <DatasetFilterProvider>
       <NavigationProvider onNavigateToTransformations={navigateToTransformations}>
       <DataCacheProvider>
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
@@ -191,11 +183,6 @@ function AppContent() {
               ) : null}
             </div>
             <div className="ml-auto flex shrink-0 items-start gap-3">
-              <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-white px-3 py-2">
-                <TimeRangeSelector />
-                <span className="text-slate-300">|</span>
-                <DatasetSelector />
-              </div>
               <PrivateModeBadge />
               <button
                 type="button"
@@ -262,8 +249,6 @@ function AppContent() {
         </div>
       </DataCacheProvider>
       </NavigationProvider>
-      </DatasetFilterProvider>
-      </TimeRangeProvider>
       </LimitsProvider>
     </div>
   );
@@ -296,56 +281,6 @@ function PrivateModeBadge() {
     </button>
   );
 }
-function TimeRangeSelector() {
-  const { range, setRange } = useTimeRange();
-  const presets: TimeRangePreset[] = ["12h", "1d", "7d", "30d"];
-  return (
-    <label className="flex items-center gap-2 text-xs text-slate-600">
-      <span className="text-slate-400">Range</span>
-      <select
-        className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
-        value={range.kind === "custom" ? "custom" : range.kind}
-        onChange={(event) => {
-          const next = event.target.value as TimeRangePreset | "custom";
-          if (next === "custom") return;
-          setRange({ kind: next });
-        }}
-      >
-        {presets.map((preset) => (
-          <option key={preset} value={preset}>
-            {preset}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
-function DatasetSelector() {
-  const { datasets, selectedDatasetId, setSelectedDatasetId, isLoading } = useDatasetFilter();
-  return (
-    <label className="flex items-center gap-2 text-xs text-slate-600">
-      <span className="text-slate-400">Dataset</span>
-      <select
-        className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
-        value={selectedDatasetId ?? ""}
-        onChange={(event) => {
-          const value = event.target.value;
-          setSelectedDatasetId(value === "" ? null : Number(value));
-        }}
-        disabled={isLoading}
-      >
-        <option value="">All datasets</option>
-        {datasets.map((dataset) => (
-          <option key={dataset.id} value={dataset.id}>
-            {dataset.name ?? dataset.externalId ?? String(dataset.id)}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
 function App() {
   return (
     <I18nProvider>

--- a/modules/tools/apps/qualitizer/src/App.tsx
+++ b/modules/tools/apps/qualitizer/src/App.tsx
@@ -13,6 +13,12 @@ import { I18nProvider, useI18n } from "./shared/i18n";
 import { LimitsProvider } from "./shared/LimitsContext";
 import { NavigationProvider } from "./shared/NavigationContext";
 import { PrivateModeProvider, usePrivateMode } from "./shared/PrivateModeContext";
+import { DatasetFilterProvider, useDatasetFilter } from "./shared/dataset-filter-context";
+import {
+  TimeRangeProvider,
+  useTimeRange,
+  type TimeRangePreset,
+} from "./shared/time-range-context";
 import { loadNavState, saveNavState } from "./shared/nav-persistence";
 import { LruCacheStatsPanel } from "./shared/LruCacheStatsPanel";
 
@@ -110,6 +116,8 @@ function AppContent() {
   return (
     <div className="min-h-screen w-full px-6 py-10">
       <LimitsProvider>
+      <TimeRangeProvider>
+      <DatasetFilterProvider>
       <NavigationProvider onNavigateToTransformations={navigateToTransformations}>
       <DataCacheProvider>
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
@@ -183,6 +191,11 @@ function AppContent() {
               ) : null}
             </div>
             <div className="ml-auto flex shrink-0 items-start gap-3">
+              <div className="flex items-center gap-3 rounded-md border border-slate-200 bg-white px-3 py-2">
+                <TimeRangeSelector />
+                <span className="text-slate-300">|</span>
+                <DatasetSelector />
+              </div>
               <PrivateModeBadge />
               <button
                 type="button"
@@ -249,6 +262,8 @@ function AppContent() {
         </div>
       </DataCacheProvider>
       </NavigationProvider>
+      </DatasetFilterProvider>
+      </TimeRangeProvider>
       </LimitsProvider>
     </div>
   );
@@ -281,6 +296,56 @@ function PrivateModeBadge() {
     </button>
   );
 }
+function TimeRangeSelector() {
+  const { range, setRange } = useTimeRange();
+  const presets: TimeRangePreset[] = ["12h", "1d", "7d", "30d"];
+  return (
+    <label className="flex items-center gap-2 text-xs text-slate-600">
+      <span className="text-slate-400">Range</span>
+      <select
+        className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
+        value={range.kind === "custom" ? "custom" : range.kind}
+        onChange={(event) => {
+          const next = event.target.value as TimeRangePreset | "custom";
+          if (next === "custom") return;
+          setRange({ kind: next });
+        }}
+      >
+        {presets.map((preset) => (
+          <option key={preset} value={preset}>
+            {preset}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function DatasetSelector() {
+  const { datasets, selectedDatasetId, setSelectedDatasetId, isLoading } = useDatasetFilter();
+  return (
+    <label className="flex items-center gap-2 text-xs text-slate-600">
+      <span className="text-slate-400">Dataset</span>
+      <select
+        className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
+        value={selectedDatasetId ?? ""}
+        onChange={(event) => {
+          const value = event.target.value;
+          setSelectedDatasetId(value === "" ? null : Number(value));
+        }}
+        disabled={isLoading}
+      >
+        <option value="">All datasets</option>
+        {datasets.map((dataset) => (
+          <option key={dataset.id} value={dataset.id}>
+            {dataset.name ?? dataset.externalId ?? String(dataset.id)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
 function App() {
   return (
     <I18nProvider>

--- a/modules/tools/apps/qualitizer/src/health-checks/HealthChecks.tsx
+++ b/modules/tools/apps/qualitizer/src/health-checks/HealthChecks.tsx
@@ -6,8 +6,17 @@ import { DataModelChecks } from "./DataModelChecks";
 import { RawChecks } from "./RawChecks";
 import { PermissionsChecks } from "./PermissionsChecks";
 import { HealthChecksAll } from "./HealthChecksAll";
+import { RunHealthChecks } from "./run-health";
 
-type CheckCategory = "landing" | "all" | "infrastructure" | "transformations" | "dataModels" | "raw" | "permissions";
+type CheckCategory =
+  | "landing"
+  | "all"
+  | "runHealth"
+  | "infrastructure"
+  | "transformations"
+  | "dataModels"
+  | "raw"
+  | "permissions";
 
 const mainCategories: Array<{
   id: Exclude<CheckCategory, "landing" | "all">;
@@ -15,6 +24,12 @@ const mainCategories: Array<{
   description: string;
   icon: string;
 }> = [
+  {
+    id: "runHealth",
+    title: "Run Health",
+    description: "Uptime % and failure counts for pipelines, workflows, transformations, functions",
+    icon: "📈",
+  },
   {
     id: "infrastructure",
     title: "Infrastructure",
@@ -54,6 +69,7 @@ export function HealthChecks() {
   const goBack = () => setActiveCategory("landing");
 
   if (activeCategory === "all") return <HealthChecksAll onBack={goBack} />;
+  if (activeCategory === "runHealth") return <RunHealthChecks onBack={goBack} />;
   if (activeCategory === "infrastructure") return <InfrastructureChecks onBack={goBack} />;
   if (activeCategory === "transformations") return <TransformationsChecks onBack={goBack} />;
   if (activeCategory === "dataModels") return <DataModelChecks onBack={goBack} />;

--- a/modules/tools/apps/qualitizer/src/health-checks/HealthChecksAll.tsx
+++ b/modules/tools/apps/qualitizer/src/health-checks/HealthChecksAll.tsx
@@ -259,7 +259,7 @@ export function HealthChecksAll({ onBack }: Props) {
         do {
           const response = await sdk.post<{ items?: FunctionSummary[]; nextCursor?: string | null }>(
             `/api/v1/projects/${sdk.project}/functions/list`,
-            { data: JSON.stringify({ limit: 100, cursor }) }
+            { data: { limit: 100, cursor } }
           );
           items.push(...(response.data?.items ?? []));
           cursor = response.data?.nextCursor ?? undefined;

--- a/modules/tools/apps/qualitizer/src/health-checks/InfrastructureChecks.tsx
+++ b/modules/tools/apps/qualitizer/src/health-checks/InfrastructureChecks.tsx
@@ -45,7 +45,7 @@ export function InfrastructureChecks({ onBack }: Props) {
             items?: FunctionSummary[];
             nextCursor?: string | null;
           }>(`/api/v1/projects/${sdk.project}/functions/list`, {
-            data: JSON.stringify({ limit: 100, cursor }),
+            data: { limit: 100, cursor },
           });
           items.push(...(response.data?.items ?? []));
           cursor = response.data?.nextCursor ?? undefined;

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/ResourceHealthPanel.tsx
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/ResourceHealthPanel.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ApiError } from "@/shared/ApiError";
+import { formatIso } from "@/shared/time-utils";
+import { classifyHealth, isFailed, uptimeBg, uptimeColor } from "./uptime";
+import type { ResourceHealth, ResourceReport } from "./types";
+
+type Props = {
+  report: ResourceReport;
+  thresholdPct: number;
+  loading: boolean;
+};
+
+function StatusBadge({ status }: { status?: string }) {
+  if (!status) {
+    return <span className="rounded-sm bg-slate-100 px-2 py-0.5 text-xs text-slate-500">—</span>;
+  }
+  const failed = isFailed(status);
+  const cls = failed
+    ? "bg-red-100 text-red-700"
+    : "bg-emerald-100 text-emerald-700";
+  return <span className={`rounded-sm px-2 py-0.5 text-xs font-medium ${cls}`}>{status}</span>;
+}
+
+function HealthPill({ resource, thresholdPct }: { resource: ResourceHealth; thresholdPct: number }) {
+  const cls = classifyHealth(resource.runsInWindow, resource.uptimePercentage, thresholdPct);
+  if (cls === "no_runs") {
+    return (
+      <span className="rounded-sm bg-slate-100 px-2 py-0.5 text-xs text-slate-600">No runs</span>
+    );
+  }
+  if (cls === "healthy") {
+    return (
+      <span className="rounded-sm bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+        Healthy
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-sm bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+      Unhealthy
+    </span>
+  );
+}
+
+function ResourceRow({
+  resource,
+  thresholdPct,
+}: {
+  resource: ResourceHealth;
+  thresholdPct: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <>
+      <tr className="border-t border-slate-200 hover:bg-slate-50">
+        <td className="px-3 py-2">
+          <button
+            type="button"
+            className="cursor-pointer text-left font-medium text-slate-900 hover:underline"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {resource.name}
+          </button>
+          {resource.externalId && resource.externalId !== resource.name ? (
+            <div className="text-xs text-slate-500">{resource.externalId}</div>
+          ) : null}
+        </td>
+        <td className="px-3 py-2">
+          <StatusBadge status={resource.lastStatus} />
+        </td>
+        <td className="px-3 py-2 text-xs text-slate-600">
+          {resource.lastRunMs ? formatIso(resource.lastRunMs) : "—"}
+        </td>
+        <td className="px-3 py-2 text-right">
+          <span className={`font-mono font-semibold ${uptimeColor(resource.uptimePercentage)}`}>
+            {resource.runsInWindow > 0 ? `${resource.uptimePercentage.toFixed(1)}%` : "—"}
+          </span>
+        </td>
+        <td className="px-3 py-2 text-right font-mono text-xs text-slate-600">
+          {resource.successful}/{resource.successful + resource.failed}
+        </td>
+        <td className="px-3 py-2">
+          <HealthPill resource={resource} thresholdPct={thresholdPct} />
+        </td>
+        <td className="px-3 py-2 text-right">
+          {resource.fusionUrl ? (
+            <a
+              href={resource.fusionUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-slate-600 underline decoration-dotted hover:text-slate-900"
+            >
+              Open
+            </a>
+          ) : null}
+        </td>
+      </tr>
+      {expanded ? (
+        <tr className="border-t border-slate-100 bg-slate-50">
+          <td colSpan={7} className="px-3 py-3">
+            {resource.recentRuns.length === 0 ? (
+              <div className="text-xs text-slate-500">No recent runs in window.</div>
+            ) : (
+              <ul className="space-y-1 text-xs">
+                {resource.recentRuns.map((run, idx) => (
+                  <li key={idx} className="flex items-start gap-3">
+                    <StatusBadge status={run.status} />
+                    <span className="font-mono text-slate-600">
+                      {run.timeMs ? formatIso(run.timeMs) : "—"}
+                    </span>
+                    {run.message ? (
+                      <span className="text-slate-700">{run.message}</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+export function ResourceHealthPanel({ report, thresholdPct, loading }: Props) {
+  const { kindLabel, resources, summary, error } = report;
+  return (
+    <Card>
+      <CardHeader className="flex-row items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <CardTitle>{kindLabel}s</CardTitle>
+          <CardDescription>
+            Uptime = successful / (successful + failed) within the selected time range. Threshold: {thresholdPct}%.
+          </CardDescription>
+        </div>
+        <div className={`rounded-md border px-3 py-2 text-right text-sm ${uptimeBg(summary.aggregateUptime)}`}>
+          <div className={`font-mono text-lg font-semibold ${uptimeColor(summary.aggregateUptime)}`}>
+            {summary.total > 0 ? `${summary.aggregateUptime.toFixed(1)}%` : "—"}
+          </div>
+          <div className="text-xs text-slate-600">
+            {summary.healthy} healthy · {summary.unhealthy} unhealthy · {summary.noRuns} no runs
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="text-sm text-slate-600">Loading {kindLabel.toLowerCase()}s…</div>
+        ) : null}
+        {error ? <ApiError message={error} /> : null}
+        {!loading && !error ? (
+          resources.length === 0 ? (
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
+              No {kindLabel.toLowerCase()}s matched the filter.
+            </div>
+          ) : (
+            <div className="max-h-80 overflow-auto rounded-md border border-slate-200">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 z-10 bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500 shadow-sm">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Name</th>
+                    <th className="px-3 py-2 font-medium">Last status</th>
+                    <th className="px-3 py-2 font-medium">Last run (UTC)</th>
+                    <th className="px-3 py-2 text-right font-medium">Uptime %</th>
+                    <th className="px-3 py-2 text-right font-medium">Success / Total</th>
+                    <th className="px-3 py-2 font-medium">Health</th>
+                    <th className="px-3 py-2 text-right font-medium">Fusion</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {resources.map((resource) => (
+                    <ResourceRow
+                      key={resource.id}
+                      resource={resource}
+                      thresholdPct={thresholdPct}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/ResourceHealthPanel.tsx
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/ResourceHealthPanel.tsx
@@ -9,7 +9,13 @@ type Props = {
   report: ResourceReport;
   thresholdPct: number;
   loading: boolean;
+  onLoadAll?: () => void;
 };
+
+function formatStatus(status: string): string {
+  const lower = status.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
 
 function StatusBadge({ status }: { status?: string }) {
   if (!status) {
@@ -19,7 +25,7 @@ function StatusBadge({ status }: { status?: string }) {
   const cls = failed
     ? "bg-red-100 text-red-700"
     : "bg-emerald-100 text-emerald-700";
-  return <span className={`rounded-sm px-2 py-0.5 text-xs font-medium ${cls}`}>{status}</span>;
+  return <span className={`rounded-sm px-2 py-0.5 text-xs font-medium ${cls}`}>{formatStatus(status)}</span>;
 }
 
 function HealthPill({ resource, thresholdPct }: { resource: ResourceHealth; thresholdPct: number }) {
@@ -29,16 +35,23 @@ function HealthPill({ resource, thresholdPct }: { resource: ResourceHealth; thre
       <span className="rounded-sm bg-slate-100 px-2 py-0.5 text-xs text-slate-600">No runs</span>
     );
   }
-  if (cls === "healthy") {
+  if (cls === "success") {
     return (
       <span className="rounded-sm bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
-        Healthy
+        Success
+      </span>
+    );
+  }
+  if (cls === "warning") {
+    return (
+      <span className="rounded-sm bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+        Warning
       </span>
     );
   }
   return (
     <span className="rounded-sm bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
-      Unhealthy
+      Critical
     </span>
   );
 }
@@ -123,15 +136,15 @@ function ResourceRow({
   );
 }
 
-export function ResourceHealthPanel({ report, thresholdPct, loading }: Props) {
-  const { kindLabel, resources, summary, error } = report;
+export function ResourceHealthPanel({ report, thresholdPct, loading, onLoadAll }: Props) {
+  const { kindLabel, resources, summary, error, sampling } = report;
   return (
     <Card>
       <CardHeader className="flex-row items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
           <CardTitle>{kindLabel}s</CardTitle>
           <CardDescription>
-            Uptime = successful / (successful + failed) within the selected time range. Threshold: {thresholdPct}%.
+            Uptime = successful / (successful + failed) within the selected time range.
           </CardDescription>
         </div>
         <div className={`rounded-md border px-3 py-2 text-right text-sm ${uptimeBg(summary.aggregateUptime)}`}>
@@ -139,7 +152,7 @@ export function ResourceHealthPanel({ report, thresholdPct, loading }: Props) {
             {summary.total > 0 ? `${summary.aggregateUptime.toFixed(1)}%` : "—"}
           </div>
           <div className="text-xs text-slate-600">
-            {summary.healthy} healthy · {summary.unhealthy} unhealthy · {summary.noRuns} no runs
+            {summary.success} ok · {summary.warning} warning · {summary.critical} critical · {summary.noRuns} no runs
           </div>
         </div>
       </CardHeader>
@@ -154,30 +167,48 @@ export function ResourceHealthPanel({ report, thresholdPct, loading }: Props) {
               No {kindLabel.toLowerCase()}s matched the filter.
             </div>
           ) : (
-            <div className="max-h-80 overflow-auto rounded-md border border-slate-200">
-              <table className="w-full text-sm">
-                <thead className="sticky top-0 z-10 bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500 shadow-sm">
-                  <tr>
-                    <th className="px-3 py-2 font-medium">Name</th>
-                    <th className="px-3 py-2 font-medium">Last status</th>
-                    <th className="px-3 py-2 font-medium">Last run (UTC)</th>
-                    <th className="px-3 py-2 text-right font-medium">Uptime %</th>
-                    <th className="px-3 py-2 text-right font-medium">Success / Total</th>
-                    <th className="px-3 py-2 font-medium">Health</th>
-                    <th className="px-3 py-2 text-right font-medium">Fusion</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {resources.map((resource) => (
-                    <ResourceRow
-                      key={resource.id}
-                      resource={resource}
-                      thresholdPct={thresholdPct}
-                    />
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <>
+              {sampling?.isSampled ? (
+                <div className="mb-3 flex flex-wrap items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+                  <span className="text-xs text-amber-800">
+                    Sampled {sampling.sampledCount} of {sampling.totalCount} {kindLabel.toLowerCase()}s.
+                  </span>
+                  {onLoadAll ? (
+                    <button
+                      type="button"
+                      className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50"
+                      onClick={onLoadAll}
+                    >
+                      Load All
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+              <div className="max-h-80 overflow-auto rounded-md border border-slate-200">
+                <table className="w-full text-sm">
+                  <thead className="sticky top-0 z-10 bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500 shadow-sm">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">Name</th>
+                      <th className="px-3 py-2 font-medium">Last status</th>
+                      <th className="px-3 py-2 font-medium">Last run (UTC)</th>
+                      <th className="px-3 py-2 text-right font-medium">Uptime %</th>
+                      <th className="px-3 py-2 text-right font-medium">Success / Total</th>
+                      <th className="px-3 py-2 font-medium">Health</th>
+                      <th className="px-3 py-2 text-right font-medium">Fusion</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {resources.map((resource) => (
+                      <ResourceRow
+                        key={resource.id}
+                        resource={resource}
+                        thresholdPct={thresholdPct}
+                      />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
           )
         ) : null}
       </CardContent>

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/RunHealthChecks.tsx
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/RunHealthChecks.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAppSdk } from "@/shared/auth";
+import { useDatasetFilter } from "@/shared/dataset-filter-context";
+import { Loader } from "@/shared/Loader";
+import { formatIso } from "@/shared/time-utils";
+import { useTimeRange, formatRangeLabel } from "@/shared/time-range-context";
+import type { LoadState } from "../types";
+import {
+  fetchExtractionPipelineHealth,
+  fetchFunctionHealth,
+  fetchTransformationHealth,
+  fetchWorkflowHealth,
+} from "./fetchers";
+import { ResourceHealthPanel } from "./ResourceHealthPanel";
+import { isFailed } from "./uptime";
+import { DEFAULT_THRESHOLDS, loadThresholds, saveThresholds, type ResourceKind } from "./thresholds";
+import type { ResourceReport } from "./types";
+
+type Props = { onBack: () => void };
+
+const EMPTY_REPORT = (kindLabel: ResourceReport["kindLabel"]): ResourceReport => ({
+  kindLabel,
+  resources: [],
+  summary: { total: 0, healthy: 0, unhealthy: 0, noRuns: 0, aggregateUptime: 100 },
+  errors: [],
+  error: null,
+});
+
+export function RunHealthChecks({ onBack }: Props) {
+  const { sdk, isLoading: isSdkLoading } = useAppSdk();
+  const { startMs, endMs, range } = useTimeRange();
+  const { selectedDatasetId, selectedDataset } = useDatasetFilter();
+
+  const [thresholds, setThresholdsState] = useState(loadThresholds);
+  const [showThresholds, setShowThresholds] = useState(false);
+
+  const [status, setStatus] = useState<LoadState>("idle");
+  const [reports, setReports] = useState<Record<ResourceKind, ResourceReport>>({
+    extractionPipelines: EMPTY_REPORT("Extraction pipeline"),
+    workflows: EMPTY_REPORT("Workflow"),
+    transformations: EMPTY_REPORT("Transformation"),
+    functions: EMPTY_REPORT("Function"),
+  });
+  const [computedAt, setComputedAt] = useState<number | null>(null);
+
+  const signalRef = useRef<{ cancelled: boolean }>({ cancelled: false });
+
+  const run = useCallback(async () => {
+    if (isSdkLoading) return;
+    signalRef.current.cancelled = true;
+    const signal = { cancelled: false };
+    signalRef.current = signal;
+
+    setStatus("loading");
+    const opts = { sdk, datasetId: selectedDatasetId, startMs, endMs, signal };
+
+    const [ep, wf, tr, fn] = await Promise.all([
+      fetchExtractionPipelineHealth({ ...opts, thresholdPct: thresholds.extractionPipelines }),
+      fetchWorkflowHealth({ ...opts, thresholdPct: thresholds.workflows }),
+      fetchTransformationHealth({ ...opts, thresholdPct: thresholds.transformations }),
+      fetchFunctionHealth({ ...opts, thresholdPct: thresholds.functions }),
+    ]);
+
+    if (signal.cancelled) return;
+
+    setReports({
+      extractionPipelines: ep,
+      workflows: wf,
+      transformations: tr,
+      functions: fn,
+    });
+    setComputedAt(Date.now());
+    setStatus("success");
+  }, [isSdkLoading, sdk, selectedDatasetId, startMs, endMs, thresholds]);
+
+  useEffect(() => {
+    void run();
+    return () => {
+      signalRef.current.cancelled = true;
+    };
+  }, [run]);
+
+  const aggregatedErrors = useMemo(() => {
+    const all = [
+      ...reports.extractionPipelines.errors,
+      ...reports.workflows.errors,
+      ...reports.transformations.errors,
+      ...reports.functions.errors,
+    ];
+    return all
+      .filter((e) => isFailed(e.status) || e.status === "error")
+      .sort((a, b) => (b.timeMs ?? 0) - (a.timeMs ?? 0))
+      .slice(0, 25);
+  }, [reports]);
+
+  const updateThreshold = (key: ResourceKind, value: number) => {
+    const sanitized = Math.max(0, Math.min(100, Math.round(value)));
+    const next = { ...thresholds, [key]: sanitized };
+    setThresholdsState(next);
+    saveThresholds(next);
+  };
+
+  const resetThresholds = () => {
+    setThresholdsState({ ...DEFAULT_THRESHOLDS });
+    saveThresholds({ ...DEFAULT_THRESHOLDS });
+  };
+
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-2xl font-semibold text-slate-900">Run Health</h2>
+          <p className="text-sm text-slate-500">
+            Uptime and failure counts for extraction pipelines, workflows, transformations, and functions.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="cursor-pointer rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+            onClick={() => setShowThresholds((v) => !v)}
+          >
+            {showThresholds ? "Hide" : "Thresholds"}
+          </button>
+          <button
+            type="button"
+            className="cursor-pointer rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+            onClick={() => void run()}
+            disabled={status === "loading"}
+          >
+            {status === "loading" ? "Refreshing…" : "Refresh"}
+          </button>
+          <button
+            type="button"
+            className="cursor-pointer shrink-0 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+            onClick={onBack}
+          >
+            Back to checks
+          </button>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+        <span>Range: <span className="font-mono text-slate-800">{formatRangeLabel(range)}</span></span>
+        <span>·</span>
+        <span>
+          Dataset:{" "}
+          <span className="font-mono text-slate-800">
+            {selectedDataset ? selectedDataset.name ?? selectedDataset.externalId ?? selectedDataset.id : "All"}
+          </span>
+        </span>
+        {computedAt ? (
+          <>
+            <span>·</span>
+            <span>Computed at {formatIso(computedAt)}</span>
+          </>
+        ) : null}
+      </div>
+
+      {showThresholds ? (
+        <div className="rounded-md border border-slate-200 bg-white p-4">
+          <div className="mb-2 text-sm font-semibold text-slate-900">Uptime thresholds</div>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {(Object.keys(DEFAULT_THRESHOLDS) as ResourceKind[]).map((key) => (
+              <label key={key} className="flex flex-col gap-1 text-xs text-slate-600">
+                <span className="font-medium text-slate-800">{labelForKind(key)}</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={thresholds[key]}
+                  onChange={(e) => updateThreshold(key, Number(e.target.value))}
+                  className="w-24 rounded-md border border-slate-200 px-2 py-1 text-sm"
+                />
+              </label>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="mt-3 cursor-pointer rounded-md border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 hover:bg-slate-50"
+            onClick={resetThresholds}
+          >
+            Reset to defaults
+          </button>
+        </div>
+      ) : null}
+
+      <ResourceHealthPanel
+        report={reports.extractionPipelines}
+        thresholdPct={thresholds.extractionPipelines}
+        loading={status === "loading"}
+      />
+      <ResourceHealthPanel
+        report={reports.workflows}
+        thresholdPct={thresholds.workflows}
+        loading={status === "loading"}
+      />
+      <ResourceHealthPanel
+        report={reports.transformations}
+        thresholdPct={thresholds.transformations}
+        loading={status === "loading"}
+      />
+      <ResourceHealthPanel
+        report={reports.functions}
+        thresholdPct={thresholds.functions}
+        loading={status === "loading"}
+      />
+
+      <div className="rounded-md border border-slate-200 bg-white p-4">
+        <div className="mb-2 text-sm font-semibold text-slate-900">Recent failures</div>
+        {aggregatedErrors.length === 0 ? (
+          <div className="text-xs text-slate-500">No failed runs in the current window.</div>
+        ) : (
+          <ul className="space-y-1 text-xs">
+            {aggregatedErrors.map((err, idx) => (
+              <li key={idx} className="flex flex-wrap items-start gap-2">
+                <span className="rounded-sm bg-red-100 px-2 py-0.5 font-medium text-red-700">
+                  {err.status}
+                </span>
+                <span className="font-mono text-slate-600">
+                  {err.timeMs ? formatIso(err.timeMs) : "—"}
+                </span>
+                <span className="font-medium text-slate-800">{err.resource}</span>
+                {err.message ? <span className="text-slate-700">{err.message}</span> : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <Loader
+        open={status === "loading"}
+        onClose={() => { /* informational only */ }}
+        title="Running run-health checks…"
+      />
+    </section>
+  );
+}
+
+function labelForKind(kind: ResourceKind): string {
+  switch (kind) {
+    case "extractionPipelines":
+      return "Extraction pipelines";
+    case "workflows":
+      return "Workflows";
+    case "transformations":
+      return "Transformations";
+    case "functions":
+      return "Functions";
+  }
+}

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/RunHealthChecks.tsx
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/RunHealthChecks.tsx
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAppSdk } from "@/shared/auth";
-import { useDatasetFilter } from "@/shared/dataset-filter-context";
+import { DatasetFilterProvider, useDatasetFilter } from "@/shared/dataset-filter-context";
 import { Loader } from "@/shared/Loader";
 import { formatIso } from "@/shared/time-utils";
-import { useTimeRange, formatRangeLabel } from "@/shared/time-range-context";
+import {
+  TimeRangeProvider,
+  useTimeRange,
+  type TimeRangePreset,
+} from "@/shared/time-range-context";
 import type { LoadState } from "../types";
 import {
   fetchExtractionPipelineHealth,
@@ -13,28 +17,38 @@ import {
 } from "./fetchers";
 import { ResourceHealthPanel } from "./ResourceHealthPanel";
 import { isFailed } from "./uptime";
-import { DEFAULT_THRESHOLDS, loadThresholds, saveThresholds, type ResourceKind } from "./thresholds";
+import type { ResourceKind } from "./thresholds";
 import type { ResourceReport } from "./types";
 
 type Props = { onBack: () => void };
 
+const THRESHOLD_PCT = 75;
+
 const EMPTY_REPORT = (kindLabel: ResourceReport["kindLabel"]): ResourceReport => ({
   kindLabel,
   resources: [],
-  summary: { total: 0, healthy: 0, unhealthy: 0, noRuns: 0, aggregateUptime: 100 },
+  summary: { total: 0, success: 0, warning: 0, critical: 0, noRuns: 0, aggregateUptime: 100 },
   errors: [],
   error: null,
 });
 
-export function RunHealthChecks({ onBack }: Props) {
-  const { sdk, isLoading: isSdkLoading } = useAppSdk();
-  const { startMs, endMs, range } = useTimeRange();
-  const { selectedDatasetId, selectedDataset } = useDatasetFilter();
+export function RunHealthChecks(props: Props) {
+  return (
+    <TimeRangeProvider>
+      <DatasetFilterProvider>
+        <RunHealthChecksInner {...props} />
+      </DatasetFilterProvider>
+    </TimeRangeProvider>
+  );
+}
 
-  const [thresholds, setThresholdsState] = useState(loadThresholds);
-  const [showThresholds, setShowThresholds] = useState(false);
+function RunHealthChecksInner({ onBack }: Props) {
+  const { sdk, isLoading: isSdkLoading } = useAppSdk();
+  const { startMs, endMs, range, setRange } = useTimeRange();
+  const { selectedDatasetId, datasets, setSelectedDatasetId, isLoading: isDatasetsLoading } = useDatasetFilter();
 
   const [status, setStatus] = useState<LoadState>("idle");
+  const [loadingKind, setLoadingKind] = useState<string | null>(null);
   const [reports, setReports] = useState<Record<ResourceKind, ResourceReport>>({
     extractionPipelines: EMPTY_REPORT("Extraction pipeline"),
     workflows: EMPTY_REPORT("Workflow"),
@@ -42,8 +56,11 @@ export function RunHealthChecks({ onBack }: Props) {
     functions: EMPTY_REPORT("Function"),
   });
   const [computedAt, setComputedAt] = useState<number | null>(null);
+  const [loadAllKinds, setLoadAllKinds] = useState<Set<ResourceKind>>(new Set());
 
   const signalRef = useRef<{ cancelled: boolean }>({ cancelled: false });
+
+  const sampleMode = (endMs - startMs) > 3_600_000;
 
   const run = useCallback(async () => {
     if (isSdkLoading) return;
@@ -52,26 +69,33 @@ export function RunHealthChecks({ onBack }: Props) {
     signalRef.current = signal;
 
     setStatus("loading");
-    const opts = { sdk, datasetId: selectedDatasetId, startMs, endMs, signal };
+    setLoadAllKinds(new Set());
+    const opts = { sdk, datasetId: selectedDatasetId, startMs, endMs, signal, sampleMode };
 
-    const [ep, wf, tr, fn] = await Promise.all([
-      fetchExtractionPipelineHealth({ ...opts, thresholdPct: thresholds.extractionPipelines }),
-      fetchWorkflowHealth({ ...opts, thresholdPct: thresholds.workflows }),
-      fetchTransformationHealth({ ...opts, thresholdPct: thresholds.transformations }),
-      fetchFunctionHealth({ ...opts, thresholdPct: thresholds.functions }),
-    ]);
-
+    setLoadingKind("Extraction pipelines");
+    const ep = await fetchExtractionPipelineHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
     if (signal.cancelled) return;
+    setReports((prev) => ({ ...prev, extractionPipelines: ep }));
 
-    setReports({
-      extractionPipelines: ep,
-      workflows: wf,
-      transformations: tr,
-      functions: fn,
-    });
+    setLoadingKind("Workflows");
+    const wf = await fetchWorkflowHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
+    if (signal.cancelled) return;
+    setReports((prev) => ({ ...prev, workflows: wf }));
+
+    setLoadingKind("Transformations");
+    const tr = await fetchTransformationHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
+    if (signal.cancelled) return;
+    setReports((prev) => ({ ...prev, transformations: tr }));
+
+    setLoadingKind("Functions");
+    const fn = await fetchFunctionHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
+    if (signal.cancelled) return;
+    setReports((prev) => ({ ...prev, functions: fn }));
+
     setComputedAt(Date.now());
+    setLoadingKind(null);
     setStatus("success");
-  }, [isSdkLoading, sdk, selectedDatasetId, startMs, endMs, thresholds]);
+  }, [isSdkLoading, sdk, selectedDatasetId, startMs, endMs, sampleMode]);
 
   useEffect(() => {
     void run();
@@ -79,6 +103,33 @@ export function RunHealthChecks({ onBack }: Props) {
       signalRef.current.cancelled = true;
     };
   }, [run]);
+
+  const loadAllForKind = useCallback(async (kind: ResourceKind) => {
+    if (isSdkLoading) return;
+    const signal = { cancelled: false };
+    const opts = { sdk, datasetId: selectedDatasetId, startMs, endMs, signal, sampleMode: false };
+
+    setLoadAllKinds((prev) => new Set(prev).add(kind));
+
+    let report: ResourceReport;
+    switch (kind) {
+      case "extractionPipelines":
+        report = await fetchExtractionPipelineHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
+        break;
+      case "workflows":
+        report = await fetchWorkflowHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
+        break;
+      case "transformations":
+        report = await fetchTransformationHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
+        break;
+      case "functions":
+        report = await fetchFunctionHealth({ ...opts, thresholdPct: THRESHOLD_PCT });
+        break;
+    }
+    if (!signal.cancelled) {
+      setReports((prev) => ({ ...prev, [kind]: report }));
+    }
+  }, [isSdkLoading, sdk, selectedDatasetId, startMs, endMs]);
 
   const aggregatedErrors = useMemo(() => {
     const all = [
@@ -93,17 +144,7 @@ export function RunHealthChecks({ onBack }: Props) {
       .slice(0, 25);
   }, [reports]);
 
-  const updateThreshold = (key: ResourceKind, value: number) => {
-    const sanitized = Math.max(0, Math.min(100, Math.round(value)));
-    const next = { ...thresholds, [key]: sanitized };
-    setThresholdsState(next);
-    saveThresholds(next);
-  };
-
-  const resetThresholds = () => {
-    setThresholdsState({ ...DEFAULT_THRESHOLDS });
-    saveThresholds({ ...DEFAULT_THRESHOLDS });
-  };
+  const presets: TimeRangePreset[] = ["1h", "6h", "12h", "24h", "7d"];
 
   return (
     <section className="flex flex-col gap-4">
@@ -115,13 +156,6 @@ export function RunHealthChecks({ onBack }: Props) {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            className="cursor-pointer rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
-            onClick={() => setShowThresholds((v) => !v)}
-          >
-            {showThresholds ? "Hide" : "Thresholds"}
-          </button>
           <button
             type="button"
             className="cursor-pointer rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
@@ -140,70 +174,78 @@ export function RunHealthChecks({ onBack }: Props) {
         </div>
       </header>
 
-      <div className="flex flex-wrap items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
-        <span>Range: <span className="font-mono text-slate-800">{formatRangeLabel(range)}</span></span>
-        <span>·</span>
-        <span>
-          Dataset:{" "}
-          <span className="font-mono text-slate-800">
-            {selectedDataset ? selectedDataset.name ?? selectedDataset.externalId ?? selectedDataset.id : "All"}
-          </span>
-        </span>
+      <div className="flex flex-wrap items-center gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+        <label className="flex items-center gap-2">
+          <span className="text-slate-400">Range</span>
+          <select
+            className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
+            value={range.kind === "custom" ? "custom" : range.kind}
+            onChange={(e) => {
+              const next = e.target.value as TimeRangePreset | "custom";
+              if (next === "custom") return;
+              setRange({ kind: next });
+            }}
+          >
+            {presets.map((preset) => (
+              <option key={preset} value={preset}>{preset}</option>
+            ))}
+          </select>
+        </label>
+        <span className="text-slate-300">|</span>
+        <label className="flex items-center gap-2">
+          <span className="text-slate-400">Dataset</span>
+          <select
+            className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700"
+            value={selectedDatasetId ?? ""}
+            onChange={(e) => {
+              const value = e.target.value;
+              setSelectedDatasetId(value === "" ? null : Number(value));
+            }}
+            disabled={isDatasetsLoading}
+          >
+            <option value="">All datasets</option>
+            {datasets.map((ds) => (
+              <option key={ds.id} value={ds.id}>
+                {ds.name ?? ds.externalId ?? String(ds.id)}
+              </option>
+            ))}
+          </select>
+        </label>
         {computedAt ? (
           <>
-            <span>·</span>
+            <span className="text-slate-300">|</span>
             <span>Computed at {formatIso(computedAt)}</span>
           </>
         ) : null}
       </div>
 
-      {showThresholds ? (
-        <div className="rounded-md border border-slate-200 bg-white p-4">
-          <div className="mb-2 text-sm font-semibold text-slate-900">Uptime thresholds</div>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            {(Object.keys(DEFAULT_THRESHOLDS) as ResourceKind[]).map((key) => (
-              <label key={key} className="flex flex-col gap-1 text-xs text-slate-600">
-                <span className="font-medium text-slate-800">{labelForKind(key)}</span>
-                <input
-                  type="number"
-                  min={0}
-                  max={100}
-                  value={thresholds[key]}
-                  onChange={(e) => updateThreshold(key, Number(e.target.value))}
-                  className="w-24 rounded-md border border-slate-200 px-2 py-1 text-sm"
-                />
-              </label>
-            ))}
-          </div>
-          <button
-            type="button"
-            className="mt-3 cursor-pointer rounded-md border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 hover:bg-slate-50"
-            onClick={resetThresholds}
-          >
-            Reset to defaults
-          </button>
-        </div>
-      ) : null}
-
       <ResourceHealthPanel
         report={reports.extractionPipelines}
-        thresholdPct={thresholds.extractionPipelines}
-        loading={status === "loading"}
+        thresholdPct={THRESHOLD_PCT}
+        loading={status === "loading" && !reports.extractionPipelines.resources.length}
+        onLoadAll={reports.extractionPipelines.sampling?.isSampled && !loadAllKinds.has("extractionPipelines")
+          ? () => void loadAllForKind("extractionPipelines") : undefined}
       />
       <ResourceHealthPanel
         report={reports.workflows}
-        thresholdPct={thresholds.workflows}
-        loading={status === "loading"}
+        thresholdPct={THRESHOLD_PCT}
+        loading={status === "loading" && !reports.workflows.resources.length}
+        onLoadAll={reports.workflows.sampling?.isSampled && !loadAllKinds.has("workflows")
+          ? () => void loadAllForKind("workflows") : undefined}
       />
       <ResourceHealthPanel
         report={reports.transformations}
-        thresholdPct={thresholds.transformations}
-        loading={status === "loading"}
+        thresholdPct={THRESHOLD_PCT}
+        loading={status === "loading" && !reports.transformations.resources.length}
+        onLoadAll={reports.transformations.sampling?.isSampled && !loadAllKinds.has("transformations")
+          ? () => void loadAllForKind("transformations") : undefined}
       />
       <ResourceHealthPanel
         report={reports.functions}
-        thresholdPct={thresholds.functions}
-        loading={status === "loading"}
+        thresholdPct={THRESHOLD_PCT}
+        loading={status === "loading" && !reports.functions.resources.length}
+        onLoadAll={reports.functions.sampling?.isSampled && !loadAllKinds.has("functions")
+          ? () => void loadAllForKind("functions") : undefined}
       />
 
       <div className="rounded-md border border-slate-200 bg-white p-4">
@@ -215,7 +257,7 @@ export function RunHealthChecks({ onBack }: Props) {
             {aggregatedErrors.map((err, idx) => (
               <li key={idx} className="flex flex-wrap items-start gap-2">
                 <span className="rounded-sm bg-red-100 px-2 py-0.5 font-medium text-red-700">
-                  {err.status}
+                  {err.status.charAt(0).toUpperCase() + err.status.slice(1).toLowerCase()}
                 </span>
                 <span className="font-mono text-slate-600">
                   {err.timeMs ? formatIso(err.timeMs) : "—"}
@@ -231,21 +273,8 @@ export function RunHealthChecks({ onBack }: Props) {
       <Loader
         open={status === "loading"}
         onClose={() => { /* informational only */ }}
-        title="Running run-health checks…"
+        title={loadingKind ? `Loading ${loadingKind}…` : "Running run-health checks…"}
       />
     </section>
   );
-}
-
-function labelForKind(kind: ResourceKind): string {
-  switch (kind) {
-    case "extractionPipelines":
-      return "Extraction pipelines";
-    case "workflows":
-      return "Workflows";
-    case "transformations":
-      return "Transformations";
-    case "functions":
-      return "Functions";
-  }
 }

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/fetchers.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/fetchers.ts
@@ -21,6 +21,7 @@ import type { ResourceHealth, ResourceReport, RunEntry } from "./types";
 
 const API_LIST_LIMIT = 500;
 const API_RUNS_LIMIT = 100;
+const SAMPLE_RESOURCE_LIMIT = 50;
 
 type FetcherOpts = {
   sdk: CogniteClient;
@@ -29,6 +30,7 @@ type FetcherOpts = {
   endMs: number;
   thresholdPct: number;
   signal?: { cancelled: boolean };
+  sampleMode?: boolean;
 };
 
 function getExtractionPipelineUrl(project: string, externalId: string): string {
@@ -74,6 +76,10 @@ function finalizeResource(
 
 function sortByFailureFirst(resources: ResourceHealth[]): ResourceHealth[] {
   return [...resources].sort((a, b) => {
+    const aHasRuns = a.runsInWindow > 0 ? 0 : 1;
+    const bHasRuns = b.runsInWindow > 0 ? 0 : 1;
+    if (aHasRuns !== bHasRuns) return aHasRuns - bHasRuns;
+
     const aFailed = isFailed(a.lastStatus) ? 0 : 1;
     const bFailed = isFailed(b.lastStatus) ? 0 : 1;
     if (aFailed !== bFailed) return aFailed - bFailed;
@@ -85,19 +91,22 @@ function buildReport(
   kindLabel: ResourceReport["kindLabel"],
   resources: ResourceHealth[],
   thresholdPct: number,
-  extraErrors: ResourceReport["errors"]
+  extraErrors: ResourceReport["errors"],
+  sampling?: ResourceReport["sampling"]
 ): ResourceReport {
   const sorted = sortByFailureFirst(resources);
-  let healthy = 0;
-  let unhealthy = 0;
+  let success = 0;
+  let warning = 0;
+  let critical = 0;
   let noRuns = 0;
   let totalSuccess = 0;
   let totalFailed = 0;
   const errors = [...extraErrors];
   for (const r of sorted) {
     const cls = classifyHealth(r.runsInWindow, r.uptimePercentage, thresholdPct);
-    if (cls === "healthy") healthy += 1;
-    else if (cls === "unhealthy") unhealthy += 1;
+    if (cls === "success") success += 1;
+    else if (cls === "warning") warning += 1;
+    else if (cls === "critical") critical += 1;
     else noRuns += 1;
     totalSuccess += r.successful;
     totalFailed += r.failed;
@@ -116,9 +125,10 @@ function buildReport(
   return {
     kindLabel,
     resources: sorted,
-    summary: { total: sorted.length, healthy, unhealthy, noRuns, aggregateUptime },
+    summary: { total: sorted.length, success, warning, critical, noRuns, aggregateUptime },
     errors,
     error: null,
+    sampling,
   };
 }
 
@@ -126,7 +136,7 @@ function errorReport(kindLabel: ResourceReport["kindLabel"], message: string): R
   return {
     kindLabel,
     resources: [],
-    summary: { total: 0, healthy: 0, unhealthy: 0, noRuns: 0, aggregateUptime: 100 },
+    summary: { total: 0, success: 0, warning: 0, critical: 0, noRuns: 0, aggregateUptime: 100 },
     errors: [{ resource: kindLabel, status: "error", message }],
     error: message,
   };
@@ -150,7 +160,7 @@ type ExtPipeRun = {
 };
 
 export async function fetchExtractionPipelineHealth(opts: FetcherOpts): Promise<ResourceReport> {
-  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal, sampleMode } = opts;
   try {
     const configs: ExtPipeSummary[] = [];
     let cursor: string | undefined;
@@ -166,9 +176,14 @@ export async function fetchExtractionPipelineHealth(opts: FetcherOpts): Promise<
     } while (cursor);
 
     const filtered = configs.filter((c) => matchesDataset(c.dataSetId, datasetId));
+    const totalCount = filtered.length;
+    const toProcess = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? filtered.slice(0, SAMPLE_RESOURCE_LIMIT) : filtered;
+    const sampling = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? { isSampled: true, sampledCount: SAMPLE_RESOURCE_LIMIT, totalCount } : undefined;
     const resources: ResourceHealth[] = [];
 
-    for (const cfg of filtered) {
+    for (const cfg of toProcess) {
       if (signal?.cancelled) break;
       try {
         const response = await sdk.post<{
@@ -217,7 +232,7 @@ export async function fetchExtractionPipelineHealth(opts: FetcherOpts): Promise<
       }
     }
 
-    return buildReport("Extraction pipeline", resources, thresholdPct, []);
+    return buildReport("Extraction pipeline", resources, thresholdPct, [], sampling);
   } catch (err) {
     return errorReport(
       "Extraction pipeline",
@@ -245,7 +260,7 @@ type WorkflowExec = {
 };
 
 export async function fetchWorkflowHealth(opts: FetcherOpts): Promise<ResourceReport> {
-  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal, sampleMode } = opts;
   try {
     const workflows: WorkflowListItem[] = [];
     let cursor: string | undefined;
@@ -261,6 +276,11 @@ export async function fetchWorkflowHealth(opts: FetcherOpts): Promise<ResourceRe
     } while (cursor);
 
     const filtered = workflows.filter((w) => matchesDataset(w.dataSetId, datasetId));
+    const totalCount = filtered.length;
+    const toProcess = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? filtered.slice(0, SAMPLE_RESOURCE_LIMIT) : filtered;
+    const sampling = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? { isSampled: true, sampledCount: SAMPLE_RESOURCE_LIMIT, totalCount } : undefined;
 
     const executions: WorkflowExec[] = [];
     let execCursor: string | undefined;
@@ -292,7 +312,7 @@ export async function fetchWorkflowHealth(opts: FetcherOpts): Promise<ResourceRe
       execsByWorkflow.set(e.workflowExternalId, list);
     }
 
-    const resources: ResourceHealth[] = filtered.map((w) =>
+    const resources: ResourceHealth[] = toProcess.map((w) =>
       finalizeResource(
         {
           id: w.externalId,
@@ -305,7 +325,7 @@ export async function fetchWorkflowHealth(opts: FetcherOpts): Promise<ResourceRe
       )
     );
 
-    return buildReport("Workflow", resources, thresholdPct, []);
+    return buildReport("Workflow", resources, thresholdPct, [], sampling);
   } catch (err) {
     return errorReport(
       "Workflow",
@@ -334,7 +354,7 @@ type TransformationJob = {
 };
 
 export async function fetchTransformationHealth(opts: FetcherOpts): Promise<ResourceReport> {
-  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal, sampleMode } = opts;
   try {
     const transformations: TransformationListItem[] = [];
     let cursor: string | undefined;
@@ -350,9 +370,14 @@ export async function fetchTransformationHealth(opts: FetcherOpts): Promise<Reso
     } while (cursor);
 
     const filtered = transformations.filter((t) => matchesDataset(t.dataSetId, datasetId));
+    const totalCount = filtered.length;
+    const toProcess = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? filtered.slice(0, SAMPLE_RESOURCE_LIMIT) : filtered;
+    const sampling = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? { isSampled: true, sampledCount: SAMPLE_RESOURCE_LIMIT, totalCount } : undefined;
 
     const resources: ResourceHealth[] = [];
-    for (const t of filtered) {
+    for (const t of toProcess) {
       if (signal?.cancelled) break;
       try {
         const response = await sdk.get<{ items?: TransformationJob[] }>(
@@ -394,7 +419,7 @@ export async function fetchTransformationHealth(opts: FetcherOpts): Promise<Reso
       }
     }
 
-    return buildReport("Transformation", resources, thresholdPct, []);
+    return buildReport("Transformation", resources, thresholdPct, [], sampling);
   } catch (err) {
     return errorReport(
       "Transformation",
@@ -424,7 +449,7 @@ type FunctionCall = {
 };
 
 export async function fetchFunctionHealth(opts: FetcherOpts): Promise<ResourceReport> {
-  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal, sampleMode } = opts;
   try {
     const functions: FunctionListItem[] = [];
     let cursor: string | undefined;
@@ -433,7 +458,7 @@ export async function fetchFunctionHealth(opts: FetcherOpts): Promise<ResourceRe
         items?: FunctionListItem[];
         nextCursor?: string | null;
       }>(`/api/v1/projects/${sdk.project}/functions/list`, {
-        data: JSON.stringify({ limit: 100, cursor }),
+        data: { limit: 100, cursor },
       });
       functions.push(...(response.data?.items ?? []));
       cursor = response.data?.nextCursor ?? undefined;
@@ -449,10 +474,10 @@ export async function fetchFunctionHealth(opts: FetcherOpts): Promise<ResourceRe
           const response = await sdk.post<{
             items?: Array<{ id: number; dataSetId?: number }>;
           }>(`/api/v1/projects/${sdk.project}/files/byids`, {
-            data: JSON.stringify({
+            data: {
               items: fileIds.map((id) => ({ id })),
               ignoreUnknownIds: true,
-            }),
+            },
           });
           for (const file of response.data?.items ?? []) {
             if (file.dataSetId != null) dataSetByFileId.set(file.id, file.dataSetId);
@@ -468,10 +493,15 @@ export async function fetchFunctionHealth(opts: FetcherOpts): Promise<ResourceRe
       if (typeof f.fileId !== "number") return false;
       return dataSetByFileId.get(f.fileId) === datasetId;
     });
+    const totalCount = filtered.length;
+    const toProcess = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? filtered.slice(0, SAMPLE_RESOURCE_LIMIT) : filtered;
+    const sampling = sampleMode && filtered.length > SAMPLE_RESOURCE_LIMIT
+      ? { isSampled: true, sampledCount: SAMPLE_RESOURCE_LIMIT, totalCount } : undefined;
 
     const extraErrors: ResourceReport["errors"] = [];
     const resources: ResourceHealth[] = [];
-    for (const fn of filtered) {
+    for (const fn of toProcess) {
       if (signal?.cancelled) break;
       if (normalize(fn.status) === "failed") {
         extraErrors.push({
@@ -484,10 +514,10 @@ export async function fetchFunctionHealth(opts: FetcherOpts): Promise<ResourceRe
         const response = await sdk.post<{ items?: FunctionCall[] }>(
           `/api/v1/projects/${sdk.project}/functions/${fn.id}/calls/list`,
           {
-            data: JSON.stringify({
+            data: {
               filter: { startTime: { min: startMs, max: endMs } },
               limit: API_RUNS_LIMIT,
-            }),
+            },
           }
         );
         const runs: RunEntry[] = (response.data?.items ?? []).map<RunEntry>((c) => {
@@ -530,7 +560,7 @@ export async function fetchFunctionHealth(opts: FetcherOpts): Promise<ResourceRe
       }
     }
 
-    return buildReport("Function", resources, thresholdPct, extraErrors);
+    return buildReport("Function", resources, thresholdPct, extraErrors, sampling);
   } catch (err) {
     return errorReport(
       "Function",

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/fetchers.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/fetchers.ts
@@ -1,0 +1,547 @@
+import type { CogniteClient } from "@cognite/sdk";
+import { toTimestampLoose } from "@/shared/time-utils";
+import {
+  CDF_BROWSER_URL,
+  CDF_CLUSTER,
+  getFunctionsPageUrl,
+  getTransformationRunHistoryUrl,
+  getWorkflowEditorUrl,
+} from "@/shared/cdf-browser-url";
+import {
+  FAILED_STATUSES,
+  MAX_RECENT_RUNS,
+  SUCCESS_STATUSES,
+  classifyHealth,
+  isFailed,
+  isSuccess,
+  normalize,
+  uptimePercentage,
+} from "./uptime";
+import type { ResourceHealth, ResourceReport, RunEntry } from "./types";
+
+const API_LIST_LIMIT = 500;
+const API_RUNS_LIMIT = 100;
+
+type FetcherOpts = {
+  sdk: CogniteClient;
+  datasetId: number | null;
+  startMs: number;
+  endMs: number;
+  thresholdPct: number;
+  signal?: { cancelled: boolean };
+};
+
+function getExtractionPipelineUrl(project: string, externalId: string): string {
+  return `${CDF_BROWSER_URL}/${project}/extpipes/extpipe/${encodeURIComponent(
+    externalId
+  )}?cluster=${CDF_CLUSTER}&workspace=data-management`;
+}
+
+function matchesDataset(dataSetId: number | undefined | null, filterId: number | null): boolean {
+  if (filterId == null) return true;
+  return dataSetId === filterId;
+}
+
+function sortRecentRuns(runs: RunEntry[]): RunEntry[] {
+  const failedFirst = [...runs].sort((a, b) => {
+    const aFailed = isFailed(a.status) ? 0 : 1;
+    const bFailed = isFailed(b.status) ? 0 : 1;
+    if (aFailed !== bFailed) return aFailed - bFailed;
+    return (b.timeMs ?? 0) - (a.timeMs ?? 0);
+  });
+  return failedFirst.slice(0, MAX_RECENT_RUNS);
+}
+
+function finalizeResource(
+  base: Omit<ResourceHealth, "runsInWindow" | "successful" | "failed" | "uptimePercentage" | "recentRuns" | "lastStatus" | "lastRunMs">,
+  runs: RunEntry[]
+): ResourceHealth {
+  const inWindow = runs;
+  const successful = inWindow.filter((r) => isSuccess(r.status)).length;
+  const failed = inWindow.filter((r) => isFailed(r.status)).length;
+  const last = [...inWindow].sort((a, b) => (b.timeMs ?? 0) - (a.timeMs ?? 0))[0];
+  return {
+    ...base,
+    runsInWindow: inWindow.length,
+    successful,
+    failed,
+    uptimePercentage: uptimePercentage(successful, failed),
+    recentRuns: sortRecentRuns(inWindow),
+    lastStatus: last?.status,
+    lastRunMs: last?.timeMs,
+  };
+}
+
+function sortByFailureFirst(resources: ResourceHealth[]): ResourceHealth[] {
+  return [...resources].sort((a, b) => {
+    const aFailed = isFailed(a.lastStatus) ? 0 : 1;
+    const bFailed = isFailed(b.lastStatus) ? 0 : 1;
+    if (aFailed !== bFailed) return aFailed - bFailed;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function buildReport(
+  kindLabel: ResourceReport["kindLabel"],
+  resources: ResourceHealth[],
+  thresholdPct: number,
+  extraErrors: ResourceReport["errors"]
+): ResourceReport {
+  const sorted = sortByFailureFirst(resources);
+  let healthy = 0;
+  let unhealthy = 0;
+  let noRuns = 0;
+  let totalSuccess = 0;
+  let totalFailed = 0;
+  const errors = [...extraErrors];
+  for (const r of sorted) {
+    const cls = classifyHealth(r.runsInWindow, r.uptimePercentage, thresholdPct);
+    if (cls === "healthy") healthy += 1;
+    else if (cls === "unhealthy") unhealthy += 1;
+    else noRuns += 1;
+    totalSuccess += r.successful;
+    totalFailed += r.failed;
+    for (const run of r.recentRuns) {
+      if (isFailed(run.status)) {
+        errors.push({
+          resource: `${kindLabel}: ${r.name}`,
+          status: run.status,
+          timeMs: run.timeMs,
+          message: run.message,
+        });
+      }
+    }
+  }
+  const aggregateUptime = uptimePercentage(totalSuccess, totalFailed);
+  return {
+    kindLabel,
+    resources: sorted,
+    summary: { total: sorted.length, healthy, unhealthy, noRuns, aggregateUptime },
+    errors,
+    error: null,
+  };
+}
+
+function errorReport(kindLabel: ResourceReport["kindLabel"], message: string): ResourceReport {
+  return {
+    kindLabel,
+    resources: [],
+    summary: { total: 0, healthy: 0, unhealthy: 0, noRuns: 0, aggregateUptime: 100 },
+    errors: [{ resource: kindLabel, status: "error", message }],
+    error: message,
+  };
+}
+
+/* ---------- Extraction pipelines ---------- */
+
+type ExtPipeSummary = {
+  id: number;
+  externalId: string;
+  name?: string;
+  description?: string;
+  dataSetId?: number;
+};
+
+type ExtPipeRun = {
+  id?: number;
+  status?: string;
+  message?: string;
+  createdTime?: number;
+};
+
+export async function fetchExtractionPipelineHealth(opts: FetcherOpts): Promise<ResourceReport> {
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  try {
+    const configs: ExtPipeSummary[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = await sdk.get<{
+        items?: ExtPipeSummary[];
+        nextCursor?: string | null;
+      }>(`/api/v1/projects/${sdk.project}/extpipes`, {
+        params: { limit: "100", cursor },
+      });
+      configs.push(...(response.data?.items ?? []));
+      cursor = response.data?.nextCursor ?? undefined;
+    } while (cursor);
+
+    const filtered = configs.filter((c) => matchesDataset(c.dataSetId, datasetId));
+    const resources: ResourceHealth[] = [];
+
+    for (const cfg of filtered) {
+      if (signal?.cancelled) break;
+      try {
+        const response = await sdk.post<{
+          items?: ExtPipeRun[];
+        }>(`/api/v1/projects/${sdk.project}/extpipes/runs/list`, {
+          data: {
+            limit: API_RUNS_LIMIT,
+            filter: {
+              externalId: cfg.externalId,
+              createdTime: { min: startMs, max: endMs },
+            },
+          },
+        });
+        const runs: RunEntry[] = (response.data?.items ?? [])
+          .map<RunEntry>((r) => ({
+            status: r.status ?? "",
+            timeMs: toTimestampLoose(r.createdTime),
+            message: r.message,
+          }))
+          .filter((r) => (r.timeMs ?? 0) >= startMs && (r.timeMs ?? 0) <= endMs);
+        resources.push(
+          finalizeResource(
+            {
+              id: String(cfg.id),
+              name: cfg.name ?? cfg.externalId,
+              externalId: cfg.externalId,
+              datasetId: cfg.dataSetId,
+              fusionUrl: getExtractionPipelineUrl(sdk.project, cfg.externalId),
+            },
+            runs
+          )
+        );
+      } catch (err) {
+        resources.push(
+          finalizeResource(
+            {
+              id: String(cfg.id),
+              name: cfg.name ?? cfg.externalId,
+              externalId: cfg.externalId,
+              datasetId: cfg.dataSetId,
+              extraLabel: err instanceof Error ? err.message : "Runs fetch failed",
+            },
+            []
+          )
+        );
+      }
+    }
+
+    return buildReport("Extraction pipeline", resources, thresholdPct, []);
+  } catch (err) {
+    return errorReport(
+      "Extraction pipeline",
+      err instanceof Error ? err.message : "Failed to load extraction pipelines"
+    );
+  }
+}
+
+/* ---------- Workflows ---------- */
+
+type WorkflowListItem = {
+  externalId: string;
+  description?: string;
+  dataSetId?: number;
+};
+
+type WorkflowExec = {
+  id?: string;
+  workflowExternalId?: string;
+  status?: string;
+  startTime?: number;
+  endTime?: number;
+  createdTime?: number;
+  reasonForIncompletion?: string;
+};
+
+export async function fetchWorkflowHealth(opts: FetcherOpts): Promise<ResourceReport> {
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  try {
+    const workflows: WorkflowListItem[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = await sdk.get<{
+        items?: WorkflowListItem[];
+        nextCursor?: string | null;
+      }>(`/api/v1/projects/${sdk.project}/workflows`, {
+        params: { limit: "1000", cursor },
+      });
+      workflows.push(...(response.data?.items ?? []));
+      cursor = response.data?.nextCursor ?? undefined;
+    } while (cursor);
+
+    const filtered = workflows.filter((w) => matchesDataset(w.dataSetId, datasetId));
+
+    const executions: WorkflowExec[] = [];
+    let execCursor: string | undefined;
+    do {
+      if (signal?.cancelled) break;
+      const response = await sdk.post<{
+        items?: WorkflowExec[];
+        nextCursor?: string | null;
+      }>(`/api/v1/projects/${sdk.project}/workflows/executions/list`, {
+        data: {
+          limit: 1000,
+          cursor: execCursor,
+          filter: { createdTimeStart: startMs, createdTimeEnd: endMs },
+        },
+      });
+      executions.push(...(response.data?.items ?? []));
+      execCursor = response.data?.nextCursor ?? undefined;
+    } while (execCursor);
+
+    const execsByWorkflow = new Map<string, RunEntry[]>();
+    for (const e of executions) {
+      if (!e.workflowExternalId) continue;
+      const list = execsByWorkflow.get(e.workflowExternalId) ?? [];
+      list.push({
+        status: e.status ?? "",
+        timeMs: toTimestampLoose(e.endTime ?? e.startTime ?? e.createdTime),
+        message: e.reasonForIncompletion,
+      });
+      execsByWorkflow.set(e.workflowExternalId, list);
+    }
+
+    const resources: ResourceHealth[] = filtered.map((w) =>
+      finalizeResource(
+        {
+          id: w.externalId,
+          name: w.externalId,
+          externalId: w.externalId,
+          datasetId: w.dataSetId,
+          fusionUrl: getWorkflowEditorUrl(sdk.project, w.externalId),
+        },
+        execsByWorkflow.get(w.externalId) ?? []
+      )
+    );
+
+    return buildReport("Workflow", resources, thresholdPct, []);
+  } catch (err) {
+    return errorReport(
+      "Workflow",
+      err instanceof Error ? err.message : "Failed to load workflows"
+    );
+  }
+}
+
+/* ---------- Transformations ---------- */
+
+type TransformationListItem = {
+  id: number;
+  externalId?: string;
+  name?: string;
+  dataSetId?: number;
+};
+
+type TransformationJob = {
+  id?: number;
+  transformationId?: number;
+  status?: string;
+  error?: string;
+  startedTime?: number;
+  finishedTime?: number;
+  createdTime?: number;
+};
+
+export async function fetchTransformationHealth(opts: FetcherOpts): Promise<ResourceReport> {
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  try {
+    const transformations: TransformationListItem[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = await sdk.get<{
+        items?: TransformationListItem[];
+        nextCursor?: string | null;
+      }>(`/api/v1/projects/${sdk.project}/transformations`, {
+        params: { limit: "1000", cursor },
+      });
+      transformations.push(...(response.data?.items ?? []));
+      cursor = response.data?.nextCursor ?? undefined;
+    } while (cursor);
+
+    const filtered = transformations.filter((t) => matchesDataset(t.dataSetId, datasetId));
+
+    const resources: ResourceHealth[] = [];
+    for (const t of filtered) {
+      if (signal?.cancelled) break;
+      try {
+        const response = await sdk.get<{ items?: TransformationJob[] }>(
+          `/api/v1/projects/${sdk.project}/transformations/jobs`,
+          { params: { limit: String(API_RUNS_LIMIT), transformationId: String(t.id) } }
+        );
+        const runs: RunEntry[] = (response.data?.items ?? [])
+          .map<RunEntry>((j) => ({
+            status: j.status ?? "",
+            timeMs: toTimestampLoose(j.finishedTime ?? j.startedTime ?? j.createdTime),
+            message: j.error,
+          }))
+          .filter((r) => (r.timeMs ?? 0) >= startMs && (r.timeMs ?? 0) <= endMs);
+        resources.push(
+          finalizeResource(
+            {
+              id: String(t.id),
+              name: t.name ?? t.externalId ?? String(t.id),
+              externalId: t.externalId,
+              datasetId: t.dataSetId,
+              fusionUrl: getTransformationRunHistoryUrl(sdk.project, t.id),
+            },
+            runs
+          )
+        );
+      } catch (err) {
+        resources.push(
+          finalizeResource(
+            {
+              id: String(t.id),
+              name: t.name ?? t.externalId ?? String(t.id),
+              externalId: t.externalId,
+              datasetId: t.dataSetId,
+              extraLabel: err instanceof Error ? err.message : "Jobs fetch failed",
+            },
+            []
+          )
+        );
+      }
+    }
+
+    return buildReport("Transformation", resources, thresholdPct, []);
+  } catch (err) {
+    return errorReport(
+      "Transformation",
+      err instanceof Error ? err.message : "Failed to load transformations"
+    );
+  }
+}
+
+/* ---------- Functions ---------- */
+
+type FunctionListItem = {
+  id: string | number;
+  externalId?: string;
+  name?: string;
+  description?: string;
+  status?: string;
+  fileId?: number;
+};
+
+type FunctionCall = {
+  id?: string | number;
+  status?: string;
+  error?: { message?: string } | string;
+  startTime?: number;
+  endTime?: number;
+  createdTime?: number;
+};
+
+export async function fetchFunctionHealth(opts: FetcherOpts): Promise<ResourceReport> {
+  const { sdk, datasetId, startMs, endMs, thresholdPct, signal } = opts;
+  try {
+    const functions: FunctionListItem[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = await sdk.post<{
+        items?: FunctionListItem[];
+        nextCursor?: string | null;
+      }>(`/api/v1/projects/${sdk.project}/functions/list`, {
+        data: JSON.stringify({ limit: 100, cursor }),
+      });
+      functions.push(...(response.data?.items ?? []));
+      cursor = response.data?.nextCursor ?? undefined;
+    } while (cursor);
+
+    let dataSetByFileId = new Map<number, number>();
+    if (datasetId != null) {
+      const fileIds = Array.from(
+        new Set(functions.map((f) => f.fileId).filter((id): id is number => typeof id === "number"))
+      );
+      if (fileIds.length > 0) {
+        try {
+          const response = await sdk.post<{
+            items?: Array<{ id: number; dataSetId?: number }>;
+          }>(`/api/v1/projects/${sdk.project}/files/byids`, {
+            data: JSON.stringify({
+              items: fileIds.map((id) => ({ id })),
+              ignoreUnknownIds: true,
+            }),
+          });
+          for (const file of response.data?.items ?? []) {
+            if (file.dataSetId != null) dataSetByFileId.set(file.id, file.dataSetId);
+          }
+        } catch {
+          dataSetByFileId = new Map();
+        }
+      }
+    }
+
+    const filtered = functions.filter((f) => {
+      if (datasetId == null) return true;
+      if (typeof f.fileId !== "number") return false;
+      return dataSetByFileId.get(f.fileId) === datasetId;
+    });
+
+    const extraErrors: ResourceReport["errors"] = [];
+    const resources: ResourceHealth[] = [];
+    for (const fn of filtered) {
+      if (signal?.cancelled) break;
+      if (normalize(fn.status) === "failed") {
+        extraErrors.push({
+          resource: `Function: ${fn.name ?? fn.externalId ?? fn.id}`,
+          status: fn.status ?? "failed",
+          message: "Function deployment failed",
+        });
+      }
+      try {
+        const response = await sdk.post<{ items?: FunctionCall[] }>(
+          `/api/v1/projects/${sdk.project}/functions/${fn.id}/calls/list`,
+          {
+            data: JSON.stringify({
+              filter: { startTime: { min: startMs, max: endMs } },
+              limit: API_RUNS_LIMIT,
+            }),
+          }
+        );
+        const runs: RunEntry[] = (response.data?.items ?? []).map<RunEntry>((c) => {
+          const msg =
+            typeof c.error === "string"
+              ? c.error
+              : typeof c.error === "object" && c.error
+                ? c.error.message
+                : undefined;
+          return {
+            status: c.status ?? "",
+            timeMs: toTimestampLoose(c.endTime ?? c.startTime ?? c.createdTime),
+            message: msg,
+          };
+        });
+        resources.push(
+          finalizeResource(
+            {
+              id: String(fn.id),
+              name: fn.name ?? fn.externalId ?? String(fn.id),
+              externalId: fn.externalId,
+              fusionUrl: getFunctionsPageUrl(sdk.project),
+              extraLabel: fn.status,
+            },
+            runs
+          )
+        );
+      } catch (err) {
+        resources.push(
+          finalizeResource(
+            {
+              id: String(fn.id),
+              name: fn.name ?? fn.externalId ?? String(fn.id),
+              externalId: fn.externalId,
+              extraLabel: err instanceof Error ? err.message : "Calls fetch failed",
+            },
+            []
+          )
+        );
+      }
+    }
+
+    return buildReport("Function", resources, thresholdPct, extraErrors);
+  } catch (err) {
+    return errorReport(
+      "Function",
+      err instanceof Error ? err.message : "Failed to load functions"
+    );
+  }
+}
+
+export const __internal_testing = {
+  SUCCESS_STATUSES,
+  FAILED_STATUSES,
+  API_LIST_LIMIT,
+  API_RUNS_LIMIT,
+};

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/index.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/index.ts
@@ -1,0 +1,1 @@
+export { RunHealthChecks } from "./RunHealthChecks";

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/thresholds.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/thresholds.ts
@@ -1,0 +1,34 @@
+export type ResourceKind = "extractionPipelines" | "workflows" | "transformations" | "functions";
+
+const STORAGE_KEY = "qualitizer.runHealth.thresholds";
+
+export const DEFAULT_THRESHOLDS: Record<ResourceKind, number> = {
+  extractionPipelines: 75,
+  workflows: 75,
+  transformations: 75,
+  functions: 75,
+};
+
+export function loadThresholds(): Record<ResourceKind, number> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_THRESHOLDS };
+    const parsed = JSON.parse(raw) as Partial<Record<ResourceKind, unknown>>;
+    const result: Record<ResourceKind, number> = { ...DEFAULT_THRESHOLDS };
+    (Object.keys(DEFAULT_THRESHOLDS) as ResourceKind[]).forEach((k) => {
+      const v = Number(parsed[k]);
+      if (Number.isFinite(v) && v >= 0 && v <= 100) result[k] = v;
+    });
+    return result;
+  } catch {
+    return { ...DEFAULT_THRESHOLDS };
+  }
+}
+
+export function saveThresholds(value: Record<ResourceKind, number>) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // ignore
+  }
+}

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/types.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/types.ts
@@ -1,0 +1,46 @@
+export type RunEntry = {
+  status: string;
+  timeMs?: number;
+  message?: string;
+};
+
+export type ResourceHealth = {
+  id: string;
+  name: string;
+  externalId?: string;
+  datasetId?: number;
+  lastStatus?: string;
+  lastRunMs?: number;
+  runsInWindow: number;
+  successful: number;
+  failed: number;
+  uptimePercentage: number;
+  recentRuns: RunEntry[];
+  fusionUrl?: string;
+  extraLabel?: string;
+};
+
+export type ResourceKindLabel =
+  | "Extraction pipeline"
+  | "Workflow"
+  | "Transformation"
+  | "Function";
+
+export type ResourceReport = {
+  kindLabel: ResourceKindLabel;
+  resources: ResourceHealth[];
+  summary: {
+    total: number;
+    healthy: number;
+    unhealthy: number;
+    noRuns: number;
+    aggregateUptime: number;
+  };
+  errors: Array<{
+    resource: string;
+    status: string;
+    timeMs?: number;
+    message?: string;
+  }>;
+  error: string | null;
+};

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/types.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/types.ts
@@ -31,8 +31,9 @@ export type ResourceReport = {
   resources: ResourceHealth[];
   summary: {
     total: number;
-    healthy: number;
-    unhealthy: number;
+    success: number;
+    warning: number;
+    critical: number;
     noRuns: number;
     aggregateUptime: number;
   };
@@ -43,4 +44,9 @@ export type ResourceReport = {
     message?: string;
   }>;
   error: string | null;
+  sampling?: {
+    isSampled: boolean;
+    sampledCount: number;
+    totalCount: number;
+  };
 };

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/uptime.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/uptime.ts
@@ -1,0 +1,53 @@
+export const SUCCESS_STATUSES = new Set(["success", "completed", "ready", "seen"]);
+export const FAILED_STATUSES = new Set([
+  "failed",
+  "failure",
+  "error",
+  "timed_out",
+  "timeout",
+]);
+
+export const MAX_RECENT_RUNS = 5;
+
+export function normalize(status?: string | null): string {
+  return (status ?? "").toLowerCase();
+}
+
+export function isSuccess(status?: string | null): boolean {
+  return SUCCESS_STATUSES.has(normalize(status));
+}
+
+export function isFailed(status?: string | null): boolean {
+  return FAILED_STATUSES.has(normalize(status));
+}
+
+export function uptimePercentage(successful: number, failed: number): number {
+  const total = successful + failed;
+  if (total <= 0) return 100;
+  return (successful / total) * 100;
+}
+
+export type HealthClass = "healthy" | "unhealthy" | "no_runs";
+
+export function classifyHealth(
+  runs: number,
+  uptime: number,
+  thresholdPct: number
+): HealthClass {
+  if (runs <= 0) return "no_runs";
+  return uptime >= thresholdPct ? "healthy" : "unhealthy";
+}
+
+export function uptimeColor(uptime: number): string {
+  if (uptime >= 90) return "text-emerald-700";
+  if (uptime >= 70) return "text-amber-700";
+  if (uptime >= 50) return "text-orange-700";
+  return "text-red-700";
+}
+
+export function uptimeBg(uptime: number): string {
+  if (uptime >= 90) return "bg-emerald-50 border-emerald-200";
+  if (uptime >= 70) return "bg-amber-50 border-amber-200";
+  if (uptime >= 50) return "bg-orange-50 border-orange-200";
+  return "bg-red-50 border-red-200";
+}

--- a/modules/tools/apps/qualitizer/src/health-checks/run-health/uptime.ts
+++ b/modules/tools/apps/qualitizer/src/health-checks/run-health/uptime.ts
@@ -27,15 +27,17 @@ export function uptimePercentage(successful: number, failed: number): number {
   return (successful / total) * 100;
 }
 
-export type HealthClass = "healthy" | "unhealthy" | "no_runs";
+export type HealthClass = "success" | "warning" | "critical" | "no_runs";
 
 export function classifyHealth(
   runs: number,
   uptime: number,
-  thresholdPct: number
+  _thresholdPct: number
 ): HealthClass {
   if (runs <= 0) return "no_runs";
-  return uptime >= thresholdPct ? "healthy" : "unhealthy";
+  if (uptime >= 100) return "success";
+  if (uptime > 10) return "warning";
+  return "critical";
 }
 
 export function uptimeColor(uptime: number): string {

--- a/modules/tools/apps/qualitizer/src/shared/dataset-filter-context.tsx
+++ b/modules/tools/apps/qualitizer/src/shared/dataset-filter-context.tsx
@@ -62,7 +62,7 @@ export function DatasetFilterProvider({ children }: { children: React.ReactNode 
             items?: Array<{ id: number; externalId?: string; name?: string }>;
             nextCursor?: string | null;
           }>(`/api/v1/projects/${sdk.project}/datasets/list`, {
-            data: JSON.stringify({ limit: 1000, cursor }),
+            data: { limit: 1000, cursor },
           });
           items.push(...(response.data?.items ?? []));
           cursor = response.data?.nextCursor ?? undefined;

--- a/modules/tools/apps/qualitizer/src/shared/dataset-filter-context.tsx
+++ b/modules/tools/apps/qualitizer/src/shared/dataset-filter-context.tsx
@@ -1,0 +1,108 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useAppSdk } from "./auth";
+
+export type DatasetSummary = {
+  id: number;
+  externalId?: string;
+  name?: string;
+};
+
+const STORAGE_KEY = "qualitizer.datasetFilter";
+
+function loadSelected(): number | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    if (raw === "null" || raw === "") return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveSelected(value: number | null) {
+  try {
+    if (value == null) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // ignore
+  }
+}
+
+type DatasetFilterContextValue = {
+  datasets: DatasetSummary[];
+  isLoading: boolean;
+  error: string | null;
+  selectedDatasetId: number | null;
+  setSelectedDatasetId: (id: number | null) => void;
+  selectedDataset: DatasetSummary | null;
+};
+
+const DatasetFilterContext = createContext<DatasetFilterContextValue | null>(null);
+
+export function DatasetFilterProvider({ children }: { children: React.ReactNode }) {
+  const { sdk, isLoading: isSdkLoading } = useAppSdk();
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedDatasetId, setSelectedDatasetIdState] = useState<number | null>(loadSelected);
+
+  useEffect(() => {
+    if (isSdkLoading) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const items: DatasetSummary[] = [];
+        let cursor: string | undefined;
+        do {
+          const response = await sdk.post<{
+            items?: Array<{ id: number; externalId?: string; name?: string }>;
+            nextCursor?: string | null;
+          }>(`/api/v1/projects/${sdk.project}/datasets/list`, {
+            data: JSON.stringify({ limit: 1000, cursor }),
+          });
+          items.push(...(response.data?.items ?? []));
+          cursor = response.data?.nextCursor ?? undefined;
+        } while (cursor);
+        if (cancelled) return;
+        items.sort((a, b) => (a.name ?? a.externalId ?? "").localeCompare(b.name ?? b.externalId ?? ""));
+        setDatasets(items);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load datasets");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isSdkLoading, sdk]);
+
+  const setSelectedDatasetId = useCallback((id: number | null) => {
+    setSelectedDatasetIdState(id);
+    saveSelected(id);
+  }, []);
+
+  const value = useMemo<DatasetFilterContextValue>(() => {
+    const selected = selectedDatasetId == null ? null : datasets.find((d) => d.id === selectedDatasetId) ?? null;
+    return {
+      datasets,
+      isLoading,
+      error,
+      selectedDatasetId,
+      setSelectedDatasetId,
+      selectedDataset: selected,
+    };
+  }, [datasets, isLoading, error, selectedDatasetId, setSelectedDatasetId]);
+
+  return <DatasetFilterContext.Provider value={value}>{children}</DatasetFilterContext.Provider>;
+}
+
+export function useDatasetFilter() {
+  const ctx = useContext(DatasetFilterContext);
+  if (!ctx) throw new Error("useDatasetFilter must be used within DatasetFilterProvider");
+  return ctx;
+}

--- a/modules/tools/apps/qualitizer/src/shared/time-range-context.tsx
+++ b/modules/tools/apps/qualitizer/src/shared/time-range-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
-export type TimeRangePreset = "12h" | "1d" | "7d" | "30d";
+export type TimeRangePreset = "1h" | "6h" | "12h" | "24h" | "7d";
 export type TimeRangeKind = TimeRangePreset | "custom";
 
 export type TimeRangeValue =
@@ -8,14 +8,15 @@ export type TimeRangeValue =
   | { kind: "custom"; startMs: number; endMs: number };
 
 const PRESET_HOURS: Record<TimeRangePreset, number> = {
+  "1h": 1,
+  "6h": 6,
   "12h": 12,
-  "1d": 24,
+  "24h": 24,
   "7d": 24 * 7,
-  "30d": 24 * 30,
 };
 
 const STORAGE_KEY = "qualitizer.timeRange";
-const DEFAULT: TimeRangeValue = { kind: "1d" };
+const DEFAULT: TimeRangeValue = { kind: "1h" };
 
 function load(): TimeRangeValue {
   try {
@@ -30,7 +31,7 @@ function load(): TimeRangeValue {
       }
       return DEFAULT;
     }
-    if (parsed.kind === "12h" || parsed.kind === "1d" || parsed.kind === "7d" || parsed.kind === "30d") {
+    if (parsed.kind === "1h" || parsed.kind === "6h" || parsed.kind === "12h" || parsed.kind === "24h" || parsed.kind === "7d") {
       return { kind: parsed.kind };
     }
     return DEFAULT;

--- a/modules/tools/apps/qualitizer/src/shared/time-range-context.tsx
+++ b/modules/tools/apps/qualitizer/src/shared/time-range-context.tsx
@@ -1,0 +1,96 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+export type TimeRangePreset = "12h" | "1d" | "7d" | "30d";
+export type TimeRangeKind = TimeRangePreset | "custom";
+
+export type TimeRangeValue =
+  | { kind: TimeRangePreset }
+  | { kind: "custom"; startMs: number; endMs: number };
+
+const PRESET_HOURS: Record<TimeRangePreset, number> = {
+  "12h": 12,
+  "1d": 24,
+  "7d": 24 * 7,
+  "30d": 24 * 30,
+};
+
+const STORAGE_KEY = "qualitizer.timeRange";
+const DEFAULT: TimeRangeValue = { kind: "1d" };
+
+function load(): TimeRangeValue {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT;
+    const parsed = JSON.parse(raw) as Partial<TimeRangeValue> & { kind?: string };
+    if (parsed.kind === "custom") {
+      const s = Number((parsed as { startMs?: unknown }).startMs);
+      const e = Number((parsed as { endMs?: unknown }).endMs);
+      if (Number.isFinite(s) && Number.isFinite(e) && e > s) {
+        return { kind: "custom", startMs: s, endMs: e };
+      }
+      return DEFAULT;
+    }
+    if (parsed.kind === "12h" || parsed.kind === "1d" || parsed.kind === "7d" || parsed.kind === "30d") {
+      return { kind: parsed.kind };
+    }
+    return DEFAULT;
+  } catch {
+    return DEFAULT;
+  }
+}
+
+function save(value: TimeRangeValue) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // ignore
+  }
+}
+
+export function resolveRange(value: TimeRangeValue, now = Date.now()): { startMs: number; endMs: number } {
+  if (value.kind === "custom") {
+    return { startMs: value.startMs, endMs: value.endMs };
+  }
+  const hours = PRESET_HOURS[value.kind];
+  return { startMs: now - hours * 60 * 60 * 1000, endMs: now };
+}
+
+type TimeRangeContextValue = {
+  range: TimeRangeValue;
+  setRange: (next: TimeRangeValue) => void;
+  startMs: number;
+  endMs: number;
+};
+
+const TimeRangeContext = createContext<TimeRangeContextValue | null>(null);
+
+export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
+  const [range, setRangeState] = useState<TimeRangeValue>(load);
+
+  const setRange = useCallback((next: TimeRangeValue) => {
+    setRangeState(next);
+    save(next);
+  }, []);
+
+  const value = useMemo<TimeRangeContextValue>(() => {
+    const { startMs, endMs } = resolveRange(range);
+    return { range, setRange, startMs, endMs };
+  }, [range, setRange]);
+
+  return <TimeRangeContext.Provider value={value}>{children}</TimeRangeContext.Provider>;
+}
+
+export function useTimeRange() {
+  const ctx = useContext(TimeRangeContext);
+  if (!ctx) throw new Error("useTimeRange must be used within TimeRangeProvider");
+  return ctx;
+}
+
+export function formatRangeLabel(range: TimeRangeValue): string {
+  if (range.kind === "custom") {
+    const s = new Date(range.startMs).toISOString().slice(0, 16).replace("T", " ");
+    const e = new Date(range.endMs).toISOString().slice(0, 16).replace("T", " ");
+    return `${s} → ${e} UTC`;
+  }
+  return range.kind;
+}

--- a/modules/tools/apps/qualitizer/src/transformations/Transformations.tsx
+++ b/modules/tools/apps/qualitizer/src/transformations/Transformations.tsx
@@ -6,6 +6,12 @@ import { ApiError } from "@/shared/ApiError";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { LoadState } from "@/processing/types";
 import { formatDuration, formatIso, toTimestamp } from "@/shared/time-utils";
+import {
+  isFailed as isFailedStatus,
+  isSuccess as isSuccessStatus,
+  uptimeColor,
+  uptimePercentage,
+} from "@/health-checks/run-health/uptime";
 
 function formatDurationShort(ms: number | undefined): string {
   if (ms == null) return "—";
@@ -219,6 +225,9 @@ export function TransformationsList({
   const [statsById, setStatsById] = useState<
     Record<string, { count: number; lastRun?: number; totalMs: number }>
   >({});
+  const [uptimeById, setUptimeById] = useState<
+    Record<string, { success: number; failed: number; uptime: number }>
+  >({});
   const [countsById, setCountsById] = useState<Record<string, ParsedInsightCounts>>({});
   const [metricsById, setMetricsById] = useState<
     Record<string, { reads: number; writes: number; noops: number; rateLimit429: number }>
@@ -284,6 +293,7 @@ export function TransformationsList({
             onTransformationSelected();
           }
           setStatsById({});
+          setUptimeById({});
           setCountsById({});
           setLatestJobById({});
           setMetricsById({});
@@ -318,6 +328,9 @@ export function TransformationsList({
       lastRun?: number;
       totalMs: number;
       latestJobId: string | null;
+      success: number;
+      failed: number;
+      uptime: number;
     } => {
       const recent = jobs.filter((job) => {
         const start = toTimestamp(job.startedTime);
@@ -336,16 +349,20 @@ export function TransformationsList({
         if (!start || !end || end < start) return acc;
         return acc + (end - start);
       }, 0);
+      const success = recent.filter((job) => isSuccessStatus(job.status)).length;
+      const failed = recent.filter((job) => isFailedStatus(job.status)).length;
+      const uptime = uptimePercentage(success, failed);
       const sorted = [...jobs].sort(
         (a, b) => (toTimestamp(b.startedTime) ?? 0) - (toTimestamp(a.startedTime) ?? 0)
       );
       const latest = sorted[0];
       const latestJobId = latest?.id != null ? String(latest.id) : null;
-      return { count, lastRun, totalMs, latestJobId };
+      return { count, lastRun, totalMs, latestJobId, success, failed, uptime };
     };
 
     const run = async () => {
       const nextStats: Record<string, { count: number; lastRun?: number; totalMs: number }> = {};
+      const nextUptime: Record<string, { success: number; failed: number; uptime: number }> = {};
       const nextLatest: Record<string, string | null> = {};
 
       for (let i = 0; i < transformations.length; i += TRANSFORMATIONS_STATS_CONCURRENCY) {
@@ -362,12 +379,19 @@ export function TransformationsList({
               );
               const data = (jobResponse as { data?: { items?: TransformationJobSummary[] } }).data;
               const jobs = data?.items ?? [];
-              const { count, lastRun, totalMs, latestJobId } = computeJobStats(jobs);
-              return { id, stats: { count, lastRun, totalMs }, latestJobId };
+              const { count, lastRun, totalMs, latestJobId, success, failed, uptime } =
+                computeJobStats(jobs);
+              return {
+                id,
+                stats: { count, lastRun, totalMs },
+                uptime: { success, failed, uptime },
+                latestJobId,
+              };
             } catch {
               return {
                 id,
                 stats: { count: 0, totalMs: 0 } as { count: number; lastRun?: number; totalMs: number },
+                uptime: { success: 0, failed: 0, uptime: 100 },
                 latestJobId: null,
               };
             }
@@ -375,6 +399,7 @@ export function TransformationsList({
         );
         for (const row of chunkResults) {
           nextStats[row.id] = row.stats;
+          nextUptime[row.id] = row.uptime;
           nextLatest[row.id] = row.latestJobId;
         }
       }
@@ -382,6 +407,7 @@ export function TransformationsList({
       if (!cancelled) {
         startTransition(() => {
           setStatsById(nextStats);
+          setUptimeById(nextUptime);
           setLatestJobById(nextLatest);
         });
       }
@@ -921,6 +947,18 @@ export function TransformationsList({
                                 {sortKey === "totalMs" ? (sortDesc ? " ↓" : " ↑") : ""}
                               </button>
                             </th>
+                            <th
+                              className="px-2 py-2 font-medium"
+                              title="Uptime % = successful / (successful + failed) over the last 24h."
+                            >
+                              Uptime 24h
+                            </th>
+                            <th
+                              className="px-2 py-2 font-medium"
+                              title="Successful / failed job counts over the last 24h."
+                            >
+                              S / F
+                            </th>
                             <th className="px-2 py-2 font-medium" title={t("transformations.list.columnHelp.reads")}>
                               {t("transformations.list.reads")}
                             </th>
@@ -986,6 +1024,28 @@ export function TransformationsList({
                                     formatDuration(stats.totalMs)
                                   ) : (
                                     "—"
+                                  )}
+                                </td>
+                                <td className="px-2 py-2 tabular-nums">
+                                  {!statsReady ? (
+                                    <CellSpinner />
+                                  ) : (uptimeById[id]?.success ?? 0) + (uptimeById[id]?.failed ?? 0) > 0 ? (
+                                    <span className={`font-semibold ${uptimeColor(uptimeById[id]?.uptime ?? 100)}`}>
+                                      {(uptimeById[id]?.uptime ?? 0).toFixed(1)}%
+                                    </span>
+                                  ) : (
+                                    "—"
+                                  )}
+                                </td>
+                                <td className="px-2 py-2 tabular-nums">
+                                  {!statsReady ? (
+                                    <CellSpinner />
+                                  ) : (
+                                    <span className="text-xs text-slate-600">
+                                      <span className="text-emerald-700">{uptimeById[id]?.success ?? 0}</span>
+                                      {" / "}
+                                      <span className="text-red-700">{uptimeById[id]?.failed ?? 0}</span>
+                                    </span>
                                   )}
                                 </td>
                                 <td className="px-2 py-2 tabular-nums">


### PR DESCRIPTION
Why: the two tools overlap in intent (both watch CDF run health) but Project Health is a Streamlit+Function snapshot and Qualitizer runs on the newer Flows Framework. Rather than keep two codebases, I ported the high-value, low-effort pieces of Project Health into Qualitizer as a new Health Checks category.

What's in this PR:
• New Health Checks category: "Run Health"— per-resource uptime %, healthy/unhealthy/no-runs summary, and aggregated recent failures for extraction pipelines, workflows, transformations, and functions. Configurable uptime thresholds, persisted in localStorage.
• Global `TimeRangeContext`— 12h / 1d / 7d / 30d selector in the top bar, shared across views. Closes Qualitizer's fixed-1h-window limitation.
• Dataset filter — dropdown in the top bar, wired through a new `DatasetFilterContext`. Scopes Run Health panels (and gives other views a drop-in hook for future use).
• Transformations list — two new columns, `Uptime 24h` and `S / F` (successful / failed), so the existing list now surfaces the same signal as Project Health without needing a separate page.