### PR TITLE
Actions fix

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -155,9 +155,9 @@ python modules/common/cdf_project_foundation/scripts/generate_actions.py --force
 
 The script reads `org-dir` and toolkit version from `cdf.toml` automatically. It uses `environment.project` from each `config.<env>.yaml` as the CDF project name and validates that `environment.name` matches the expected environment.
 
-This writes `.github/workflows/` (`dry-run.yml`, `deploy-dev.yml`, `deploy-test.yml`, `deploy-prod.yml`) and `docs/FOUNDATION_CICD.md` (GitHub Environments and secrets). Configure `ADMIN_SOURCE_ID`, `CONSUMER_SOURCE_ID`, and `PRODUCER_SOURCE_ID` as GitHub Environment variables alongside the CDF auth variables.
+This writes `.github/workflows/` (`dry-run.yml`, `deploy-dev.yml`, `deploy-prod.yml`, and `deploy-test.yml` when `config.test.yaml` exists) and `docs/FOUNDATION_CICD.md` (GitHub Environments and secrets). Configure `ADMIN_SOURCE_ID`, `CONSUMER_SOURCE_ID`, and `PRODUCER_SOURCE_ID` as GitHub Environment variables alongside the CDF auth variables.
 
-Branching model: PRs to `dev` / `main`; deploy **dev** on merge to `dev`, **test** on merge to `main`, **prod** on GitHub Release from `main`.
+Branching model: PRs to `dev`; PRs to `main` and deploy **test** on merge to `main` only when `config.test.yaml` exists; deploy **dev** on merge to `dev`, and **prod** on GitHub Release from `main`.
 
 ---
 

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -150,7 +150,7 @@ python modules/common/cdf_project_foundation/scripts/generate_actions.py --force
 
 The script reads `org-dir` and toolkit version from `cdf.toml` automatically. It uses `environment.project` from each `config.<env>.yaml` as the CDF project name and validates that `environment.name` matches the expected environment.
 
-This writes `.github/workflows/` (`dry-run.yml`, `deploy-dev.yml`, `deploy-test.yml`, `deploy-prod.yml`) and `docs/FOUNDATION_CICD.md` (GitHub Environments and secrets).
+This writes `.github/workflows/` (`dry-run.yml`, `deploy-dev.yml`, `deploy-test.yml`, `deploy-prod.yml`) and `docs/FOUNDATION_CICD.md` (GitHub Environments and secrets). Configure `ADMIN_SOURCE_ID`, `CONSUMER_SOURCE_ID`, and `PRODUCER_SOURCE_ID` as GitHub Environment variables alongside the CDF auth variables.
 
 Branching model: PRs to `dev` / `main`; deploy **dev** on merge to `dev`, **test** on merge to `main`, **prod** on GitHub Release from `main`.
 

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -122,8 +122,13 @@ python modules/common/cdf_project_foundation/scripts/setup_project.py --check   
 Run a build and dry-run to catch config errors before touching any live CDF project:
 
 ```bash
+# Toolkit < 0.8.0
 cdf build --env dev
-cdf deploy --env dev --dry-run
+
+# Toolkit >= 0.8.0
+cdf build -c config.dev.yaml
+
+cdf deploy --dry-run
 ```
 
 Repeat for `test` and `prod` as needed. Fix any reported issues and re-run.
@@ -135,7 +140,7 @@ Repeat for `test` and `prod` as needed. Fix any reported issues and re-run.
 Once the dry-run is clean, deploy to your project:
 
 ```bash
-cdf deploy --env dev
+cdf deploy
 ```
 
 ---

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -148,7 +148,7 @@ Generate GitHub Actions workflows that automate build, dry-run, and deploy on PR
 python modules/common/cdf_project_foundation/scripts/generate_actions.py --force
 ```
 
-Set `enterprise` in `cdf.toml` under `[cdf]` (e.g. `enterprise = "acme"`) or pass `--enterprise <slug>` to override. The script reads `org-dir` and toolkit version from `cdf.toml` automatically.
+The script reads `org-dir` and toolkit version from `cdf.toml` automatically. It uses `environment.project` from each `config.<env>.yaml` as the CDF project name and validates that `environment.name` matches the expected environment.
 
 This writes `.github/workflows/` (`dry-run.yml`, `deploy-dev.yml`, `deploy-test.yml`, `deploy-prod.yml`) and `docs/FOUNDATION_CICD.md` (GitHub Environments and secrets).
 

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -3,9 +3,9 @@
 Generate GitHub Actions CI/CD for a Toolkit project using the Foundation Deployment Pack.
 
 Implements the branching model and workflows from sop-cdf-project-setup.md (Step 5):
-  - PR to dev or main → dry-run (lint, test, cdf build, cdf deploy --dry-run)
+  - PR to dev, and PR to main when config.test.yaml exists → dry-run
   - Push to dev → deploy to config.dev.yaml's environment.project
-  - Push to main → deploy to config.test.yaml's environment.project
+  - Push to main → deploy to config.test.yaml's environment.project when present
   - Release published from main → deploy to config.prod.yaml's environment.project
 
 Run from the Toolkit project root after `cdf modules add -d dp:foundation`:
@@ -31,6 +31,7 @@ except ImportError:
 MODULE_DIR = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = MODULE_DIR / "templates" / "github"
 ENVIRONMENTS = ("dev", "test", "prod")
+REQUIRED_ENVIRONMENTS = ("dev", "prod")
 CONFIG_FLAG_MIN_VERSION = (0, 8, 0)
 
 
@@ -102,6 +103,12 @@ def write_file(path: Path, content: str, force: bool) -> None:
     print(f"Wrote {path}")
 
 
+def remove_file(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+        print(f"Removed {path}")
+
+
 def build_lint_paths(org_dir: str | None) -> str:
     """Return git pathspecs for generated workflow linting.
 
@@ -152,9 +159,11 @@ def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str,
     for env in ENVIRONMENTS:
         path = config_path(repo_root, org_dir, env)
         if not path.is_file():
-            raise FileNotFoundError(
-                f"Missing {path.relative_to(repo_root)}. Run setup_project.py before generating workflows."
-            )
+            if env in REQUIRED_ENVIRONMENTS:
+                raise FileNotFoundError(
+                    f"Missing {path.relative_to(repo_root)}. Run setup_project.py before generating workflows."
+                )
+            continue
 
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         environment = data.get("environment") or {}
@@ -168,6 +177,75 @@ def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str,
             raise ValueError(f"{path.relative_to(repo_root)} is missing environment.project.")
         projects[env] = str(project)
     return projects
+
+
+def workflow_file_list(include_test: bool) -> str:
+    files = [
+        '".github/workflows/dry-run.yml"',
+        '".github/workflows/deploy-dev.yml"',
+    ]
+    if include_test:
+        files.append('".github/workflows/deploy-test.yml"')
+    files.append('".github/workflows/deploy-prod.yml"')
+    return "\n".join(f"              {path}," for path in files)
+
+
+def pr_branches(include_test: bool) -> str:
+    branches = ["dev"]
+    if include_test:
+        branches.append("main")
+    return "\n".join(f"      - {branch}" for branch in branches)
+
+
+def dry_run_environment(include_test: bool) -> str:
+    if include_test:
+        return "${{ github.base_ref == 'dev' && 'dev-toolkit-credentials' || 'test-toolkit-credentials' }}"
+    return "dev-toolkit-credentials"
+
+
+def dry_run_build_script(toolkit_version: str, org_dir: str | None, include_test: bool) -> str:
+    dev_build = f"cdf build {build_args(toolkit_version, org_dir, 'dev')} | tee build-output.txt"
+    if not include_test:
+        return dev_build
+    test_build = f"cdf build {build_args(toolkit_version, org_dir, 'test')} | tee build-output.txt"
+    return "\n".join(
+        [
+            'if [ "${{ github.base_ref }}" = "dev" ]; then',
+            f"  {dev_build}",
+            "else",
+            f"  {test_build}",
+            "fi",
+        ]
+    )
+
+
+def indent(text: str, spaces: int) -> str:
+    prefix = " " * spaces
+    return "\n".join(f"{prefix}{line}" if line else line for line in text.splitlines())
+
+
+def test_branching_rows(projects: dict[str, str]) -> str:
+    if "test" not in projects:
+        return ""
+    return "\n".join(
+        [
+            f"| PR → `main` | `{projects['test']}` | Dry-run |",
+            f"| Push to `main` | `{projects['test']}` | Deploy |",
+        ]
+    )
+
+
+def test_environment_row(projects: dict[str, str]) -> str:
+    if "test" not in projects:
+        return ""
+    return f"| `test-toolkit-credentials` | PR → main, push `main` | `{projects['test']}` |"
+
+
+def env_config_list(projects: dict[str, str]) -> str:
+    configs = [f"`config.{env}.yaml`" for env in ENVIRONMENTS if env in projects]
+    if len(configs) == 1:
+        return configs[0]
+    return ", ".join(configs[:-1]) + f", or {configs[-1]}"
 
 
 def main() -> None:
@@ -187,20 +265,33 @@ def main() -> None:
     cdf = load_cdf_toml(repo_root)
     org_dir: str | None = args.org_dir or cdf.get("cdf", {}).get("default_organization_dir") or None
     projects = load_environment_projects(repo_root, org_dir)
+    include_test = "test" in projects
 
     toolkit_version = cdf.get("modules", {}).get("version", "0.7.220")
     resolve_modules_root(repo_root, org_dir)
 
     base_values: dict[str, str] = {
         "DEV_PROJECT": projects["dev"],
-        "TEST_PROJECT": projects["test"],
         "PROD_PROJECT": projects["prod"],
         "DEV_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "dev"),
-        "TEST_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "test"),
         "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
+        "WORKFLOW_FILES": workflow_file_list(include_test),
+        "PR_BRANCHES": pr_branches(include_test),
+        "DRY_RUN_ENVIRONMENT": dry_run_environment(include_test),
+        "DRY_RUN_BUILD_SCRIPT": indent(dry_run_build_script(str(toolkit_version), org_dir, include_test), 10),
+        "TEST_BRANCHING_ROWS": test_branching_rows(projects),
+        "TEST_ENVIRONMENT_ROW": test_environment_row(projects),
+        "ENV_CONFIG_LIST": env_config_list(projects),
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
     }
+    if include_test:
+        base_values.update(
+            {
+                "TEST_PROJECT": projects["test"],
+                "TEST_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "test"),
+            }
+        )
 
     for name in ("dry-run.yml", "deploy-prod.yml"):
         template = TEMPLATES_DIR / name
@@ -214,10 +305,12 @@ def main() -> None:
     if not deploy_template.is_file():
         print(f"Missing template: {deploy_template}", file=sys.stderr)
         sys.exit(1)
-    for env, branch, label in (
-        ("dev", "dev", "Dev"),
-        ("test", "main", "Test"),
-    ):
+    deploy_envs = [("dev", "dev", "Dev")]
+    if include_test:
+        deploy_envs.append(("test", "main", "Test"))
+    else:
+        remove_file(repo_root / ".github" / "workflows" / "deploy-test.yml")
+    for env, branch, label in deploy_envs:
         merged = {
             **base_values,
             "ENV": env,
@@ -237,10 +330,14 @@ def main() -> None:
     )
 
     print()
+    environments = ["dev-toolkit-credentials"]
+    if include_test:
+        environments.append("test-toolkit-credentials")
+    environments.append("prod-toolkit-credentials")
     print("Next steps:")
-    print("  1. Create GitHub Environments: dev-toolkit-credentials, test-toolkit-credentials,")
-    print("     prod-toolkit-credentials (see docs/FOUNDATION_CICD.md)")
-    print("  2. Create branches dev and main; protect them")
+    print(f"  1. Create GitHub Environments: {', '.join(environments)}")
+    print("     (see docs/FOUNDATION_CICD.md)")
+    print("  2. Create and protect the branches used by the generated workflows")
     print("  3. Open a PR to dev to validate dry-run.yml")
 
 

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -31,6 +31,7 @@ except ImportError:
 MODULE_DIR = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = MODULE_DIR / "templates" / "github"
 ENVIRONMENTS = ("dev", "test", "prod")
+CONFIG_FLAG_MIN_VERSION = (0, 8, 0)
 
 
 def resolve_modules_root(repo_root: Path, org_dir: str | None) -> Path:
@@ -120,6 +121,26 @@ def build_lint_paths(org_dir: str | None) -> str:
     return " \\\n            ".join(entries)
 
 
+def parse_version(version: str) -> tuple[int, int, int]:
+    parts = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if not parts:
+        return (0, 0, 0)
+    return tuple(int(part) for part in parts.groups())
+
+
+def config_arg(org_dir: str | None, env: str) -> str:
+    config = f"config.{env}.yaml"
+    if org_dir:
+        config = f"{org_dir}/{config}"
+    return f"-c {config}"
+
+
+def build_args(toolkit_version: str, org_dir: str | None, env: str) -> str:
+    if parse_version(toolkit_version) >= CONFIG_FLAG_MIN_VERSION:
+        return config_arg(org_dir, env)
+    return f"--env {env}"
+
+
 def config_path(repo_root: Path, org_dir: str | None, env: str) -> Path:
     base = repo_root / org_dir if org_dir else repo_root
     return base / f"config.{env}.yaml"
@@ -174,6 +195,9 @@ def main() -> None:
         "DEV_PROJECT": projects["dev"],
         "TEST_PROJECT": projects["test"],
         "PROD_PROJECT": projects["prod"],
+        "DEV_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "dev"),
+        "TEST_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "test"),
+        "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
     }
@@ -200,6 +224,7 @@ def main() -> None:
             "BRANCH": branch,
             "ENV_LABEL": label,
             "PROJECT": projects[env],
+            "BUILD_ARGS": build_args(str(toolkit_version), org_dir, env),
         }
         out = repo_root / ".github" / "workflows" / f"deploy-{env}.yml"
         write_file(out, render_template(deploy_template, merged), args.force)

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -4,9 +4,9 @@ Generate GitHub Actions CI/CD for a Toolkit project using the Foundation Deploym
 
 Implements the branching model and workflows from sop-cdf-project-setup.md (Step 5):
   - PR to dev or main → dry-run (lint, test, cdf build, cdf deploy --dry-run)
-  - Push to dev → deploy to {enterprise}-dev
-  - Push to main → deploy to {enterprise}-test
-  - Release published from main → deploy to {enterprise}-prod
+  - Push to dev → deploy to config.dev.yaml's environment.project
+  - Push to main → deploy to config.test.yaml's environment.project
+  - Release published from main → deploy to config.prod.yaml's environment.project
 
 Run from the Toolkit project root after `cdf modules add -d dp:foundation`:
 
@@ -21,6 +21,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 try:
     import tomllib
 except ImportError:
@@ -28,6 +30,7 @@ except ImportError:
 
 MODULE_DIR = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = MODULE_DIR / "templates" / "github"
+ENVIRONMENTS = ("dev", "test", "prod")
 
 
 def resolve_modules_root(repo_root: Path, org_dir: str | None) -> Path:
@@ -117,32 +120,37 @@ def build_lint_paths(org_dir: str | None) -> str:
     return " \\\n            ".join(entries)
 
 
-def resolve_enterprise(args_enterprise: str | None, cdf: dict[str, Any]) -> str:
-    if args_enterprise:
-        return args_enterprise
-    from_toml = cdf.get("cdf", {}).get("enterprise", "")
-    if from_toml:
-        return from_toml
-    try:
-        value = input("Enterprise slug (e.g. 'acme' for acme-dev/test/prod): ").strip()
-    except EOFError:
-        value = ""
-    if not value:
-        print(
-            "Enterprise slug is required. Pass --enterprise or set cdf.enterprise in cdf.toml.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    return value
+def config_path(repo_root: Path, org_dir: str | None, env: str) -> Path:
+    base = repo_root / org_dir if org_dir else repo_root
+    return base / f"config.{env}.yaml"
+
+
+def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str, str]:
+    """Read CDF project names from config.<env>.yaml files."""
+    projects: dict[str, str] = {}
+    for env in ENVIRONMENTS:
+        path = config_path(repo_root, org_dir, env)
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"Missing {path.relative_to(repo_root)}. Run setup_project.py before generating workflows."
+            )
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        environment = data.get("environment") or {}
+        name = environment.get("name")
+        project = environment.get("project")
+        if name != env:
+            raise ValueError(
+                f"{path.relative_to(repo_root)} has environment.name={name!r}; expected {env!r}."
+            )
+        if not project:
+            raise ValueError(f"{path.relative_to(repo_root)} is missing environment.project.")
+        projects[env] = str(project)
+    return projects
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--enterprise",
-        help="Enterprise slug for CDF projects ({enterprise}-dev|test|prod); "
-        "defaults to cdf.enterprise in cdf.toml",
-    )
     parser.add_argument(
         "--org-dir",
         help="Organization directory (default: cdf.toml default_organization_dir)",
@@ -157,13 +165,15 @@ def main() -> None:
     repo_root = find_repo_root(Path.cwd())
     cdf = load_cdf_toml(repo_root)
     org_dir: str | None = args.org_dir or cdf.get("cdf", {}).get("default_organization_dir") or None
-    enterprise = resolve_enterprise(args.enterprise, cdf)
+    projects = load_environment_projects(repo_root, org_dir)
 
     toolkit_version = cdf.get("modules", {}).get("version", "0.7.220")
     resolve_modules_root(repo_root, org_dir)
 
     base_values: dict[str, str] = {
-        "ENTERPRISE": enterprise,
+        "DEV_PROJECT": projects["dev"],
+        "TEST_PROJECT": projects["test"],
+        "PROD_PROJECT": projects["prod"],
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
     }
@@ -184,7 +194,13 @@ def main() -> None:
         ("dev", "dev", "Dev"),
         ("test", "main", "Test"),
     ):
-        merged = {**base_values, "ENV": env, "BRANCH": branch, "ENV_LABEL": label}
+        merged = {
+            **base_values,
+            "ENV": env,
+            "BRANCH": branch,
+            "ENV_LABEL": label,
+            "PROJECT": projects[env],
+        }
         out = repo_root / ".github" / "workflows" / f"deploy-{env}.yml"
         write_file(out, render_template(deploy_template, merged), args.force)
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -646,28 +646,9 @@ def _prompt_source_system_ownership(
     return integration_owners, data_owners
 
 
-def _derive_enterprise(project_names: dict[str, str]) -> str | None:
-    """Try to derive the enterprise slug from project names like ``acme-dev`` → ``acme``."""
-    candidates: set[str] = set()
-    for env, name in project_names.items():
-        suffix = f"-{env}"
-        if name.endswith(suffix):
-            candidates.add(name[: -len(suffix)])
-    return candidates.pop() if len(candidates) == 1 else None
-
-
-def _run_cicd_wizard(pack_root: Path, project_names: dict[str, str] | None = None) -> None:
+def _run_cicd_wizard(pack_root: Path) -> None:
     _section("CI/CD Pipeline Generation")
     if not prompt_yes_no("Generate GitHub Actions workflows for this project?", default=False):
-        return
-
-    derived = _derive_enterprise(project_names or {})
-    enterprise = prompt(
-        "Enterprise slug (e.g. acme for acme-dev / acme-prod)",
-        default=derived,
-    ).strip()
-    if not enterprise:
-        _warn("No enterprise slug provided — skipping CI/CD generation.")
         return
 
     generate_script = Path(__file__).parent / "generate_actions.py"
@@ -675,7 +656,7 @@ def _run_cicd_wizard(pack_root: Path, project_names: dict[str, str] | None = Non
         _warn(f"Could not find generate_actions.py at {generate_script} — skipping.")
         return
 
-    cmd = [sys.executable, str(generate_script), "--enterprise", enterprise, "--force"]
+    cmd = [sys.executable, str(generate_script), "--force"]
     from _style import _C
     print(f"\n  {_C.DIM}Running: {' '.join(cmd)}{_C.RESET}")
     result = subprocess.run(cmd, cwd=str(REPO_ROOT))
@@ -863,7 +844,7 @@ def _run_wizard(
     patched = patch_cfihos_auth_for_missing_search(repo_root)
 
     # ── CI/CD generation ──────────────────────────────────────────────────────
-    _run_cicd_wizard(pack_root, project_names)
+    _run_cicd_wizard(pack_root)
 
     # ── Summary ───────────────────────────────────────────────────────────────
     _section("Done")

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -51,7 +51,7 @@ files together with the workflows:
 
 ```bash
 python modules/common/cdf_project_foundation/scripts/setup_project.py
-cdf build --env dev
+cdf build {{DEV_BUILD_ARGS}}
 ```
 
 CI validates the committed configs as-is; it does not regenerate them.

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -55,6 +55,8 @@ cdf build --env dev
 ```
 
 CI validates the committed configs as-is; it does not regenerate them.
+If the repository does not have a root `.pre-commit-config.yaml`, the generated
+PR workflow skips the pre-commit config lint step.
 
 ## Regenerate workflows
 

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -1,6 +1,6 @@
 # Foundation Deployment Pack — CI/CD setup
 
-Generated for enterprise **`{{ENTERPRISE}}`**.
+Generated from committed Toolkit environment configs.
 
 This follows [sop-cdf-project-setup.md](https://github.com/cognitedata/library/blob/main/sop-cdf-project-setup.md) Step 5.
 
@@ -8,11 +8,11 @@ This follows [sop-cdf-project-setup.md](https://github.com/cognitedata/library/b
 
 | Git branch / event | CDF project | Trigger |
 |--------------------|-------------|---------|
-| PR → `dev` | `{{ENTERPRISE}}-dev` | Dry-run (`cdf build`, `cdf deploy --dry-run`) |
-| PR → `main` | `{{ENTERPRISE}}-test` | Dry-run |
-| Push to `dev` | `{{ENTERPRISE}}-dev` | Deploy |
-| Push to `main` | `{{ENTERPRISE}}-test` | Deploy |
-| GitHub Release (tag `vX.Y.Z` from `main`) | `{{ENTERPRISE}}-prod` | Deploy |
+| PR → `dev` | `{{DEV_PROJECT}}` | Dry-run (`cdf build`, `cdf deploy --dry-run`) |
+| PR → `main` | `{{TEST_PROJECT}}` | Dry-run |
+| Push to `dev` | `{{DEV_PROJECT}}` | Deploy |
+| Push to `main` | `{{TEST_PROJECT}}` | Deploy |
+| GitHub Release (tag `vX.Y.Z` from `main`) | `{{PROD_PROJECT}}` | Deploy |
 
 PRs to `main` must come from `dev` or `hotfix/*` only.
 
@@ -22,9 +22,9 @@ Create three environments under **Settings → Environments**:
 
 | Environment | Used by | `CDF_PROJECT` example |
 |-------------|---------|-------------------------|
-| `dev-toolkit-credentials` | PR → dev, push `dev` | `{{ENTERPRISE}}-dev` |
-| `test-toolkit-credentials` | PR → main, push `main` | `{{ENTERPRISE}}-test` |
-| `prod-toolkit-credentials` | Release published | `{{ENTERPRISE}}-prod` |
+| `dev-toolkit-credentials` | PR → dev, push `dev` | `{{DEV_PROJECT}}` |
+| `test-toolkit-credentials` | PR → main, push `main` | `{{TEST_PROJECT}}` |
+| `prod-toolkit-credentials` | Release published | `{{PROD_PROJECT}}` |
 
 Each environment needs these **variables**:
 

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -33,6 +33,9 @@ Each environment needs these **variables**:
 - `LOGIN_FLOW` (typically `client_credentials`)
 - `IDP_TENANT_ID`
 - `IDP_CLIENT_ID`
+- `ADMIN_SOURCE_ID`
+- `CONSUMER_SOURCE_ID`
+- `PRODUCER_SOURCE_ID`
 
 And this **secret**:
 

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -9,12 +9,11 @@ This follows [sop-cdf-project-setup.md](https://github.com/cognitedata/library/b
 | Git branch / event | CDF project | Trigger |
 |--------------------|-------------|---------|
 | PR → `dev` | `{{DEV_PROJECT}}` | Dry-run (`cdf build`, `cdf deploy --dry-run`) |
-| PR → `main` | `{{TEST_PROJECT}}` | Dry-run |
 | Push to `dev` | `{{DEV_PROJECT}}` | Deploy |
-| Push to `main` | `{{TEST_PROJECT}}` | Deploy |
+{{TEST_BRANCHING_ROWS}}
 | GitHub Release (tag `vX.Y.Z` from `main`) | `{{PROD_PROJECT}}` | Deploy |
 
-PRs to `main` must come from `dev` or `hotfix/*` only.
+If the test environment is present, PRs to `main` must come from `dev` or `hotfix/*` only.
 
 ## GitHub Environments
 
@@ -23,7 +22,7 @@ Create three environments under **Settings → Environments**:
 | Environment | Used by | `CDF_PROJECT` example |
 |-------------|---------|-------------------------|
 | `dev-toolkit-credentials` | PR → dev, push `dev` | `{{DEV_PROJECT}}` |
-| `test-toolkit-credentials` | PR → main, push `main` | `{{TEST_PROJECT}}` |
+{{TEST_ENVIRONMENT_ROW}}
 | `prod-toolkit-credentials` | Release published | `{{PROD_PROJECT}}` |
 
 Each environment needs these **variables**:
@@ -44,7 +43,7 @@ And this **secret**:
 ## Toolkit configs
 
 This generator only writes GitHub Actions workflows and this guide. It does not
-create or refresh `config.dev.yaml`, `config.test.yaml`, or `config.prod.yaml`.
+create or refresh {{ENV_CONFIG_LIST}}.
 
 Before opening a PR, run the project setup wizard and commit the resulting config
 files together with the workflows:

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -46,7 +46,7 @@ jobs:
         run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
 
       - name: cdf build
-        run: cdf build --env prod
+        run: cdf build {{PROD_BUILD_ARGS}}
 
       - name: cdf deploy
-        run: cdf deploy --env prod
+        run: cdf deploy

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy to {{ENTERPRISE}}-prod
+    name: Deploy to {{PROD_PROJECT}}
     runs-on: ubuntu-latest
     environment: prod-toolkit-credentials
     env:

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -19,6 +19,9 @@ jobs:
       LOGIN_FLOW: ${{ vars.LOGIN_FLOW }}
       IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
       IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
+      ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}
+      CONSUMER_SOURCE_ID: ${{ vars.CONSUMER_SOURCE_ID }}
+      PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}
       IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
     steps:
       - name: Reject releases not created from main

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
 
       - name: cdf build
-        run: cdf build --env {{ENV}}
+        run: cdf build {{BUILD_ARGS}}
 
       - name: cdf deploy
-        run: cdf deploy --env {{ENV}}
+        run: cdf deploy

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy to {{ENTERPRISE}}-{{ENV}}
+    name: Deploy to {{PROJECT}}
     runs-on: ubuntu-latest
     environment: {{ENV}}-toolkit-credentials
     env:

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -23,6 +23,9 @@ jobs:
       LOGIN_FLOW: ${{ vars.LOGIN_FLOW }}
       IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
       IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
+      ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}
+      CONSUMER_SOURCE_ID: ${{ vars.CONSUMER_SOURCE_ID }}
+      PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}
       IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v4

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -87,6 +87,9 @@ jobs:
       LOGIN_FLOW: ${{ vars.LOGIN_FLOW }}
       IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
       IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
+      ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}
+      CONSUMER_SOURCE_ID: ${{ vars.CONSUMER_SOURCE_ID }}
+      PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}
       IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
     steps:
       - uses: actions/checkout@v4

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -3,8 +3,7 @@ name: Toolkit PR Validate
 on:
   pull_request:
     branches:
-      - dev
-      - main
+{{PR_BRANCHES}}
 
 concurrency:
   group: toolkit-pr-${{ github.head_ref }}-${{ github.base_ref }}
@@ -51,10 +50,7 @@ jobs:
           import yaml
 
           for path in (
-              ".github/workflows/dry-run.yml",
-              ".github/workflows/deploy-dev.yml",
-              ".github/workflows/deploy-test.yml",
-              ".github/workflows/deploy-prod.yml",
+{{WORKFLOW_FILES}}
           ):
               yaml.safe_load(Path(path).read_text())
               print(f"valid yaml: {path}")
@@ -85,7 +81,7 @@ jobs:
       needs.lint.result == 'success' &&
       (github.base_ref == 'dev' || needs.source-branch-guard.result == 'success')
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref == 'dev' && 'dev-toolkit-credentials' || 'test-toolkit-credentials' }}
+    environment: {{DRY_RUN_ENVIRONMENT}}
     env:
       CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
       CDF_PROJECT: ${{ vars.CDF_PROJECT }}
@@ -112,11 +108,7 @@ jobs:
       - name: cdf build
         id: build
         run: |
-          if [ "${{ github.base_ref }}" = "dev" ]; then
-            cdf build {{DEV_BUILD_ARGS}} | tee build-output.txt
-          else
-            cdf build {{TEST_BUILD_ARGS}} | tee build-output.txt
-          fi
+{{DRY_RUN_BUILD_SCRIPT}}
 
       - name: cdf deploy --dry-run
         id: deploy

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -112,14 +112,15 @@ jobs:
       - name: cdf build
         id: build
         run: |
-          ENV="${{ github.base_ref == 'dev' && 'dev' || 'test' }}"
-          cdf build --env "${ENV}" | tee build-output.txt
+          if [ "${{ github.base_ref }}" = "dev" ]; then
+            cdf build {{DEV_BUILD_ARGS}} | tee build-output.txt
+          else
+            cdf build {{TEST_BUILD_ARGS}} | tee build-output.txt
+          fi
 
       - name: cdf deploy --dry-run
         id: deploy
-        run: |
-          ENV="${{ github.base_ref == 'dev' && 'dev' || 'test' }}"
-          cdf deploy --dry-run --env "${ENV}" | tee dryrun-output.txt
+        run: cdf deploy --dry-run | tee dryrun-output.txt
 
       - name: Comment PR with dry-run output
         if: always() && github.event_name == 'pull_request' && (steps.build.outcome == 'success' || steps.build.outcome == 'failure')

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -64,6 +64,11 @@ jobs:
         env:
           SKIP: check-yaml,end-of-file-fixer,trailing-whitespace
         run: |
+          if [ ! -f .pre-commit-config.yaml ]; then
+            echo "No .pre-commit-config.yaml found; skipping pre-commit config lint."
+            exit 0
+          fi
+
           mapfile -t FILES < <(git ls-files \
             {{LINT_PATHS}})
           if [ "${#FILES[@]}" -gt 0 ]; then

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -81,11 +81,17 @@ environment:
         encoding="utf-8"
     )
     assert "name: Deploy to acme-dev" in deploy_dev
+    assert "ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}" in deploy_dev
+    assert "CONSUMER_SOURCE_ID: ${{ vars.CONSUMER_SOURCE_ID }}" in deploy_dev
+    assert "PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}" in deploy_dev
 
     cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
     assert "`acme-dev`" in cicd_docs
     assert "`acme-test`" in cicd_docs
     assert "`acme-prod`" in cicd_docs
+    assert "`ADMIN_SOURCE_ID`" in cicd_docs
+    assert "`CONSUMER_SOURCE_ID`" in cicd_docs
+    assert "`PRODUCER_SOURCE_ID`" in cicd_docs
 
 
 def test_generate_actions_validates_environment_name(tmp_path: Path) -> None:

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -45,13 +45,20 @@ version = "0.7.220"
         encoding="utf-8",
     )
     (mod / "default.config.yaml").write_text("location: site1\n", encoding="utf-8")
+    for env in ("dev", "test", "prod"):
+        (tmp_path / org_dir / f"config.{env}.yaml").write_text(
+            f"""
+environment:
+  name: {env}
+  project: acme-{env}
+""".lstrip(),
+            encoding="utf-8",
+        )
 
     subprocess.run(
         [
             sys.executable,
             str(GENERATE_ACTIONS),
-            "--enterprise",
-            "acme",
             "--force",
         ],
         check=True,
@@ -63,10 +70,60 @@ version = "0.7.220"
     assert (tmp_path / ".github" / "workflows" / "deploy-test.yml").is_file()
     assert (tmp_path / ".github" / "workflows" / "deploy-prod.yml").is_file()
     assert (tmp_path / "docs" / "FOUNDATION_CICD.md").is_file()
-    assert not (tmp_path / org_dir / "config.dev.yaml").exists()
 
     dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(
         encoding="utf-8"
     )
     assert "'industrial/config*.yaml'" in dry_run
     assert "'industrial/modules/sourcesystem/cdf_pi_foundation/'" not in dry_run
+
+    deploy_dev = (tmp_path / ".github" / "workflows" / "deploy-dev.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "name: Deploy to acme-dev" in deploy_dev
+
+    cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    assert "`acme-dev`" in cicd_docs
+    assert "`acme-test`" in cicd_docs
+    assert "`acme-prod`" in cicd_docs
+
+
+def test_generate_actions_validates_environment_name(tmp_path: Path) -> None:
+    (tmp_path / "cdf.toml").write_text(
+        """
+[modules]
+version = "0.7.220"
+""".strip(),
+        encoding="utf-8",
+    )
+    modules = tmp_path / "modules" / "common" / "cdf_project_foundation"
+    modules.mkdir(parents=True)
+    (modules / "module.toml").write_text(
+        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+        encoding="utf-8",
+    )
+    for env in ("dev", "test", "prod"):
+        name = "prod" if env == "dev" else env
+        (tmp_path / f"config.{env}.yaml").write_text(
+            f"""
+environment:
+  name: {name}
+  project: acme-{env}
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(GENERATE_ACTIONS),
+            "--force",
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "environment.name='prod'; expected 'dev'" in result.stderr

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -77,11 +77,17 @@ environment:
     assert "'industrial/config*.yaml'" in dry_run
     assert "'industrial/modules/sourcesystem/cdf_pi_foundation/'" not in dry_run
     assert "No .pre-commit-config.yaml found; skipping pre-commit config lint." in dry_run
+    assert "cdf build --env dev" in dry_run
+    assert "cdf deploy --dry-run | tee dryrun-output.txt" in dry_run
+    assert "cdf deploy --dry-run --env" not in dry_run
 
     deploy_dev = (tmp_path / ".github" / "workflows" / "deploy-dev.yml").read_text(
         encoding="utf-8"
     )
     assert "name: Deploy to acme-dev" in deploy_dev
+    assert "run: cdf build --env dev" in deploy_dev
+    assert "run: cdf deploy" in deploy_dev
+    assert "cdf deploy --env" not in deploy_dev
     assert "ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}" in deploy_dev
     assert "CONSUMER_SOURCE_ID: ${{ vars.CONSUMER_SOURCE_ID }}" in deploy_dev
     assert "PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}" in deploy_dev
@@ -135,3 +141,56 @@ environment:
 
     assert result.returncode != 0
     assert "environment.name='prod'; expected 'dev'" in result.stderr
+
+
+def test_generate_actions_uses_config_flag_for_toolkit_0_8(tmp_path: Path) -> None:
+    org_dir = "industrial"
+    (tmp_path / "cdf.toml").write_text(
+        f"""
+[cdf]
+default_organization_dir = "{org_dir}"
+
+[modules]
+version = "0.8.0"
+""".strip(),
+        encoding="utf-8",
+    )
+    modules = tmp_path / org_dir / "modules" / "common" / "cdf_project_foundation"
+    modules.mkdir(parents=True)
+    (modules / "module.toml").write_text(
+        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+        encoding="utf-8",
+    )
+    for env in ("dev", "test", "prod"):
+        (tmp_path / org_dir / f"config.{env}.yaml").write_text(
+            f"""
+environment:
+  name: {env}
+  project: acme-{env}
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(GENERATE_ACTIONS),
+            "--force",
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "cdf build -c industrial/config.dev.yaml" in dry_run
+    assert "cdf build -c industrial/config.test.yaml" in dry_run
+    assert "cdf build --env" not in dry_run
+
+    deploy_prod = (tmp_path / ".github" / "workflows" / "deploy-prod.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "run: cdf build -c industrial/config.prod.yaml" in deploy_prod
+    assert "run: cdf deploy" in deploy_prod
+    assert "cdf deploy --env" not in deploy_prod

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -194,3 +194,66 @@ environment:
     assert "run: cdf build -c industrial/config.prod.yaml" in deploy_prod
     assert "run: cdf deploy" in deploy_prod
     assert "cdf deploy --env" not in deploy_prod
+
+
+def test_generate_actions_skips_test_workflow_when_test_config_missing(tmp_path: Path) -> None:
+    org_dir = "industrial"
+    (tmp_path / "cdf.toml").write_text(
+        f"""
+[cdf]
+default_organization_dir = "{org_dir}"
+
+[modules]
+version = "0.8.0"
+""".strip(),
+        encoding="utf-8",
+    )
+    modules = tmp_path / org_dir / "modules" / "common" / "cdf_project_foundation"
+    modules.mkdir(parents=True)
+    (modules / "module.toml").write_text(
+        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+        encoding="utf-8",
+    )
+    for env in ("dev", "prod"):
+        (tmp_path / org_dir / f"config.{env}.yaml").write_text(
+            f"""
+environment:
+  name: {env}
+  project: acme-{env}
+""".lstrip(),
+            encoding="utf-8",
+        )
+    stale_test_workflow = tmp_path / ".github" / "workflows" / "deploy-test.yml"
+    stale_test_workflow.parent.mkdir(parents=True)
+    stale_test_workflow.write_text("stale\n", encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(GENERATE_ACTIONS),
+            "--force",
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    assert (tmp_path / ".github" / "workflows" / "dry-run.yml").is_file()
+    assert (tmp_path / ".github" / "workflows" / "deploy-dev.yml").is_file()
+    assert not stale_test_workflow.exists()
+    assert (tmp_path / ".github" / "workflows" / "deploy-prod.yml").is_file()
+
+    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "      - dev" in dry_run
+    assert "      - main" not in dry_run
+    assert "deploy-test.yml" not in dry_run
+    assert "test-toolkit-credentials" not in dry_run
+    assert "config.test.yaml" not in dry_run
+    assert "cdf build -c industrial/config.dev.yaml" in dry_run
+
+    cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    assert "`acme-dev`" in cicd_docs
+    assert "`acme-prod`" in cicd_docs
+    assert "`acme-test`" not in cicd_docs
+    assert "config.test.yaml" not in cicd_docs

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -76,6 +76,7 @@ environment:
     )
     assert "'industrial/config*.yaml'" in dry_run
     assert "'industrial/modules/sourcesystem/cdf_pi_foundation/'" not in dry_run
+    assert "No .pre-commit-config.yaml found; skipping pre-commit config lint." in dry_run
 
     deploy_dev = (tmp_path / ".github" / "workflows" / "deploy-dev.yml").read_text(
         encoding="utf-8"
@@ -92,6 +93,7 @@ environment:
     assert "`ADMIN_SOURCE_ID`" in cicd_docs
     assert "`CONSUMER_SOURCE_ID`" in cicd_docs
     assert "`PRODUCER_SOURCE_ID`" in cicd_docs
+    assert "skips the pre-commit config lint step" in cicd_docs
 
 
 def test_generate_actions_validates_environment_name(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Use `environment.project` from committed config files instead of prompting for a separate enterprise slug.
- Add `ADMIN_SOURCE_ID`, `CONSUMER_SOURCE_ID`, and `PRODUCER_SOURCE_ID` to generated GitHub workflow environment variables.
- Skip pre-commit linting when `.pre-commit-config.yaml` is missing.
- Remove unsupported `--env` usage from `cdf deploy` commands.
- Use `cdf build -c <config path>` for Toolkit `>= 0.8.0`, including org-dir prefixes when configured.
- Skip test workflow generation when `config.test.yaml` is missing, supporting dev/prod-only projects.