### PR TITLE
fix: resolve open CodeQL alerts on main

### DIFF
--- a/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/CacheService.py
+++ b/modules/contextualization/cdf_file_annotation/functions/fn_file_annotation_launch/services/CacheService.py
@@ -96,7 +96,7 @@ class GeneralCacheService(ICacheService):
 
         try:
             row: Row | None = self.client.raw.rows.retrieve(db_name=self.db_name, table_name=self.tbl_name, key=key)
-        except:
+        except Exception:
             row = None
 
         # Attempt to retrieve from the cache

--- a/modules/dashboards/context_quality/functions/context_quality_handler/metrics/common.py
+++ b/modules/dashboards/context_quality/functions/context_quality_handler/metrics/common.py
@@ -535,7 +535,8 @@ class CombinedAccumulator:
         if now_str:
             try:
                 acc.now = datetime.fromisoformat(now_str)
-            except:
+            except ValueError:
+                # Ignore malformed timestamps from persisted batch data.
                 pass
         
         # Time Series Data

--- a/modules/dashboards/context_quality/streamlit/context_quality_dashboard/main.py
+++ b/modules/dashboards/context_quality/streamlit/context_quality_dashboard/main.py
@@ -28,6 +28,7 @@ try:
     import pyodide_http  # type: ignore[import-untyped]
     pyodide_http.patch_all()
 except ImportError:
+    # pyodide_http is only available when Streamlit runs in the browser (Pyodide).
     pass
 
 # Import dashboard modules

--- a/modules/dashboards/project_health/streamlit/project_health_dashboard/main.py
+++ b/modules/dashboards/project_health/streamlit/project_health_dashboard/main.py
@@ -18,6 +18,7 @@ try:
     import pyodide_http  # type: ignore[import-untyped]
     pyodide_http.patch_all()
 except ImportError:
+    # pyodide_http is only available when Streamlit runs in the browser (Pyodide).
     pass
 
 from cognite.client import CogniteClient
@@ -204,10 +205,7 @@ def main():
         datasets_dict = None
         dataset_ids = []
     else:
-        metadata = {}
         config = {}
-        datasets_dict = None
-        dataset_ids = []
 
     # Sidebar: only Project URL (organization base); project and cluster from metrics file (set by function from client config)
     with st.sidebar:
@@ -258,7 +256,6 @@ def main():
                 st.caption(f"Loaded {metadata.get('dataset_count') or len(datasets_dict)} dataset(s) from file.")
         else:
             dataset_external_id = "—"
-            payload = {}
             if metrics.get("_error"):
                 st.warning("Load failed. Run the function in **Configuration**, then **Refresh data**.")
             else:


### PR DESCRIPTION
- Catch Exception instead of bare except in CacheService RAW retrieve
- Parse accumulator timestamps with ValueError handler and comment
- Document optional pyodide_http ImportError in Streamlit dashboards
- Remove unused locals in project health dashboard no-metrics path