### PR TITLE
[ctnd. AT-42] 🐛 Bug Fixes & README Improvements

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -1,6 +1,15 @@
 # CDF Project Foundation Module
 
-Provides the **project-level foundation** for the `dp:foundation` deployment pack: three persona-based access groups and a project setup wizard, aligned with the project-setup SOP.
+The **Foundation Deployment Pack** (`dp:foundation`) is the recommended starting point for any new Cognite Data Fusion project.
+
+- **Built for new projects** — provides exactly what you need to start fresh
+- **Quick to set up** — gets you up and running with minimal friction
+- **Bloat-free** — no demo data or clutter to clean up later
+- **Intuitive** — easy to understand and navigate from day one
+- **Highly extensible** — simple to plug in your own data sources and processing logic
+- **Reliable** — everything included works out of the box
+
+This module provides the **project-level foundation** of the pack: three persona-based access groups and a project setup wizard, aligned with the [project-setup SOP](https://docs.google.com/document/d/14g_hNbJ398sS-iDWBNeXbZi8qzMM-YaZoyskiJt1ql0/edit?usp=sharing).
 
 ---
 
@@ -81,9 +90,11 @@ The module selector presents all available modules. Make selections carefully:
 
 - `cdf_project_foundation` ← this module (access groups + setup wizard)
 
-**Project health** — optional:
+**Project observability** — recommended:
 
-- `qualitizer` ← data quality monitoring tool
+| Module | Purpose |
+|--------|---------|
+| `qualitizer` | Real-time data quality monitoring and KPI dashboards. Not required for the pack to deploy, but strongly recommended — gives visibility into ingestion health and contextualization coverage from day one. |
 
 ---
 
@@ -270,6 +281,8 @@ adminSourceId: "${ADMIN_SOURCE_ID}"
 **Package**: `dp:foundation`
 
 Self-contained. The group ACLs reference `{{ dataset }}`, `{{ instanceSpace }}`, and `{{ schemaSpace }}`, which must match the values used by the deployed source-system and data-model modules.
+
+See the [project-setup SOP](https://docs.google.com/document/d/14g_hNbJ398sS-iDWBNeXbZi8qzMM-YaZoyskiJt1ql0/edit?usp=sharing) for the authoritative procedure covering environments, Entra ID integration, CI/CD, and sign-off.
 
 ---
 

--- a/modules/common/cdf_project_foundation/scripts/_pack_config.py
+++ b/modules/common/cdf_project_foundation/scripts/_pack_config.py
@@ -72,7 +72,7 @@ def get_org_dir_name(repo_root: Path | None = None) -> str | None:
         return None
     try:
         data = tomllib.loads(toml_path.read_text())
-        default_dir = data.get("default_organization_dir")
+        default_dir = data.get("cdf", {}).get("default_organization_dir")
         if isinstance(default_dir, str):
             value = default_dir.strip()
             return value or None

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -796,8 +796,9 @@ def _run_wizard(
         if not selected_envs:
             raise SystemExit("No environments selected — nothing to do.")
 
-    # Migrate config.staging.yaml → config.test.yaml if needed.
-    _migrate_staging_to_test(pack_root)
+    # Migrate config.staging.yaml → config.test.yaml only when test env is selected.
+    if "test" in selected_envs:
+        _migrate_staging_to_test(pack_root)
 
     # Load existing values from config files to pre-fill prompts on re-runs.
     existing = _read_existing_values(pack_root, selected_envs, installed_ss)

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -814,18 +814,41 @@ class TestReadExistingValues:
 
 # ── setup_project — .env path resolution ─────────────────────────────────────
 
+class TestGetOrgDirName:
+    def test_reads_from_cdf_section(self, tmp_path: Path) -> None:
+        from _pack_config import get_org_dir_name
+        (tmp_path / "cdf.toml").write_text(
+            '[cdf]\ndefault_organization_dir = "industrial"\n'
+        )
+        assert get_org_dir_name(tmp_path) == "industrial"
+
+    def test_returns_none_when_no_toml(self, tmp_path: Path) -> None:
+        from _pack_config import get_org_dir_name
+        assert get_org_dir_name(tmp_path) is None
+
+    def test_returns_none_when_key_absent(self, tmp_path: Path) -> None:
+        from _pack_config import get_org_dir_name
+        (tmp_path / "cdf.toml").write_text("[cdf]\nenterprise = acme\n")
+        assert get_org_dir_name(tmp_path) is None
+
+    def test_top_level_key_not_read(self, tmp_path: Path) -> None:
+        """Ensure top-level default_organization_dir (wrong format) is not read."""
+        from _pack_config import get_org_dir_name
+        (tmp_path / "cdf.toml").write_text('default_organization_dir = "wrong"\n')
+        assert get_org_dir_name(tmp_path) is None
+
+
 class TestEnvPathResolution:
     """The .env file must always be written to repo root (where cdf.toml lives),
     not inside the org directory."""
 
     def test_env_at_repo_root_without_org_dir(self, tmp_path: Path) -> None:
-        env_path = tmp_path / ".env"  # repo_root / ".env"
+        env_path = tmp_path / ".env"
         assert env_path == tmp_path / ".env"
 
     def test_env_at_repo_root_with_org_dir(self, tmp_path: Path) -> None:
         """pack_root = repo_root/industrial, but .env should be at repo_root/.env."""
         repo_root = tmp_path
-        # The wizard uses: env_path = (repo_root or REPO_ROOT) / ".env"
         env_path = repo_root / ".env"
         pack_root = repo_root / "industrial"
         assert env_path == repo_root / ".env"


### PR DESCRIPTION
  ### Bug Fixes

  - **`get_org_dir_name` TOML section fix**: `default_organization_dir` is defined under the `[cdf]` section in `cdf.toml` — was incorrectly read as a top-level key, causing org dir to always return `None`
  - **Staging migration guard**: `config.staging.yaml` → `config.test.yaml` migration now only runs when the `test` environment is included in the user's selection

  ### Tests

  - Added `TestGetOrgDirName` (4 tests) covering correct `[cdf]` section reading, missing toml, absent key, and explicit rejection of the wrong top-level format

  ### README

  - Added Foundation DP value proposition at the top (built for new projects, quick setup, bloat-free, intuitive, extensible, reliable)
  - `qualitizer` moved to **Project observability — recommended** with description explaining its role in ingestion health and contextualization KPI monitoring
  - Linked [project-setup SOP](https://docs.google.com/document/d/14g_hNbJ398sS-iDWBNeXbZi8qzMM-YaZoyskiJt1ql0/edit?usp=sharing) in both the intro paragraph and the Dependencies section