### PR TITLE
fix(foundation): add DataSet resources for extraction pipelines

### DIFF
--- a/modules/sourcesystem/cdf_db_foundation/data_sets/ds_db_postgres.DataSet.yaml
+++ b/modules/sourcesystem/cdf_db_foundation/data_sets/ds_db_postgres.DataSet.yaml
@@ -1,0 +1,6 @@
+- externalId: ds_db_postgres
+  name: Database Foundation
+  description: Data set for database foundation extraction pipelines
+  writeProtected: false
+  metadata:
+    origin: cognite-toolkit

--- a/modules/sourcesystem/cdf_files_foundation/data_sets/ds_files.DataSet.yaml
+++ b/modules/sourcesystem/cdf_files_foundation/data_sets/ds_files.DataSet.yaml
@@ -1,0 +1,6 @@
+- externalId: ds_files
+  name: Files Foundation
+  description: Data set for CDF Files foundation extraction pipelines
+  writeProtected: false
+  metadata:
+    origin: cognite-toolkit

--- a/modules/sourcesystem/cdf_opcua_foundation/data_sets/ds_opcua.DataSet.yaml
+++ b/modules/sourcesystem/cdf_opcua_foundation/data_sets/ds_opcua.DataSet.yaml
@@ -1,0 +1,6 @@
+- externalId: ds_opcua
+  name: OPC UA Foundation
+  description: Data set for OPC UA foundation extraction pipelines
+  writeProtected: false
+  metadata:
+    origin: cognite-toolkit

--- a/modules/sourcesystem/cdf_pi_foundation/data_sets/ds_pi.DataSet.yaml
+++ b/modules/sourcesystem/cdf_pi_foundation/data_sets/ds_pi.DataSet.yaml
@@ -1,0 +1,6 @@
+- externalId: ds_pi
+  name: PI Foundation
+  description: Data set for PI foundation extraction pipelines
+  writeProtected: false
+  metadata:
+    origin: cognite-toolkit

--- a/modules/sourcesystem/cdf_sap_foundation/data_sets/ds_sap.DataSet.yaml
+++ b/modules/sourcesystem/cdf_sap_foundation/data_sets/ds_sap.DataSet.yaml
@@ -1,0 +1,6 @@
+- externalId: ds_sap
+  name: SAP Foundation
+  description: Data set for SAP foundation extraction pipelines
+  writeProtected: false
+  metadata:
+    origin: cognite-toolkit


### PR DESCRIPTION
Foundation modules referenced ds_* external IDs without defining datasets, causing cdf deploy to fail when resolving dataSetId for extraction pipelines.