### PR TITLE
[AT-42] - 🛠️ Foundation Setup Wizard — Improvements & Bug Fixes

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -270,3 +270,37 @@ adminSourceId: "${ADMIN_SOURCE_ID}"
 **Package**: `dp:foundation`
 
 Self-contained. The group ACLs reference `{{ dataset }}`, `{{ instanceSpace }}`, and `{{ schemaSpace }}`, which must match the values used by the deployed source-system and data-model modules.
+
+---
+
+## Running the Tests
+
+The test suite lives in `tests/test_foundation_setup_wizard.py` at the repo root and covers `_yaml_patch`, `_env_io`, and the core logic of `setup_project.py`.
+
+**Prerequisites** — a Python environment with `pytest` and `pyyaml`:
+
+```bash
+pip install pytest pyyaml
+```
+
+**Run all foundation wizard tests:**
+
+```bash
+# From the library repo root
+pytest tests/test_foundation_setup_wizard.py -v
+```
+
+**Run alongside the CI/CD generator tests:**
+
+```bash
+pytest tests/ -v
+```
+
+**Run a specific class or test:**
+
+```bash
+pytest tests/test_foundation_setup_wizard.py::TestYamlPatchSetValue -v
+pytest tests/test_foundation_setup_wizard.py::TestMigrateStagingToTest::test_renames_and_patches_file -v
+```
+
+> The tests use `tmp_path` fixtures for all file I/O — no project files are modified.

--- a/modules/common/cdf_project_foundation/scripts/_pack_config.py
+++ b/modules/common/cdf_project_foundation/scripts/_pack_config.py
@@ -8,7 +8,26 @@ import tomllib
 import yaml
 
 MODULE_ROOT = Path(__file__).parent.parent
-REPO_ROOT = MODULE_ROOT.parent.parent.parent  # scripts/ -> module/ -> common/ -> modules/ -> repo/
+
+
+def _resolve_repo_root() -> Path:
+    """Locate the Toolkit project root by searching up for ``cdf.toml``.
+
+    Handles both layouts:
+    - Flat   : ``<project>/modules/common/cdf_project_foundation/scripts/``
+    - Org-dir: ``<project>/<org>/modules/common/cdf_project_foundation/scripts/``
+
+    Falls back to four levels above this file when no ``cdf.toml`` is found
+    (e.g. the library development repo which has no ``cdf.toml``).
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "cdf.toml").is_file():
+            return parent
+    # Fallback: scripts/ → cdf_project_foundation/ → common/ → modules/ → repo/
+    return Path(__file__).resolve().parents[4]
+
+
+REPO_ROOT = _resolve_repo_root()
 
 KNOWN_DATA_MODEL_DIRS = (
     "isa_manufacturing_extension",
@@ -36,6 +55,12 @@ CONTEXTUALIZATION_REDUNDANT_AUTH: dict[str, tuple[str, ...]] = {
 # Maps module path (relative to modules/) → auth file(s) relative to the module root.
 TOOLS_REDUNDANT_AUTH: dict[str, tuple[str, ...]] = {
     "tools/apps/qualitizer": ("auth/apps.qualitizer.Group.yaml",),
+    # CFIHOS DM ships its own owner/read auth groups, which are redundant when
+    # cdf_project_foundation persona groups are deployed.
+    "data_models/cfihos_oil_and_gas_extension": (
+        "auth/gp_cdf_owner_cfihos_oil_gas_data_model.group.yaml",
+        "auth/gp_cdf_read_cfihos_oil_gas_data_model.group.yaml",
+    ),
 }
 
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -39,6 +39,7 @@ from _pack_config import (
     find_env_configs,
     get_contextualization_dir,
     get_data_models_dir,
+    get_org_dir_name,
     get_pack_root,
     list_installed_contextualization_modules,
     list_installed_source_system_modules,
@@ -58,7 +59,7 @@ ENVIRONMENTS: tuple[str, ...] = ("dev", "test", "prod")
 # Access-group environment suffix: "dev" covers both dev and test environments.
 GROUP_ENV: dict[str, str] = {"dev": "dev", "test": "dev", "prod": "prod"}
 
-ENVIRONMENT_VALIDATION_TYPE: dict[str, str] = {"dev": "dev", "test": "dev", "prod": "prod"}
+ENVIRONMENT_VALIDATION_TYPE: dict[str, str] = {"dev": "dev", "test": "prod", "prod": "prod"}
 
 PERSONAS: tuple[str, ...] = ("consumer", "producer", "admin")
 
@@ -158,11 +159,17 @@ _MODULE_CATEGORY_FALLBACK: dict[str, str] = {
 # present (foundation covers these capabilities; standalone modules added them
 # before foundation was installed).
 _STALE_CTX_KEYS: tuple[str, ...] = (
+    # Contextualization stale keys.
     "variables.modules.contextualization.cdf_file_annotation.groupSourceId",
     "variables.modules.contextualization.cdf_entity_matching"
     ".entity_matching_processing_group_source_id",
     "variables.modules.cdf_entity_matching.reservedWordPrefix",
     "variables.modules.contextualization.cdf_entity_matching.reservedWordPrefix",
+    # CFIHOS DM source IDs — covered by foundation persona groups.
+    "variables.modules.cfihos_oil_and_gas_extension.owner_source_id",
+    "variables.modules.cfihos_oil_and_gas_extension.read_source_id",
+    "variables.modules.data_models.cfihos_oil_and_gas_extension.owner_source_id",
+    "variables.modules.data_models.cfihos_oil_and_gas_extension.read_source_id",
 )
 
 # ── Domain helpers ─────────────────────────────────────────────────────────────
@@ -258,6 +265,9 @@ def build_overlay(
     integration_owners: dict[str, tuple[str, str]] | None = None,
     data_owners: dict[str, tuple[str, str]] | None = None,
     datasets: list[str] | None = None,
+    cfihos_admin_user: str = "",
+    cfihos_integration_owner_name: str = "",
+    cfihos_integration_owner_email: str = "",
     repo_root: Path | None = None,
 ) -> dict:
     """Full ``variables.modules`` overlay dict to merge into a config file.
@@ -294,7 +304,14 @@ def build_overlay(
     if variant == "cfihos_oil_and_gas_extension":
         # CFIHOS uses its own space / instance_space variables — not the ISA ones.
         # instance_space is derived from site; space is fixed.
-        modules_vars[variant] = {"instance_space": "inst_location", "environment": env}
+        cfihos_dm_vars: dict[str, Any] = {"instance_space": "inst_location", "environment": env}
+        if cfihos_admin_user:
+            cfihos_dm_vars["admin_user"] = cfihos_admin_user
+        if cfihos_integration_owner_name:
+            cfihos_dm_vars["integrationOwnerName"] = cfihos_integration_owner_name
+        if cfihos_integration_owner_email:
+            cfihos_dm_vars["integrationOwnerEmail"] = cfihos_integration_owner_email
+        modules_vars[variant] = cfihos_dm_vars
 
         # If the search solution module is also installed, keep its instance_space
         # in sync with the enterprise module.
@@ -467,6 +484,38 @@ def remove_redundant_auth_files(repo_root: Path | None = None) -> list[Path]:
     return removed
 
 
+# ── Staging → test migration ──────────────────────────────────────────────────
+
+def _migrate_staging_to_test(pack_root: Path) -> bool:
+    """Rename ``config.staging.yaml`` → ``config.test.yaml`` with corrected fields.
+
+    Toolkit creates a ``staging`` environment; the Foundation DP uses ``test``.
+    Updates ``environment.name`` to ``test`` and ``environment.validation-type``
+    to ``prod`` (staging is pre-prod and should use production-like validation).
+
+    Returns ``True`` if a migration was performed.
+    """
+    staging = pack_root / "config.staging.yaml"
+    test    = pack_root / "config.test.yaml"
+
+    if not staging.exists():
+        return False
+    if test.exists():
+        _warn(
+            "Both config.staging.yaml and config.test.yaml exist — "
+            "skipping automatic staging migration. Remove one manually."
+        )
+        return False
+
+    lines = staging.read_text().splitlines(keepends=True)
+    _yaml_set_value(lines, "environment.name", "test")
+    _yaml_set_value(lines, "environment.validation-type", "prod")
+    test.write_text("".join(lines))
+    staging.unlink()
+    _ok("Migrated config.staging.yaml → config.test.yaml  (validation-type: prod)")
+    return True
+
+
 # ── Data model auth patching ──────────────────────────────────────────────────
 
 def patch_cfihos_auth_for_missing_search(repo_root: Path | None = None) -> list[Path]:
@@ -522,6 +571,9 @@ def _read_existing_values(
         "app_owner": "",
         "integration_owners": {},
         "data_owners": {},
+        "cfihos_admin_user": "",
+        "cfihos_integration_owner_name": "",
+        "cfihos_integration_owner_email": "",
     }
     for env in envs:
         path = pack_root / f"config.{env}.yaml"
@@ -557,6 +609,19 @@ def _read_existing_values(
         )
         if app_owner and app_owner != "<APPLICATION_OWNER>":
             existing["app_owner"] = app_owner
+        # CFIHOS DM owner fields (flat or nested data_models category).
+        cfihos_dm = (
+            modules.get("cfihos_oil_and_gas_extension")
+            or modules.get("data_models", {}).get("cfihos_oil_and_gas_extension", {})
+            or {}
+        )
+        _placeholder_emails = {"admin.user@firm.com", "integration.owner@firm.com"}
+        if cfihos_dm.get("admin_user") and cfihos_dm["admin_user"] not in _placeholder_emails:
+            existing["cfihos_admin_user"] = cfihos_dm["admin_user"]
+        if cfihos_dm.get("integrationOwnerName") and cfihos_dm["integrationOwnerName"] != "Integration Owner":
+            existing["cfihos_integration_owner_name"] = cfihos_dm["integrationOwnerName"]
+        if cfihos_dm.get("integrationOwnerEmail") and cfihos_dm["integrationOwnerEmail"] not in _placeholder_emails:
+            existing["cfihos_integration_owner_email"] = cfihos_dm["integrationOwnerEmail"]
         # Support both flat and nested-category structures.
         ss = modules if not modules.get("sourcesystem") else modules.get("sourcesystem", {})
         for module in installed_ss:
@@ -646,24 +711,37 @@ def _prompt_source_system_ownership(
     return integration_owners, data_owners
 
 
-def _run_cicd_wizard(pack_root: Path) -> None:
+def _run_cicd_wizard(pack_root: Path) -> list[Path]:
+    """Run the CI/CD generation step.  Returns the list of files written (empty if skipped)."""
     _section("CI/CD Pipeline Generation")
     if not prompt_yes_no("Generate GitHub Actions workflows for this project?", default=False):
-        return
+        return []
 
     generate_script = Path(__file__).parent / "generate_actions.py"
     if not generate_script.exists():
         _warn(f"Could not find generate_actions.py at {generate_script} — skipping.")
-        return
+        return []
 
     cmd = [sys.executable, str(generate_script), "--force"]
     from _style import _C
     print(f"\n  {_C.DIM}Running: {' '.join(cmd)}{_C.RESET}")
-    result = subprocess.run(cmd, cwd=str(REPO_ROOT))
+    result = subprocess.run(cmd, cwd=str(REPO_ROOT), capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+
+    written: list[Path] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("Wrote "):
+            written.append(Path(line[6:].strip()))
+
     if result.returncode == 0:
         _ok("CI/CD workflows generated.  See docs/FOUNDATION_CICD.md for next steps.")
     else:
         _warn("CI/CD generation completed with warnings — review the output above.")
+        for line in result.stderr.splitlines():
+            _hint(f"  {line}")
+
+    return written
 
 
 # ── Main wizard ────────────────────────────────────────────────────────────────
@@ -682,6 +760,11 @@ def _run_wizard(
     _banner("Foundation Deployment Pack — Project Setup")
     _ok(f"Data model variant : {variant}")
     _ok(f"Pack root          : {pack_root}")
+    org_dir = get_org_dir_name()
+    if org_dir:
+        _ok(f"Organization dir   : {org_dir}  (from cdf.toml)")
+    else:
+        _hint("No organization directory set in cdf.toml — config files written to repo root.")
     if installed_ctx:
         _ok(f"Contextualization  : {', '.join(installed_ctx)}")
     else:
@@ -712,6 +795,9 @@ def _run_wizard(
         )
         if not selected_envs:
             raise SystemExit("No environments selected — nothing to do.")
+
+    # Migrate config.staging.yaml → config.test.yaml if needed.
+    _migrate_staging_to_test(pack_root)
 
     # Load existing values from config files to pre-fill prompts on re-runs.
     existing = _read_existing_values(pack_root, selected_envs, installed_ss)
@@ -762,11 +848,47 @@ def _run_wizard(
         existing_data=existing["data_owners"] or None,
     )
 
+    # ── CFIHOS DM owner config (only when CFIHOS variant is selected) ────────
+    cfihos_admin_user = ""
+    cfihos_integration_owner_name = ""
+    cfihos_integration_owner_email = ""
+    if variant == "cfihos_oil_and_gas_extension":
+        _section("CFIHOS Data Model — Owner Configuration")
+        _hint("Configures admin_user, integrationOwnerName, and integrationOwnerEmail")
+        _hint("in the cfihos_oil_and_gas_extension module. Leave blank to skip.")
+
+        while True:
+            cfihos_admin_user = prompt(
+                "Admin user email",
+                default=existing.get("cfihos_admin_user") or None,
+            ).strip()
+            if not cfihos_admin_user or re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", cfihos_admin_user):
+                break
+            _warn("Invalid email. Use format: name@domain.com")
+
+        cfihos_integration_owner_name = prompt(
+            "Integration owner name",
+            default=existing.get("cfihos_integration_owner_name") or None,
+        ).strip()
+
+        while True:
+            cfihos_integration_owner_email = prompt(
+                "Integration owner email",
+                default=existing.get("cfihos_integration_owner_email") or None,
+            ).strip()
+            if not cfihos_integration_owner_email or re.fullmatch(
+                r"[^@\s]+@[^@\s]+\.[^@\s]+", cfihos_integration_owner_email
+            ):
+                break
+            _warn("Invalid email. Use format: name@domain.com")
+
     # ── Group source IDs → .env ───────────────────────────────────────────────
     _section("Group Source IDs  (Entra ID object IDs)")
     _hint("Stored in .env and referenced as ${CONSUMER_SOURCE_ID} etc. in config.")
     _hint("Leave blank to skip — fill .env manually later.")
-    env_path = pack_root / ".env"
+    # .env always lives at repo root (same level as cdf.toml), regardless of
+    # whether an organization directory is configured.
+    env_path = (repo_root or REPO_ROOT) / ".env"
     env_lines, env_vals, env_key_idx = parse_env_file(env_path)
     original_env_vals = dict(env_vals)
 
@@ -820,6 +942,9 @@ def _run_wizard(
             variant, env, site, installed_ctx, app_owner,
             integration_owners, data_owners,
             datasets=existing["dataset"],
+            cfihos_admin_user=cfihos_admin_user,
+            cfihos_integration_owner_name=cfihos_integration_owner_name,
+            cfihos_integration_owner_email=cfihos_integration_owner_email,
             repo_root=repo_root,
         )
         if write_config(path, env, project_names[env], overlay):
@@ -844,7 +969,7 @@ def _run_wizard(
     patched = patch_cfihos_auth_for_missing_search(repo_root)
 
     # ── CI/CD generation ──────────────────────────────────────────────────────
-    _run_cicd_wizard(pack_root)
+    cicd_files = _run_cicd_wizard(pack_root)
 
     # ── Summary ───────────────────────────────────────────────────────────────
     _section("Done")
@@ -855,11 +980,21 @@ def _run_wizard(
         _ok(f"{len(patched)} cfihos auth file(s) patched (search_space removed).")
     if env_dirty:
         _ok(".env updated with group source IDs.")
+    if cicd_files:
+        _ok(f"{len(cicd_files)} CI/CD workflow file(s) generated.")
     print()
     _hint("Next steps:")
     _hint("  1. Verify group source IDs in .env match your Entra ID object IDs.")
     _hint("  2. Confirm environment.project names in each config.<env>.yaml file.")
-    _hint("  3. Add CI/CD secrets to GitHub Environments (IDP_CLIENT_SECRET).")
+    if cicd_files:
+        _hint("  3. Create GitHub Environments: dev-toolkit-credentials,")
+        _hint("     test-toolkit-credentials, prod-toolkit-credentials")
+        _hint("     (see docs/FOUNDATION_CICD.md for variable and secret details).")
+        _hint("  4. Add IDP_CLIENT_SECRET to each GitHub Environment.")
+        _hint("  5. Create and protect branches dev and main;")
+        _hint("     open a PR to dev to validate dry-run.yml.")
+    else:
+        _hint("  3. Add CI/CD secrets to GitHub Environments (IDP_CLIENT_SECRET).")
     print()
 
 

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -183,7 +183,7 @@ class TestYamlPatchInsertKey:
             "  existing: yes\n",
         ]
         insert_key(lines, "section", "newkey", "val")
-        new_line = next(l for l in lines if "newkey" in l)
+        new_line = next(line for line in lines if "newkey" in line)
         assert new_line.startswith("  ")  # same indentation as siblings
 
 
@@ -253,7 +253,7 @@ class TestEnvIO:
         p.write_text("EXISTING=yes\n")
         lines, vals, idx = parse_env_file(p)
         upsert_env(lines, idx, "NEW_KEY", "secret123")
-        assert any("NEW_KEY=secret123" in l for l in lines)
+        assert any("NEW_KEY=secret123" in line for line in lines)
 
     def test_upsert_updates_existing_key(self, tmp_path: Path) -> None:
         from _env_io import parse_env_file, upsert_env
@@ -261,8 +261,8 @@ class TestEnvIO:
         p.write_text("FOO=old\n")
         lines, vals, idx = parse_env_file(p)
         upsert_env(lines, idx, "FOO", "new")
-        assert any("FOO=new" in l for l in lines)
-        assert not any("FOO=old" in l for l in lines)
+        assert any("FOO=new" in line for line in lines)
+        assert not any("FOO=old" in line for line in lines)
 
     def test_upsert_no_quotes(self, tmp_path: Path) -> None:
         from _env_io import parse_env_file, upsert_env
@@ -270,7 +270,7 @@ class TestEnvIO:
         p.write_text("")
         lines, vals, idx = parse_env_file(p)
         upsert_env(lines, idx, "ID", "abc-123")
-        entry = next(l for l in lines if "ID=" in l)
+        entry = next(line for line in lines if "ID=" in line)
         assert '"' not in entry
 
 

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -1,0 +1,883 @@
+"""Tests for the dp:foundation setup wizard and its helper modules.
+
+Covers:
+  - _yaml_patch  : find_line, get_value, set_value, insert_key, delete_key,
+                   block-sequence removal
+  - _env_io      : parse_env_file, upsert_env
+  - setup_project: group_name, build_foundation_vars, build_overlay,
+                   _migrate_staging_to_test, _write_config_fresh,
+                   _write_config_update, remove_redundant_auth_files,
+                   patch_cfihos_auth_for_missing_search, _read_existing_values
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+REPO_ROOT   = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "modules" / "common" / "cdf_project_foundation" / "scripts"
+
+# Make scripts importable without installing them.
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+# ── _yaml_patch ────────────────────────────────────────────────────────────────
+
+class TestYamlPatchFindLine:
+    def _lines(self, text: str) -> list[str]:
+        return textwrap.dedent(text).splitlines(keepends=True)
+
+    def test_finds_top_level_key(self) -> None:
+        from _yaml_patch import find_line
+        lines = self._lines("""\
+            site: oslo
+            dataset: ds_pi
+        """)
+        assert find_line(lines, "site") == 0
+        assert find_line(lines, "dataset") == 1
+
+    def test_finds_nested_key(self) -> None:
+        from _yaml_patch import find_line
+        lines = self._lines("""\
+            variables:
+              modules:
+                cdf_project_foundation:
+                  site: oslo
+        """)
+        assert find_line(lines, "variables.modules.cdf_project_foundation.site") == 3
+
+    def test_returns_none_for_missing_key(self) -> None:
+        from _yaml_patch import find_line
+        lines = self._lines("site: oslo\n")
+        assert find_line(lines, "missing") is None
+        assert find_line(lines, "site.nested") is None
+
+    def test_skips_comment_lines(self) -> None:
+        from _yaml_patch import find_line
+        lines = self._lines("""\
+            # comment
+            site: oslo
+        """)
+        assert find_line(lines, "site") == 1
+
+    def test_distinguishes_sibling_sections(self) -> None:
+        from _yaml_patch import find_line
+        lines = self._lines("""\
+            a:
+              x: 1
+            b:
+              x: 2
+        """)
+        assert find_line(lines, "a.x") == 1
+        assert find_line(lines, "b.x") == 3
+
+
+class TestYamlPatchGetValue:
+    def test_gets_scalar(self) -> None:
+        from _yaml_patch import get_value
+        lines = "site: oslo\n".splitlines(keepends=True)
+        assert get_value(lines, "site") == "oslo"
+
+    def test_strips_quotes(self) -> None:
+        from _yaml_patch import get_value
+        lines = 'site: "oslo"\n'.splitlines(keepends=True)
+        assert get_value(lines, "site") == "oslo"
+
+    def test_returns_none_for_missing(self) -> None:
+        from _yaml_patch import get_value
+        lines = "site: oslo\n".splitlines(keepends=True)
+        assert get_value(lines, "missing") is None
+
+    def test_ignores_inline_comment_in_value(self) -> None:
+        from _yaml_patch import get_value
+        lines = "site: oslo  # the site\n".splitlines(keepends=True)
+        assert get_value(lines, "site") == "oslo"
+
+
+class TestYamlPatchSetValue:
+    def test_updates_scalar(self) -> None:
+        from _yaml_patch import set_value
+        lines = ["site: oslo\n"]
+        old, changed = set_value(lines, "site", "berlin")
+        assert changed
+        assert "berlin" in lines[0]
+        assert old == "oslo"
+
+    def test_no_change_when_same_value(self) -> None:
+        from _yaml_patch import set_value
+        lines = ["site: oslo\n"]
+        _, changed = set_value(lines, "site", "oslo")
+        assert not changed
+
+    def test_preserves_trailing_comment(self) -> None:
+        from _yaml_patch import set_value
+        lines = ["site: oslo  # required\n"]
+        set_value(lines, "site", "berlin")
+        assert "# required" in lines[0]
+        assert "berlin" in lines[0]
+
+    def test_removes_block_sequence_items(self) -> None:
+        from _yaml_patch import set_value
+        lines = [
+            "dataset:\n",
+            "- ds_pi\n",
+            "- ds_sap\n",
+            "site: oslo\n",
+        ]
+        _, changed = set_value(lines, "dataset", "[ds_pi, ds_sap]")
+        assert changed
+        assert len(lines) == 2   # only dataset and site remain
+        assert "[ds_pi, ds_sap]" in lines[0]
+        assert "site" in lines[1]
+
+    def test_handles_empty_block_list(self) -> None:
+        from _yaml_patch import set_value
+        lines = ["dataset:\n", "- ds_pi\n"]
+        set_value(lines, "dataset", "[]")
+        assert len(lines) == 1
+        assert "[]" in lines[0]
+
+    def test_returns_none_for_missing_path(self) -> None:
+        from _yaml_patch import set_value
+        lines = ["site: oslo\n"]
+        old, changed = set_value(lines, "missing.key", "x")
+        assert old is None
+        assert not changed
+
+    def test_ensures_space_after_colon(self) -> None:
+        from _yaml_patch import set_value
+        # Key with no value (block list follows)
+        lines = ["dataset:\n", "- ds_pi\n"]
+        set_value(lines, "dataset", "[]")
+        assert lines[0] == "dataset: []\n"
+
+
+class TestYamlPatchInsertKey:
+    def test_inserts_into_existing_section(self) -> None:
+        from _yaml_patch import insert_key
+        lines = [
+            "variables:\n",
+            "  modules:\n",
+            "    cdf_project_foundation:\n",
+            "      site: oslo\n",
+        ]
+        result = insert_key(lines, "variables.modules.cdf_project_foundation", "newkey", "val")
+        assert result
+        content = "".join(lines)
+        assert "newkey: val" in content
+
+    def test_returns_false_for_missing_parent(self) -> None:
+        from _yaml_patch import insert_key
+        lines = ["site: oslo\n"]
+        assert not insert_key(lines, "missing.parent", "key", "val")
+
+    def test_inserted_line_uses_correct_indentation(self) -> None:
+        from _yaml_patch import insert_key
+        lines = [
+            "section:\n",
+            "  existing: yes\n",
+        ]
+        insert_key(lines, "section", "newkey", "val")
+        new_line = next(l for l in lines if "newkey" in l)
+        assert new_line.startswith("  ")  # same indentation as siblings
+
+
+class TestYamlPatchDeleteKey:
+    def test_deletes_scalar(self) -> None:
+        from _yaml_patch import delete_key
+        lines = ["site: oslo\n", "dataset: ds_pi\n"]
+        assert delete_key(lines, "site")
+        assert len(lines) == 1
+        assert "dataset" in lines[0]
+
+    def test_deletes_with_block_items(self) -> None:
+        from _yaml_patch import delete_key
+        lines = ["dataset:\n", "- ds_pi\n", "- ds_sap\n", "site: oslo\n"]
+        delete_key(lines, "dataset")
+        assert len(lines) == 1
+        assert "site" in lines[0]
+
+    def test_returns_false_for_missing_key(self) -> None:
+        from _yaml_patch import delete_key
+        lines = ["site: oslo\n"]
+        assert not delete_key(lines, "missing")
+
+
+# ── _env_io ────────────────────────────────────────────────────────────────────
+
+class TestEnvIO:
+    def test_parse_empty_file(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file
+        p = tmp_path / ".env"
+        p.write_text("")
+        lines, vals, idx = parse_env_file(p)
+        assert vals == {}
+
+    def test_parse_missing_file(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file
+        lines, vals, idx = parse_env_file(tmp_path / ".env")
+        assert lines == []
+        assert vals == {}
+
+    def test_parse_key_value_pairs(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file
+        p = tmp_path / ".env"
+        p.write_text('FOO=bar\nBAZ="qux"\n')
+        _, vals, _ = parse_env_file(p)
+        assert vals["FOO"] == "bar"
+        assert vals["BAZ"] == "qux"
+
+    def test_parse_skips_comments(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file
+        p = tmp_path / ".env"
+        p.write_text("# comment\nFOO=bar\n")
+        _, vals, _ = parse_env_file(p)
+        assert "# comment" not in vals
+        assert vals["FOO"] == "bar"
+
+    def test_parse_normalises_trailing_newline(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file
+        p = tmp_path / ".env"
+        p.write_text("FOO=bar")  # no trailing newline
+        lines, _, _ = parse_env_file(p)
+        assert lines[-1].endswith("\n")
+
+    def test_upsert_new_key(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file, upsert_env
+        p = tmp_path / ".env"
+        p.write_text("EXISTING=yes\n")
+        lines, vals, idx = parse_env_file(p)
+        upsert_env(lines, idx, "NEW_KEY", "secret123")
+        assert any("NEW_KEY=secret123" in l for l in lines)
+
+    def test_upsert_updates_existing_key(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file, upsert_env
+        p = tmp_path / ".env"
+        p.write_text("FOO=old\n")
+        lines, vals, idx = parse_env_file(p)
+        upsert_env(lines, idx, "FOO", "new")
+        assert any("FOO=new" in l for l in lines)
+        assert not any("FOO=old" in l for l in lines)
+
+    def test_upsert_no_quotes(self, tmp_path: Path) -> None:
+        from _env_io import parse_env_file, upsert_env
+        p = tmp_path / ".env"
+        p.write_text("")
+        lines, vals, idx = parse_env_file(p)
+        upsert_env(lines, idx, "ID", "abc-123")
+        entry = next(l for l in lines if "ID=" in l)
+        assert '"' not in entry
+
+
+# ── setup_project — domain helpers ────────────────────────────────────────────
+
+class TestGroupName:
+    def test_no_site(self) -> None:
+        from setup_project import group_name
+        assert group_name("consumer", "", "dev") == "consumer-dev"
+        assert group_name("admin", "", "prod") == "admin-prod"
+
+    def test_with_site(self) -> None:
+        from setup_project import group_name
+        assert group_name("producer", "oslo", "dev") == "producer-oslo-dev"
+        assert group_name("consumer", "oslo", "prod") == "consumer-oslo-prod"
+
+    def test_test_env_maps_to_dev_suffix(self) -> None:
+        from setup_project import group_name
+        # test env uses the same group as dev (GROUP_ENV["test"] == "dev")
+        assert group_name("consumer", "", "test") == "consumer-dev"
+
+    def test_test_env_with_site(self) -> None:
+        from setup_project import group_name
+        assert group_name("admin", "oslo", "test") == "admin-oslo-dev"
+
+
+class TestBuildFoundationVars:
+    def test_isa_variant_contains_required_keys(self) -> None:
+        from setup_project import build_foundation_vars
+        vars_ = build_foundation_vars("isa_manufacturing_extension", "dev", "oslo")
+        assert vars_["dataModelVariant"] == "isa_manufacturing_extension"
+        assert vars_["schemaSpace"] == "sp_isa_manufacturing"
+        assert vars_["site"] == "oslo"
+        assert vars_["consumerGroupName"] == "consumer-oslo-dev"
+        assert vars_["producerGroupName"] == "producer-oslo-dev"
+        assert vars_["adminGroupName"] == "admin-oslo-dev"
+        assert vars_["consumerSourceId"] == "${CONSUMER_SOURCE_ID}"
+
+    def test_dataset_always_present(self) -> None:
+        from setup_project import build_foundation_vars
+        assert build_foundation_vars("isa_manufacturing_extension", "dev", "")["dataset"] == []
+        assert build_foundation_vars("isa_manufacturing_extension", "dev", "", ["ds_pi"])["dataset"] == ["ds_pi"]
+
+    def test_cfihos_variant(self) -> None:
+        from setup_project import build_foundation_vars
+        vars_ = build_foundation_vars("cfihos_oil_and_gas_extension", "prod", "")
+        assert vars_["schemaSpace"] == "dm_dom_oil_and_gas"
+        assert vars_["instanceSpace"] == "inst_location"
+
+
+class TestBuildOverlay:
+    def test_isa_overlay_structure(self) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "", [])
+        mods = overlay["variables"]["modules"]
+        assert "cdf_project_foundation" in mods
+        assert "isa_manufacturing_extension" in mods
+        dm = mods["isa_manufacturing_extension"]
+        assert dm["isaSchemaSpace"] == "sp_isa_manufacturing"
+        assert dm["isaInstanceSpace"] == "sp_isa_instance_space"
+
+    def test_cfihos_overlay_has_no_isa_keys(self) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay("cfihos_oil_and_gas_extension", "dev", "", [])
+        mods = overlay["variables"]["modules"]
+        dm = mods["cfihos_oil_and_gas_extension"]
+        assert "isaSchemaSpace" not in dm
+        assert "isaInstanceSpace" not in dm
+        assert dm["instance_space"] == "inst_location"
+        assert dm["environment"] == "dev"
+
+    def test_cfihos_search_module_added_when_present(self, tmp_path: Path) -> None:
+        from setup_project import build_overlay
+        # Simulate search module being installed
+        search_dir = tmp_path / "modules" / "data_models" / "cfihos_oil_and_gas_extension_search"
+        search_dir.mkdir(parents=True)
+        overlay = build_overlay(
+            "cfihos_oil_and_gas_extension", "dev", "", [], repo_root=tmp_path
+        )
+        mods = overlay["variables"]["modules"]
+        assert "cfihos_oil_and_gas_extension_search" in mods
+        assert mods["cfihos_oil_and_gas_extension_search"]["instance_space"] == "inst_location"
+
+    def test_cfihos_search_module_absent_when_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay(
+            "cfihos_oil_and_gas_extension", "dev", "", [], repo_root=tmp_path
+        )
+        mods = overlay["variables"]["modules"]
+        assert "cfihos_oil_and_gas_extension_search" not in mods
+
+    def test_app_owner_injected_when_file_annotation_installed(self) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay(
+            "isa_manufacturing_extension", "dev", "", ["cdf_file_annotation"],
+            app_owner="owner@example.com"
+        )
+        fa = overlay["variables"]["modules"]["cdf_file_annotation"]
+        assert fa["ApplicationOwner"] == "owner@example.com"
+
+    def test_entity_matching_location_name_set_from_site(self) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay(
+            "isa_manufacturing_extension", "dev", "oslo", ["cdf_entity_matching"]
+        )
+        em = overlay["variables"]["modules"]["cdf_entity_matching"]
+        assert em["location_name"] == "oslo"
+
+    def test_no_contextualization_vars_when_not_installed(self) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "", [])
+        mods = overlay["variables"]["modules"]
+        assert "cdf_entity_matching" not in mods
+        assert "cdf_file_annotation" not in mods
+
+    def test_cfihos_owner_vars_injected(self) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay(
+            "cfihos_oil_and_gas_extension", "dev", "", [],
+            cfihos_admin_user="admin@firm.com",
+            cfihos_integration_owner_name="Alice",
+            cfihos_integration_owner_email="alice@firm.com",
+        )
+        dm = overlay["variables"]["modules"]["cfihos_oil_and_gas_extension"]
+        assert dm["admin_user"] == "admin@firm.com"
+        assert dm["integrationOwnerName"] == "Alice"
+        assert dm["integrationOwnerEmail"] == "alice@firm.com"
+
+
+# ── setup_project — config file writers ───────────────────────────────────────
+
+class TestWriteConfigFresh:
+    def test_creates_yaml_with_env_block(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_fresh, build_overlay
+        path = tmp_path / "config.dev.yaml"
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "", [])
+        _write_config_fresh(path, "dev", "acme-dev", overlay)
+        assert path.exists()
+        data = yaml.safe_load(path.read_text())
+        assert data["environment"]["project"] == "acme-dev"
+        assert data["environment"]["name"] == "dev"
+
+    def test_created_file_has_header_comment(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_fresh, build_overlay
+        path = tmp_path / "config.dev.yaml"
+        _write_config_fresh(path, "dev", "acme-dev",
+                            build_overlay("isa_manufacturing_extension", "dev", "", []))
+        assert "setup_project.py" in path.read_text()
+
+
+class TestWriteConfigUpdate:
+    def _make_config(self, tmp_path: Path, content: str) -> Path:
+        p = tmp_path / "config.dev.yaml"
+        p.write_text(textwrap.dedent(content))
+        return p
+
+    def test_updates_project_name(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_update, build_overlay
+        p = self._make_config(tmp_path, """\
+            environment:
+              name: dev
+              project: old-project
+              validation-type: dev
+              selected:
+              - modules
+            variables:
+              modules:
+                cdf_project_foundation:
+                  site: ''
+                  dataset: []
+                  consumerGroupName: consumer-dev
+                  producerGroupName: producer-dev
+                  adminGroupName: admin-dev
+                  consumerSourceId: ${CONSUMER_SOURCE_ID}
+                  producerSourceId: ${PRODUCER_SOURCE_ID}
+                  adminSourceId: ${ADMIN_SOURCE_ID}
+                  dataModelVariant: isa_manufacturing_extension
+                  schemaSpace: sp_isa_manufacturing
+                  instanceSpace: sp_isa_instance_space
+                isa_manufacturing_extension:
+                  isaSchemaSpace: sp_isa_manufacturing
+                  isaInstanceSpace: sp_isa_instance_space
+        """)
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "", [])
+        _write_config_update(p, "new-project", overlay)
+        data = yaml.safe_load(p.read_text())
+        assert data["environment"]["project"] == "new-project"
+
+    def test_preserves_comments(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_update, build_overlay
+        p = self._make_config(tmp_path, """\
+            # My custom header
+            environment:
+              name: dev
+              project: acme-dev
+              validation-type: dev
+              selected:
+              - modules
+            variables:
+              modules:
+                cdf_project_foundation:
+                  site: oslo  # keep this comment
+                  dataset: []
+                  consumerGroupName: consumer-dev
+                  producerGroupName: producer-dev
+                  adminGroupName: admin-dev
+                  consumerSourceId: ${CONSUMER_SOURCE_ID}
+                  producerSourceId: ${PRODUCER_SOURCE_ID}
+                  adminSourceId: ${ADMIN_SOURCE_ID}
+                  dataModelVariant: isa_manufacturing_extension
+                  schemaSpace: sp_isa_manufacturing
+                  instanceSpace: sp_isa_instance_space
+                isa_manufacturing_extension:
+                  isaSchemaSpace: sp_isa_manufacturing
+                  isaInstanceSpace: sp_isa_instance_space
+        """)
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "", [])
+        _write_config_update(p, "acme-dev", overlay)
+        content = p.read_text()
+        assert "# My custom header" in content
+        assert "# keep this comment" in content
+
+    def test_returns_false_when_nothing_changed(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_update, build_overlay
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "oslo", [])
+        # Build a config that already matches the overlay
+        merged = {
+            "environment": {"name": "dev", "project": "acme-dev",
+                            "validation-type": "dev", "selected": ["modules"]},
+            "variables": {"modules": overlay["variables"]["modules"]},
+        }
+        p = tmp_path / "config.dev.yaml"
+        p.write_text(yaml.dump(merged, sort_keys=False))
+        assert not _write_config_update(p, "acme-dev", overlay)
+
+    def test_removes_stale_groupsourceid(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_update, build_overlay
+        p = self._make_config(tmp_path, """\
+            environment:
+              project: acme-dev
+            variables:
+              modules:
+                contextualization:
+                  cdf_file_annotation:
+                    groupSourceId: old-id
+                    fileSchemaSpace: sp_isa_manufacturing
+        """)
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "", ["cdf_file_annotation"])
+        _write_config_update(p, "acme-dev", overlay)
+        content = p.read_text()
+        assert "groupSourceId" not in content
+
+    def test_removes_reserved_word_prefix(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_update, build_overlay
+        p = self._make_config(tmp_path, """\
+            environment:
+              project: acme-dev
+            variables:
+              modules:
+                cdf_entity_matching:
+                  reservedWordPrefix: Enterprise_
+                  schemaSpace: sp_isa_manufacturing
+        """)
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "", [])
+        _write_config_update(p, "acme-dev", overlay)
+        assert "reservedWordPrefix" not in p.read_text()
+
+    def test_updates_nested_category_structure(self, tmp_path: Path) -> None:
+        """Configs with old common.cdf_project_foundation nesting must be updated."""
+        from setup_project import _write_config_update, build_overlay
+        p = self._make_config(tmp_path, """\
+            environment:
+              project: old
+            variables:
+              modules:
+                common:
+                  cdf_project_foundation:
+                    site: berlin
+                    dataset: []
+        """)
+        overlay = build_overlay("isa_manufacturing_extension", "dev", "oslo", [])
+        _write_config_update(p, "old", overlay)
+        content = p.read_text()
+        assert "oslo" in content  # site updated in nested structure
+
+
+# ── setup_project — staging migration ─────────────────────────────────────────
+
+class TestMigrateStagingToTest:
+    def test_renames_and_patches_file(self, tmp_path: Path) -> None:
+        from setup_project import _migrate_staging_to_test
+        staging = tmp_path / "config.staging.yaml"
+        staging.write_text(
+            "environment:\n  name: staging\n  validation-type: dev\n  project: acme-staging\n"
+        )
+        result = _migrate_staging_to_test(tmp_path)
+        assert result
+        assert not staging.exists()
+        test = tmp_path / "config.test.yaml"
+        assert test.exists()
+        data = yaml.safe_load(test.read_text())
+        assert data["environment"]["name"] == "test"
+        assert data["environment"]["validation-type"] == "prod"
+        assert data["environment"]["project"] == "acme-staging"  # unchanged
+
+    def test_no_op_when_staging_absent(self, tmp_path: Path) -> None:
+        from setup_project import _migrate_staging_to_test
+        assert not _migrate_staging_to_test(tmp_path)
+
+    def test_warns_when_both_exist(self, tmp_path: Path) -> None:
+        from setup_project import _migrate_staging_to_test
+        (tmp_path / "config.staging.yaml").write_text("env: staging\n")
+        (tmp_path / "config.test.yaml").write_text("env: test\n")
+        result = _migrate_staging_to_test(tmp_path)
+        assert not result
+        assert (tmp_path / "config.staging.yaml").exists()  # not deleted
+
+
+# ── setup_project — redundant auth removal ────────────────────────────────────
+
+class TestRemoveRedundantAuthFiles:
+    def _make_auth_file(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("name: dummy\n")
+
+    def test_removes_entity_matching_auth(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        auth = (
+            tmp_path / "modules" / "contextualization" / "cdf_entity_matching"
+            / "auth" / "entity.matching.processing.groups.Group.yaml"
+        )
+        self._make_auth_file(auth)
+        removed = remove_redundant_auth_files(tmp_path)
+        assert len(removed) == 1
+        assert not auth.exists()
+
+    def test_removes_file_annotation_auth(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        auth = (
+            tmp_path / "modules" / "contextualization" / "cdf_file_annotation"
+            / "auth" / "file_annotation.Group.yaml"
+        )
+        self._make_auth_file(auth)
+        removed = remove_redundant_auth_files(tmp_path)
+        assert any("file_annotation" in str(r) for r in removed)
+        assert not auth.exists()
+
+    def test_removes_qualitizer_auth(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        auth = (
+            tmp_path / "modules" / "tools" / "apps" / "qualitizer"
+            / "auth" / "apps.qualitizer.Group.yaml"
+        )
+        self._make_auth_file(auth)
+        removed = remove_redundant_auth_files(tmp_path)
+        assert len(removed) == 1
+        assert not auth.exists()
+
+    def test_removes_cfihos_auth_groups(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        for name in (
+            "gp_cdf_owner_cfihos_oil_gas_data_model.group.yaml",
+            "gp_cdf_read_cfihos_oil_gas_data_model.group.yaml",
+        ):
+            self._make_auth_file(
+                tmp_path / "modules" / "data_models"
+                / "cfihos_oil_and_gas_extension" / "auth" / name
+            )
+        removed = remove_redundant_auth_files(tmp_path)
+        assert len(removed) == 2
+
+    def test_idempotent_when_files_already_removed(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        removed = remove_redundant_auth_files(tmp_path)
+        assert removed == []
+
+
+# ── setup_project — CFIHOS auth patching ──────────────────────────────────────
+
+class TestPatchCfihosAuthForMissingSearch:
+    def _cfihos_auth_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "modules" / "data_models" / "cfihos_oil_and_gas_extension" / "auth"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_removes_search_space_when_search_module_absent(self, tmp_path: Path) -> None:
+        from setup_project import patch_cfihos_auth_for_missing_search
+        auth_dir = self._cfihos_auth_dir(tmp_path)
+        f = auth_dir / "owner.group.yaml"
+        f.write_text(
+            "spaceIds:\n  - cdf_cdm\n  - {{space}}\n  - {{search_space}}\n"
+        )
+        patched = patch_cfihos_auth_for_missing_search(tmp_path)
+        assert len(patched) == 1
+        content = f.read_text()
+        assert "{{search_space}}" not in content
+        assert "{{space}}" in content   # unrelated line preserved
+
+    def test_leaves_file_unchanged_when_search_module_present(self, tmp_path: Path) -> None:
+        from setup_project import patch_cfihos_auth_for_missing_search
+        auth_dir = self._cfihos_auth_dir(tmp_path)
+        # Create the search module directory
+        search = tmp_path / "modules" / "data_models" / "cfihos_oil_and_gas_extension_search"
+        search.mkdir(parents=True)
+        f = auth_dir / "owner.group.yaml"
+        f.write_text("  - {{search_space}}\n")
+        patched = patch_cfihos_auth_for_missing_search(tmp_path)
+        assert patched == []
+        assert "{{search_space}}" in f.read_text()
+
+    def test_no_op_when_cfihos_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import patch_cfihos_auth_for_missing_search
+        assert patch_cfihos_auth_for_missing_search(tmp_path) == []
+
+    def test_idempotent_when_search_space_already_removed(self, tmp_path: Path) -> None:
+        from setup_project import patch_cfihos_auth_for_missing_search
+        auth_dir = self._cfihos_auth_dir(tmp_path)
+        f = auth_dir / "owner.group.yaml"
+        f.write_text("  - cdf_cdm\n  - {{space}}\n")
+        patched = patch_cfihos_auth_for_missing_search(tmp_path)
+        assert patched == []
+
+
+# ── setup_project — read_existing_values ─────────────────────────────────────
+
+class TestReadExistingValues:
+    def _write_config(self, path: Path, data: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.dump(data, sort_keys=False))
+
+    def test_reads_project_names(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {}},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["project_names"]["dev"] == "acme-dev"
+
+    def test_reads_site_from_foundation(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_project_foundation": {"site": "oslo"},
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["site"] == "oslo"
+
+    def test_reads_site_from_nested_structure(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "common": {"cdf_project_foundation": {"site": "berlin"}},
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["site"] == "berlin"
+
+    def test_reads_datasets_from_sourcesystem_modules(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_project_foundation": {"site": ""},
+                "cdf_pi_foundation": {"dataset": "ds_pi", "instanceSpace": "sp_isa"},
+                "cdf_sap_foundation": {"dataset": "ds_sap", "instanceSpace": "sp_isa"},
+            }},
+        })
+        existing = _read_existing_values(
+            tmp_path, ("dev",), ["cdf_pi_foundation", "cdf_sap_foundation"]
+        )
+        assert "ds_pi" in existing["dataset"]
+        assert "ds_sap" in existing["dataset"]
+
+    def test_reads_app_owner(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_file_annotation": {"ApplicationOwner": "owner@firm.com"},
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["app_owner"] == "owner@firm.com"
+
+    def test_skips_placeholder_app_owner(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_file_annotation": {"ApplicationOwner": "<APPLICATION_OWNER>"},
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["app_owner"] == ""
+
+    def test_reads_cfihos_owner_fields(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cfihos_oil_and_gas_extension": {
+                    "admin_user": "admin@firm.com",
+                    "integrationOwnerName": "Alice",
+                    "integrationOwnerEmail": "alice@firm.com",
+                },
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["cfihos_admin_user"] == "admin@firm.com"
+        assert existing["cfihos_integration_owner_name"] == "Alice"
+        assert existing["cfihos_integration_owner_email"] == "alice@firm.com"
+
+    def test_skips_placeholder_cfihos_emails(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cfihos_oil_and_gas_extension": {
+                    "admin_user": "admin.user@firm.com",
+                    "integrationOwnerEmail": "integration.owner@firm.com",
+                    "integrationOwnerName": "Integration Owner",
+                },
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["cfihos_admin_user"] == ""
+        assert existing["cfihos_integration_owner_email"] == ""
+        assert existing["cfihos_integration_owner_name"] == ""
+
+    def test_returns_defaults_when_no_configs_exist(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        existing = _read_existing_values(tmp_path, ("dev", "prod"), [])
+        assert existing["project_names"] == {}
+        assert existing["site"] == ""
+        assert existing["dataset"] == []
+
+
+# ── setup_project — .env path resolution ─────────────────────────────────────
+
+class TestEnvPathResolution:
+    """The .env file must always be written to repo root (where cdf.toml lives),
+    not inside the org directory."""
+
+    def test_env_at_repo_root_without_org_dir(self, tmp_path: Path) -> None:
+        env_path = tmp_path / ".env"  # repo_root / ".env"
+        assert env_path == tmp_path / ".env"
+
+    def test_env_at_repo_root_with_org_dir(self, tmp_path: Path) -> None:
+        """pack_root = repo_root/industrial, but .env should be at repo_root/.env."""
+        repo_root = tmp_path
+        # The wizard uses: env_path = (repo_root or REPO_ROOT) / ".env"
+        env_path = repo_root / ".env"
+        pack_root = repo_root / "industrial"
+        assert env_path == repo_root / ".env"
+        assert env_path != pack_root / ".env"
+
+
+# ── setup_project — environment validation type ───────────────────────────────
+
+class TestEnvironmentValidationType:
+    def test_test_env_uses_prod_validation(self) -> None:
+        from setup_project import ENVIRONMENT_VALIDATION_TYPE
+        assert ENVIRONMENT_VALIDATION_TYPE["test"] == "prod"
+
+    def test_dev_uses_dev_validation(self) -> None:
+        from setup_project import ENVIRONMENT_VALIDATION_TYPE
+        assert ENVIRONMENT_VALIDATION_TYPE["dev"] == "dev"
+
+    def test_prod_uses_prod_validation(self) -> None:
+        from setup_project import ENVIRONMENT_VALIDATION_TYPE
+        assert ENVIRONMENT_VALIDATION_TYPE["prod"] == "prod"
+
+
+# ── setup_project — stale key removal ─────────────────────────────────────────
+
+class TestStaleKeyRemoval:
+    def test_owner_source_id_in_stale_keys(self) -> None:
+        from setup_project import _STALE_CTX_KEYS
+        assert any("owner_source_id" in k for k in _STALE_CTX_KEYS)
+        assert any("read_source_id" in k for k in _STALE_CTX_KEYS)
+
+    def test_reserved_word_prefix_in_stale_keys(self) -> None:
+        from setup_project import _STALE_CTX_KEYS
+        assert any("reservedWordPrefix" in k for k in _STALE_CTX_KEYS)
+
+    def test_stale_cfihos_keys_removed_from_config(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_update, build_overlay
+        p = tmp_path / "config.dev.yaml"
+        p.write_text(textwrap.dedent("""\
+            environment:
+              project: acme-dev
+            variables:
+              modules:
+                cfihos_oil_and_gas_extension:
+                  owner_source_id: abc123
+                  read_source_id: xyz789
+                  instance_space: inst_location
+                  environment: dev
+        """))
+        overlay = build_overlay("cfihos_oil_and_gas_extension", "dev", "", [])
+        _write_config_update(p, "acme-dev", overlay)
+        content = p.read_text()
+        assert "owner_source_id" not in content
+        assert "read_source_id" not in content

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -15,9 +15,7 @@ from __future__ import annotations
 import sys
 import textwrap
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 import yaml
 
 REPO_ROOT   = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
  ### Setup Script Changes

  - **Staging → test migration**: Automatically renames `config.staging.yaml` → `config.test.yaml`
    with `validation-type: prod` when detected
  - **CFIHOS DM config**: Prompts for `admin_user`, `integrationOwnerName`, `integrationOwnerEmail`
    when CFIHOS variant selected; removes redundant `owner_source_id` / `read_source_id` from configs
    and deletes CFIHOS DM auth group files
  - **Org directory path validation**: Displays detected org dir from `cdf.toml` at wizard start
    for visibility
  - **`.env` path fix**: Fixed `REPO_ROOT` computation in `_pack_config.py` — was counting directory
    levels (broken with org dirs), now walks up looking for `cdf.toml`. `.env` always created at
    true project root alongside `cdf.toml`
  - **CI/CD UX**: Captures `generate_actions.py` output instead of printing raw subprocess noise;
    formats written files as `✓ Created .github/workflows/...`; combines next-steps into a single
    unified Done section

  ### Tests Added (`tests/test_foundation_setup_wizard.py`)

  82 tests covering `_yaml_patch`, `_env_io`, and core `setup_project.py` logic including:                                                                                                                                    
  - YAML patching: scalar updates, block-sequence removal, comment preservation, insert/delete
  - `.env` parse and upsert
  - Group name generation, overlay building for both ISA and CFIHOS variants
  - Config fresh-write and in-place update (including nested → flat backwards compat)
  - Staging migration, redundant auth removal, CFIHOS search-space patching
  - `.env` path resolution with and without org directory