### PR TITLE
[AT-44] ⚙️  Feat(cdf_project_foundation): per-extractor groups, synthetic data cleanup & module links

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -59,31 +59,31 @@ The module selector presents all available modules. Make selections carefully:
 
 | Option | Description |
 |--------|-------------|
-| `isa_manufacturing_extension` | ISA-95 enterprise data model for manufacturing assets (assets, equipment, functional locations, time series). |
-| `cfihos_oil_and_gas_extension` | CFIHOS enterprise data model for oil & gas assets. |
+| [`isa_manufacturing_extension`](../../datamodels/isa_manufacturing_extension/README.md) | ISA-95 enterprise data model for manufacturing assets (assets, equipment, functional locations, time series). |
+| [`cfihos_oil_and_gas_extension`](../../datamodels/cfihos_oil_and_gas_extension/README.md) | CFIHOS enterprise data model for oil & gas assets. |
 
 **Data model — search extension** — optional, only when `cfihos_oil_and_gas_extension` is selected:
 
 | Option | Description |
 |--------|-------------|
-| `cfihos_oil_and_gas_extension_search` | Solution data model adding search-optimised views on top of the CFIHOS enterprise model. **Only select alongside `cfihos_oil_and_gas_extension`.** |
+| [`cfihos_oil_and_gas_extension_search`](../../datamodels/cfihos_oil_and_gas_extension_search/README.md) | Solution data model adding search-optimised views on top of the CFIHOS enterprise model. **Only select alongside `cfihos_oil_and_gas_extension`.** |
 
 **Source system modules** — select any combination:
 
 | Module | Description |
 |--------|-------------|
-| `cdf_pi_foundation` | Sets up extraction pipeline configs for OSIsoft PI / AVEVA PI time series data. |
-| `cdf_sap_foundation` | Sets up extraction pipeline configs for SAP assets, equipment, and functional locations via RAW staging. |
-| `cdf_opcua_foundation` | Sets up extraction pipeline configs for OPC-UA data via RAW staging. |
-| `cdf_db_foundation` | Sets up extraction pipeline configs for generic database sources (PostgreSQL, etc.) via RAW staging. |
-| `cdf_files_foundation` | Sets up extraction pipeline configs for file sources such as SharePoint. |
+| [`cdf_pi_foundation`](../../sourcesystem/cdf_pi_foundation/README.md) | Sets up extraction pipeline configs for OSIsoft PI / AVEVA PI time series data. |
+| [`cdf_sap_foundation`](../../sourcesystem/cdf_sap_foundation/README.md) | Sets up extraction pipeline configs for SAP assets, equipment, and functional locations via RAW staging. |
+| [`cdf_opcua_foundation`](../../sourcesystem/cdf_opcua_foundation/README.md) | Sets up extraction pipeline configs for OPC-UA data via RAW staging. |
+| [`cdf_db_foundation`](../../sourcesystem/cdf_db_foundation/README.md) | Sets up extraction pipeline configs for generic database sources (PostgreSQL, etc.) via RAW staging. |
+| [`cdf_files_foundation`](../../sourcesystem/cdf_files_foundation/README.md) | Sets up extraction pipeline configs for file sources such as SharePoint. |
 
 **Contextualization modules** — optional:
 
 | Module | Description |
 |--------|-------------|
-| `cdf_entity_matching` | Automated asset–time series matching using rule-based and ML-assisted methods. |
-| `cdf_file_annotation` | P&ID and document annotation with a Streamlit review app. |
+| [`cdf_entity_matching`](../../contextualization/cdf_entity_matching/README.md) | Automated asset–time series matching using rule-based and ML-assisted methods. |
+| [`cdf_file_annotation`](../../contextualization/cdf_file_annotation/README.md) | P&ID and document annotation with a Streamlit review app. |
 
 **Common module** — always include:
 
@@ -93,7 +93,7 @@ The module selector presents all available modules. Make selections carefully:
 
 | Module | Purpose |
 |--------|---------|
-| `qualitizer` | Real-time data quality monitoring and KPI dashboards. Not required for the pack to deploy, but strongly recommended — gives visibility into ingestion health and contextualization coverage from day one. |
+| [`qualitizer`](../../tools/apps/qualitizer/README.md) | Real-time data quality monitoring and KPI dashboards. Not required for the pack to deploy, but strongly recommended — gives visibility into ingestion health and contextualization coverage from day one. |
 
 ---
 

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -260,8 +260,8 @@ The wizard (`scripts/setup_project.py`) is split across four helper modules:
 # default.config.yaml — key variables (populated by the wizard)
 site: ""                                   # optional site segment for group names
 dataset: []                                # auto-populated from installed source system modules
-schemaSpace: "sp_isa_manufacturing"        # synced from the installed data model variant
-instanceSpace: "sp_isa_instance_space"
+schemaSpace: "dm_dom_isa_manufacturing"    # ISA default; CFIHOS uses dm_dom_oil_and_gas
+instanceSpace: "inst_isa_manufacturing"    # ISA default; CFIHOS uses inst_location
 dataModelVariant: isa_manufacturing_extension
 
 # Computed per env by setup_project.py:

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -62,11 +62,12 @@ The module selector presents all available modules. Make selections carefully:
 | [`isa_manufacturing_extension`](../../datamodels/isa_manufacturing_extension/README.md) | ISA-95 enterprise data model for manufacturing assets (assets, equipment, functional locations, time series). |
 | [`cfihos_oil_and_gas_extension`](../../datamodels/cfihos_oil_and_gas_extension/README.md) | CFIHOS enterprise data model for oil & gas assets. |
 
-**Data model — search extension** — optional, only when `cfihos_oil_and_gas_extension` is selected:
+**Data model — solution extensions** — optional, select alongside the matching enterprise variant:
 
 | Option | Description |
 |--------|-------------|
-| [`cfihos_oil_and_gas_extension_search`](../../datamodels/cfihos_oil_and_gas_extension_search/README.md) | Solution data model adding search-optimised views on top of the CFIHOS enterprise model. **Only select alongside `cfihos_oil_and_gas_extension`.** |
+| [`isa_manufacturing_extension_search`](../../datamodels/isa_manufacturing_extension_search/README.md) | Search-optimised solution views on top of the ISA manufacturing enterprise model. **Only select alongside `isa_manufacturing_extension`.** |
+| [`cfihos_oil_and_gas_extension_search`](../../datamodels/cfihos_oil_and_gas_extension_search/README.md) | Search-optimised solution views on top of the CFIHOS enterprise model. **Only select alongside `cfihos_oil_and_gas_extension`.** |
 
 **Source system modules** — select any combination:
 

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -9,7 +9,7 @@ The **Foundation Deployment Pack** (`dp:foundation`) is the recommended starting
 - **Highly extensible** — simple to plug in your own data sources and processing logic
 - **Reliable** — everything included works out of the box
 
-This module provides the **project-level foundation** of the pack: three persona-based access groups and a project setup wizard, aligned with the [project-setup SOP](https://docs.google.com/document/d/14g_hNbJ398sS-iDWBNeXbZi8qzMM-YaZoyskiJt1ql0/edit?usp=sharing).
+This module provides the **project-level foundation** of the pack: three persona-based access groups and a project setup wizard, aligned with the [project-setup SOP](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup).
 
 ---
 
@@ -17,7 +17,9 @@ This module provides the **project-level foundation** of the pack: three persona
 
 ### Step 0 — Prerequisites
 
-Before you start, ensure the following are in place:
+> 📖 Before starting, read the [project-setup SOP](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup) — it is required reading before any deployment step.
+
+Ensure the following are in place:
 
 - **Cognite Toolkit latest >= 0.8.102** installed. Follow the [setup instructions](https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/setup).
 - A `cdf.toml` exists in your project root. If missing, run `cdf init` and choose **Create toml file (required)**.
@@ -27,11 +29,6 @@ Before you start, ensure the following are in place:
   cdf auth verify
   ```
   See the [Toolkit authentication docs](https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/auth).
-- Library source configured in `cdf.toml`:
-  ```toml
-  [library.cognite]
-  url = "https://github.com/cognitedata/library/releases/download/latest/packages.zip"
-  ```
 
 > **Important:** Keep all client IDs and secrets as environment variables — never hardcode them in config files.
 
@@ -47,6 +44,8 @@ cdf modules init
 
 Select **Foundation Deployment Pack** from the list.
 
+> **Module selector controls:** use **Space** to select / deselect a module, **Enter** to confirm.
+
 ---
 
 ### Step 2 — Select modules
@@ -58,37 +57,37 @@ The module selector presents all available modules. Make selections carefully:
 > ⚠️ **Select only one data model variant.** Selecting both will break auto-detection
 > and require the `--variant` flag on every script run.
 
-| Option | Use when |
-|--------|----------|
-| `isa_manufacturing_extension` | ISA-95 / manufacturing assets |
-| `cfihos_oil_and_gas_extension` | CFIHOS / oil & gas assets |
+| Option | Description |
+|--------|-------------|
+| `isa_manufacturing_extension` | ISA-95 enterprise data model for manufacturing assets (assets, equipment, functional locations, time series). |
+| `cfihos_oil_and_gas_extension` | CFIHOS enterprise data model for oil & gas assets. |
 
 **Data model — search extension** — optional, only when `cfihos_oil_and_gas_extension` is selected:
 
-| Option | Purpose |
-|--------|---------|
-| `cfihos_oil_and_gas_extension_search` | Solution data model adding search spaces for the CFIHOS extension. **Only select this alongside `cfihos_oil_and_gas_extension`** |
+| Option | Description |
+|--------|-------------|
+| `cfihos_oil_and_gas_extension_search` | Solution data model adding search-optimised views on top of the CFIHOS enterprise model. **Only select alongside `cfihos_oil_and_gas_extension`.** |
 
 **Source system modules** — select any combination:
 
-| Module | Source system |
-|--------|--------------|
-| `cdf_pi_foundation` | OSIsoft PI / AVEVA PI |
-| `cdf_sap_foundation` | SAP (assets, equipment, functional locations) |
-| `cdf_opcua_foundation` | OPC-UA |
-| `cdf_db_foundation` | Generic database (PostgreSQL, etc.) |
-| `cdf_files_foundation` | File sources (SharePoint, etc.) |
+| Module | Description |
+|--------|-------------|
+| `cdf_pi_foundation` | Sets up extraction pipeline configs for OSIsoft PI / AVEVA PI time series data. |
+| `cdf_sap_foundation` | Sets up extraction pipeline configs for SAP assets, equipment, and functional locations via RAW staging. |
+| `cdf_opcua_foundation` | Sets up extraction pipeline configs for OPC-UA data via RAW staging. |
+| `cdf_db_foundation` | Sets up extraction pipeline configs for generic database sources (PostgreSQL, etc.) via RAW staging. |
+| `cdf_files_foundation` | Sets up extraction pipeline configs for file sources such as SharePoint. |
 
 **Contextualization modules** — optional:
 
-| Module | Capability |
-|--------|-----------|
-| `cdf_entity_matching` | Automated asset–time series matching |
-| `cdf_file_annotation` | P&ID / document annotation |
+| Module | Description |
+|--------|-------------|
+| `cdf_entity_matching` | Automated asset–time series matching using rule-based and ML-assisted methods. |
+| `cdf_file_annotation` | P&ID and document annotation with a Streamlit review app. |
 
 **Common module** — always include:
 
-- `cdf_project_foundation` ← this module (access groups + setup wizard)
+- `cdf_project_foundation` ← this module (access groups, extractor groups, setup wizard)
 
 **Project observability** — recommended:
 
@@ -237,7 +236,8 @@ The wizard (`scripts/setup_project.py`) is split across four helper modules:
 1. Prompts for which environments to set up (all three, dev only, dev+prod, or custom).
 2. Asks for the CDF project name for each selected environment (pre-filled on re-run).
 3. Asks for an optional site / location name — used as access-group suffix and entity-matching `location_name`.
-4. Prompts for source system integration and data owner contacts (shared or per-module).
+4. Prompts for source system integration owner and data owner contacts (shared or per-module).
+   - For the CFIHOS data model: prompts for **data model owner** name and email (renamed from "integration owner" to reflect its purpose).
 5. Prompts for group source IDs (Entra ID object IDs) and writes them to `.env`.
 6. Asks for the Streamlit ApplicationOwner email if `cdf_file_annotation` is installed.
 7. Shows a review summary then confirms before writing anything.
@@ -282,7 +282,7 @@ adminSourceId: "${ADMIN_SOURCE_ID}"
 
 Self-contained. The group ACLs reference `{{ dataset }}`, `{{ instanceSpace }}`, and `{{ schemaSpace }}`, which must match the values used by the deployed source-system and data-model modules.
 
-See the [project-setup SOP](https://docs.google.com/document/d/14g_hNbJ398sS-iDWBNeXbZi8qzMM-YaZoyskiJt1ql0/edit?usp=sharing) for the authoritative procedure covering environments, Entra ID integration, CI/CD, and sign-off.
+See the [project-setup SOP](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup) for the authoritative procedure covering environments, Entra ID integration, CI/CD, and sign-off.
 
 ---
 

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -118,7 +118,7 @@ Other options:
 
 ```bash
 python modules/common/cdf_project_foundation/scripts/setup_project.py -y --variant isa_manufacturing_extension
-python modules/common/cdf_project_foundation/scripts/setup_project.py -y --site oslo
+
 python modules/common/cdf_project_foundation/scripts/setup_project.py --check   # CI drift check
 ```
 
@@ -236,7 +236,7 @@ The wizard (`scripts/setup_project.py`) is split across four helper modules:
 
 1. Prompts for which environments to set up (all three, dev only, dev+prod, or custom).
 2. Asks for the CDF project name for each selected environment (pre-filled on re-run).
-3. Asks for an optional site / location name — used as access-group suffix and entity-matching `location_name`.
+3. Asks for an required site / location name — used as access-group suffix, source system location, and entity-matching `location_name`.
 4. Prompts for source system integration owner and data owner contacts (shared or per-module).
    - For the CFIHOS data model: prompts for **data model owner** name and email (renamed from "integration owner" to reflect its purpose).
 5. Prompts for group source IDs (Entra ID object IDs) and writes them to `.env`.

--- a/modules/common/cdf_project_foundation/default.config.yaml
+++ b/modules/common/cdf_project_foundation/default.config.yaml
@@ -20,13 +20,9 @@ producerSourceId: "${PRODUCER_SOURCE_ID}"    # read/write ingestion producers
 adminSourceId: "${ADMIN_SOURCE_ID}"          # foundation administrators
 
 # Schema space where the selected data model views are defined.
-# Generic across variants: sp_isa_manufacturing (ISA) or dm_dom_oil_and_gas (CHIFO).
-# Synced by scripts/setup_project.py from the installed data model variant.
-schemaSpace: "sp_isa_manufacturing"
-
-# Space where DM instances (ISAAsset, Equipment, FunctionalLocation, …) are written.
-# Must match the instanceSpace used by the source system modules.
-instanceSpace: "sp_isa_instance_space"
+schemaSpace: "dm_dom_isa_manufacturing"
+# Space where DM instances are written.
+instanceSpace: "inst_isa_manufacturing"
 
 # Data model variant — controls which schema/instance spaces are synced.
 # Supported: isa_manufacturing_extension | cfihos_oil_and_gas_extension

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -881,20 +881,23 @@ def _run_wizard(
             break
 
     # ── Site / location name (optional) ──────────────────────────────────────
-    _section("Site / Location Name  (optional)")
-    _hint("Used as suffix in access-group names (<persona>-<site>-<env>)")
-    _hint("and as location_name in entity-matching variables.")
-    _hint("Leave blank to omit.")
+    _section("Site / Location Name")
+    _hint("Required. Used as suffix in access-group names (<persona>-<site>-<env>),")
+    _hint("location for source system external IDs, and location_name in entity-matching.")
+    _hint("Only lowercase letters, digits, hyphens, and underscores (e.g. oslo).")
     if args_site:
         site = args_site
         _hint(f"Using --site value: {site}")
     else:
         while True:
             site = prompt(
-                "Site / location name (e.g. oslo)",
+                "Site / location name",
                 default=existing["site"] or None,
             ).strip().lower()
-            if not site or re.fullmatch(r"[a-z0-9_-]+", site):
+            if not site:
+                _warn("Site / location name is required and cannot be empty.")
+                continue
+            if re.fullmatch(r"[a-z0-9_-]+", site):
                 break
             _warn("Use only lowercase letters, digits, hyphens, and underscores.")
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -223,17 +223,15 @@ def _module_label(module: str) -> str:
 def resolve_sourcesystem_variables(
     instance_space: str,
     installed_modules: list[str],
-    env: str = "dev",
-    location: str = "",
+    env: str,
+    location: str,
     integration_owners: dict[str, tuple[str, str]] | None = None,
     data_owners: dict[str, tuple[str, str]] | None = None,
     extractor_group_source_ids: dict[str, str] | None = None,
 ) -> dict[str, dict]:
     result: dict[str, dict] = {}
     for module in installed_modules:
-        vars_: dict[str, Any] = {"instanceSpace": instance_space, "environment": env}
-        if location:
-            vars_["location"] = location
+        vars_: dict[str, Any] = {"instanceSpace": instance_space, "environment": env, "location": location}
         if integration_owners and module in integration_owners:
             name, email = integration_owners[module]
             if name:
@@ -247,9 +245,8 @@ def resolve_sourcesystem_variables(
             if email:
                 vars_["data_owner_email"] = email
         if extractor_group_source_ids and module in extractor_group_source_ids:
-            env_var = _MODULE_EXTRACTOR_ENV_VAR.get(module)
-            if env_var:
-                vars_["extractor_group_source_id"] = f"${{{env_var}}}"
+            env_var = extractor_group_source_ids[module]
+            vars_["extractor_group_source_id"] = f"${{{env_var}}}"
         result[module] = vars_
     return result
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -68,8 +68,8 @@ PERSONAS: tuple[str, ...] = ("consumer", "producer", "admin")
 INGESTION_FOUNDATION_VARIABLES: dict[str, dict[str, str]] = {
     "isa_manufacturing_extension": {
         "dataModelVariant": "isa_manufacturing_extension",
-        "schemaSpace": "sp_isa_manufacturing",
-        "instanceSpace": "sp_isa_instance_space",
+        "schemaSpace": "dm_dom_isa_manufacturing",
+        "instanceSpace": "inst_isa_manufacturing",
     },
     "cfihos_oil_and_gas_extension": {
         "dataModelVariant": "cfihos_oil_and_gas_extension",
@@ -78,13 +78,6 @@ INGESTION_FOUNDATION_VARIABLES: dict[str, dict[str, str]] = {
     },
 }
 
-DATA_MODELS_MODULE_VARIABLES: dict[str, dict[str, str]] = {
-    "isa_manufacturing_extension": {
-        "isaSchemaSpace": "sp_isa_manufacturing",
-        "isaInstanceSpace": "sp_isa_instance_space",
-    },
-    "cfihos_oil_and_gas_extension": {},
-}
 
 # Per-variant overrides for contextualization modules.
 # ``None`` values are sentinels resolved to the variant's ``instanceSpace``
@@ -92,7 +85,7 @@ DATA_MODELS_MODULE_VARIABLES: dict[str, dict[str, str]] = {
 CONTEXTUALIZATION_VARIABLES: dict[str, dict[str, dict]] = {
     "isa_manufacturing_extension": {
         "cdf_entity_matching": {
-            "schemaSpace": "sp_isa_manufacturing",
+            "schemaSpace": "dm_dom_isa_manufacturing",
             "assetInstanceSpace": None,
             "timeseriesInstanceSpace": None,
             "AssetViewExternalId": "ISAAsset",
@@ -105,10 +98,10 @@ CONTEXTUALIZATION_VARIABLES: dict[str, dict[str, dict]] = {
             "entityViewFilterValues": [],
         },
         "cdf_file_annotation": {
-            "fileSchemaSpace": "sp_isa_manufacturing",
+            "fileSchemaSpace": "dm_dom_isa_manufacturing",
             "fileInstanceSpace": None,
             "fileExternalId": "ISAFile",
-            "targetEntitySchemaSpace": "sp_isa_manufacturing",
+            "targetEntitySchemaSpace": "dm_dom_isa_manufacturing",
             "targetEntityInstanceSpace": None,
             "targetEntityExternalId": "ISAAsset",
         },
@@ -167,6 +160,11 @@ _STALE_CTX_KEYS: tuple[str, ...] = (
     ".entity_matching_processing_group_source_id",
     "variables.modules.cdf_entity_matching.reservedWordPrefix",
     "variables.modules.contextualization.cdf_entity_matching.reservedWordPrefix",
+    # Stale ISA DM vars — previously written by setup_project.py, now owned by the module.
+    "variables.modules.isa_manufacturing_extension.isaSchemaSpace",
+    "variables.modules.isa_manufacturing_extension.isaInstanceSpace",
+    "variables.modules.datamodels.isa_manufacturing_extension.isaSchemaSpace",
+    "variables.modules.datamodels.isa_manufacturing_extension.isaInstanceSpace",
     # CFIHOS DM source IDs — covered by foundation persona groups.
     "variables.modules.cfihos_oil_and_gas_extension.owner_source_id",
     "variables.modules.cfihos_oil_and_gas_extension.read_source_id",
@@ -342,9 +340,6 @@ def build_overlay(
                 "environment": env,
             }
     else:
-        # ISA variant — static variables (isaSchemaSpace, isaInstanceSpace).
-        modules_vars[variant] = DATA_MODELS_MODULE_VARIABLES[variant]
-
         # If the ISA search solution module is also installed, keep its
         # instance_space in sync with the enterprise module.
         data_models_dir = get_data_models_dir(repo_root)

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -13,7 +13,7 @@ before it is modified.  Existing comments and blank lines are preserved when
 updating a file in-place (``_yaml_patch`` helpers).
 
 Usage:
-    python setup_project.py [-y] [--check] [--variant VARIANT] [--site SITE]
+    python setup_project.py [-y] [--check] [--variant VARIANT]
 """
 
 from __future__ import annotations
@@ -804,7 +804,6 @@ def _run_cicd_wizard(pack_root: Path) -> list[Path]:
 
 def _run_wizard(
     args_variant: str | None,
-    args_site: str,
     args_yes: bool,
     repo_root: Path | None = None,
 ) -> None:
@@ -885,21 +884,17 @@ def _run_wizard(
     _hint("Required. Used as suffix in access-group names (<persona>-<site>-<env>),")
     _hint("location for source system external IDs, and location_name in entity-matching.")
     _hint("Only lowercase letters, digits, hyphens, and underscores (e.g. oslo).")
-    if args_site:
-        site = args_site
-        _hint(f"Using --site value: {site}")
-    else:
-        while True:
-            site = prompt(
-                "Site / location name",
-                default=existing["site"] or None,
-            ).strip().lower()
-            if not site:
-                _warn("Site / location name is required and cannot be empty.")
-                continue
-            if re.fullmatch(r"[a-z0-9_-]+", site):
-                break
-            _warn("Use only lowercase letters, digits, hyphens, and underscores.")
+    while True:
+        site = prompt(
+            "Site / location name",
+            default=existing["site"] or None,
+        ).strip().lower()
+        if not site:
+            _warn("Site / location name is required and cannot be empty.")
+            continue
+        if re.fullmatch(r"[a-z0-9_-]+", site):
+            break
+        _warn("Use only lowercase letters, digits, hyphens, and underscores.")
 
     # ── Source system ownership ───────────────────────────────────────────────
     integration_owners, data_owners = _prompt_source_system_ownership(
@@ -1108,8 +1103,9 @@ def collect_expected(
     env: str,
     site: str,
     installed_ctx: list[str],
+    datasets: list[str] | None = None,
 ) -> dict[str, object]:
-    overlay = build_overlay(variant, env, site, installed_ctx)
+    overlay = build_overlay(variant, env, site, installed_ctx, datasets=datasets)
     modules = overlay["variables"]["modules"]
     expected: dict[str, object] = {}
     for module, mod_vars in modules.items():
@@ -1120,8 +1116,18 @@ def collect_expected(
 
 
 def get_actual_value(config: dict, dotted: str) -> object:
-    node = config.get("variables", {}).get("modules", {})
-    for part in dotted.split("."):
+    """Read a value using the nested-category structure ``modules.<category>.<module>.<key>``.
+
+    The canonical config structure groups modules under their category
+    (e.g. ``modules.common.cdf_project_foundation.site``).
+    ``_MODULE_CATEGORY_FALLBACK`` supplies the category for each module name.
+    """
+    parts = dotted.split(".")
+    if not parts:
+        return None
+    category = _MODULE_CATEGORY_FALLBACK.get(parts[0])
+    node: object = config.get("variables", {}).get("modules", {})
+    for part in ([category] + parts if category else parts):
         if not isinstance(node, dict) or part not in node:
             return None
         node = node[part]
@@ -1134,42 +1140,74 @@ def check_config_file(
     env: str,
     site: str,
     installed_ctx: list[str],
+    datasets: list[str] | None = None,
 ) -> list[str]:
     if not path.exists():
         return ["    (file missing — run without --check to create it)"]
     config = load_yaml(path)
     errors: list[str] = []
-    for dotted, expected_value in collect_expected(variant, env, site, installed_ctx).items():
+    for dotted, expected_value in collect_expected(
+        variant, env, site, installed_ctx, datasets
+    ).items():
         actual = get_actual_value(config, dotted)
         if actual != expected_value:
             errors.append(f"    {dotted}: got {actual!r}, expected {expected_value!r}")
     return errors
 
 
+def _read_check_context(pack_root: Path) -> tuple[str, list[str]]:
+    """Read site and dataset values from the first existing config file for --check mode.
+
+    Returns (site, datasets).  Both are needed to build correct expected values
+    so user-configured fields (group names, location, dataset list) don't produce
+    false positives.
+    """
+    for env in ENVIRONMENTS:
+        path = pack_root / f"config.{env}.yaml"
+        if not path.exists():
+            continue
+        cfg = load_yaml(path)
+        modules = cfg.get("variables", {}).get("modules", {})
+        # Support nested (canonical) and flat structures.
+        foundation = (
+            modules.get("common", {}).get("cdf_project_foundation", {})
+            or modules.get("cdf_project_foundation", {})
+        )
+        site = foundation.get("site", "")
+        datasets = foundation.get("dataset") or []
+        if not isinstance(datasets, list):
+            datasets = []
+        return site, datasets
+    return "", []
+
+
 def _run_check(
     args_variant: str | None,
-    args_site: str,
     repo_root: Path | None = None,
 ) -> None:
     pack_root = get_pack_root(repo_root)
     variant = resolve_variant(args_variant, get_data_models_dir(repo_root))
-    site = args_site.strip()
-    targets = target_config_paths(pack_root, ENVIRONMENTS)
+    # Read site and datasets from existing configs so user-configured values
+    # (group names, location, dataset list) don't produce false positives.
+    site, datasets = _read_check_context(pack_root)
     installed_ctx = list_installed_contextualization_modules(repo_root)
 
+    # Only validate config files that actually exist — skip missing ones silently.
     all_errors: dict[str, list[str]] = {}
-    for env, path in targets.items():
-        errs = check_config_file(path, variant, env, site, installed_ctx)
+    for env in ENVIRONMENTS:
+        path = pack_root / f"config.{env}.yaml"
+        if not path.exists():
+            continue
+        errs = check_config_file(path, variant, env, site, installed_ctx, datasets)
         if errs:
             all_errors[path.name] = errs
 
-    target_set = set(targets.values())
     for path in find_env_configs(repo_root):
-        if path in target_set:
+        if (pack_root / path.name) in {pack_root / f"config.{e}.yaml" for e in ENVIRONMENTS}:
             continue
         env_guess = path.name.split(".")[1] if "." in path.name else "dev"
         env_guess = env_guess if env_guess in ENVIRONMENTS else "dev"
-        errs = check_config_file(path, variant, env_guess, site, installed_ctx)
+        errs = check_config_file(path, variant, env_guess, site, installed_ctx, datasets)
         if errs:
             all_errors[path.name] = errs
 
@@ -1220,17 +1258,12 @@ def main() -> None:
         default=None,
         help="Force the data model variant instead of auto-detecting it",
     )
-    parser.add_argument(
-        "--site",
-        default="",
-        help="Optional site / location name inserted into access-group names (<persona>-<site>-<env>)",
-    )
     args = parser.parse_args()
 
     if args.check:
-        _run_check(args.variant, args.site)
+        _run_check(args.variant)
     else:
-        _run_wizard(args.variant, args.site, args.yes)
+        _run_wizard(args.variant, args.yes)
 
 
 if __name__ == "__main__":

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -206,6 +206,15 @@ _MODULE_LABELS: dict[str, str] = {
     "cdf_files_foundation": "Files Foundation",
 }
 
+# .env variable name for each SS module's extractor group source ID.
+_MODULE_EXTRACTOR_ENV_VAR: dict[str, str] = {
+    "cdf_pi_foundation":    "PI_EXTRACTOR_GROUP_SOURCE_ID",
+    "cdf_sap_foundation":   "SAP_EXTRACTOR_GROUP_SOURCE_ID",
+    "cdf_opcua_foundation": "OPCUA_EXTRACTOR_GROUP_SOURCE_ID",
+    "cdf_db_foundation":    "DB_EXTRACTOR_GROUP_SOURCE_ID",
+    "cdf_files_foundation": "FILES_EXTRACTOR_GROUP_SOURCE_ID",
+}
+
 
 def _module_label(module: str) -> str:
     return _MODULE_LABELS.get(module, module)
@@ -214,13 +223,15 @@ def _module_label(module: str) -> str:
 def resolve_sourcesystem_variables(
     instance_space: str,
     installed_modules: list[str],
+    env: str = "dev",
     location: str = "",
     integration_owners: dict[str, tuple[str, str]] | None = None,
     data_owners: dict[str, tuple[str, str]] | None = None,
+    extractor_group_source_ids: dict[str, str] | None = None,
 ) -> dict[str, dict]:
     result: dict[str, dict] = {}
     for module in installed_modules:
-        vars_: dict[str, Any] = {"instanceSpace": instance_space}
+        vars_: dict[str, Any] = {"instanceSpace": instance_space, "environment": env}
         if location:
             vars_["location"] = location
         if integration_owners and module in integration_owners:
@@ -235,6 +246,10 @@ def resolve_sourcesystem_variables(
                 vars_["data_owner_name"] = name
             if email:
                 vars_["data_owner_email"] = email
+        if extractor_group_source_ids and module in extractor_group_source_ids:
+            env_var = _MODULE_EXTRACTOR_ENV_VAR.get(module)
+            if env_var:
+                vars_["extractor_group_source_id"] = f"${{{env_var}}}"
         result[module] = vars_
     return result
 
@@ -268,6 +283,7 @@ def build_overlay(
     cfihos_admin_user: str = "",
     cfihos_integration_owner_name: str = "",
     cfihos_integration_owner_email: str = "",
+    extractor_group_source_ids: dict[str, str] | None = None,
     repo_root: Path | None = None,
 ) -> dict:
     """Full ``variables.modules`` overlay dict to merge into a config file.
@@ -289,6 +305,7 @@ def build_overlay(
         ctx_vars["cdf_file_annotation"]["ApplicationOwner"] = app_owner
     if site and "cdf_entity_matching" in ctx_vars:
         ctx_vars["cdf_entity_matching"]["location_name"] = site
+        ctx_vars["cdf_entity_matching"]["source_name"] = site
 
     # Always write dataset (even as empty list) so the key is always present.
     modules_vars: dict[str, Any] = {
@@ -298,7 +315,8 @@ def build_overlay(
     if installed_ss:
         modules_vars.update(
             resolve_sourcesystem_variables(
-                instance_space, installed_ss, site, integration_owners, data_owners
+                instance_space, installed_ss, env, site,
+                integration_owners, data_owners, extractor_group_source_ids
             )
         )
     if variant == "cfihos_oil_and_gas_extension":
@@ -513,6 +531,42 @@ def _migrate_staging_to_test(pack_root: Path) -> bool:
     staging.unlink()
     _ok("Migrated config.staging.yaml → config.test.yaml  (validation-type: prod)")
     return True
+
+
+# ── Synthetic data removal ────────────────────────────────────────────────────
+
+# Directories in cfihos_oil_and_gas_extension that contain synthetic / example data
+# and should be removed when the user opts out.
+_CFIHOS_SYNTHETIC_DIRS: tuple[str, ...] = (
+    "upload_data",
+    "raw",
+    "workflows",
+    "transformations",
+)
+
+
+def remove_synthetic_data(repo_root: Path | None = None) -> int:
+    """Delete synthetic data directories from ``cfihos_oil_and_gas_extension``.
+
+    Only the CFIHOS DM module contains synthetic/example data (upload_data,
+    raw, workflows, transformations).  No other Foundation DP module requires
+    this cleanup.
+
+    Returns the total number of files removed.
+    """
+    data_models_dir = get_data_models_dir(repo_root)
+    cfihos_dir = data_models_dir / "cfihos_oil_and_gas_extension"
+    if not cfihos_dir.is_dir():
+        return 0
+
+    total = 0
+    for dir_name in _CFIHOS_SYNTHETIC_DIRS:
+        target = cfihos_dir / dir_name
+        if target.is_dir():
+            total += sum(1 for f in target.rglob("*") if f.is_file())
+            shutil.rmtree(target)
+
+    return total
 
 
 # ── Data model auth patching ──────────────────────────────────────────────────
@@ -853,7 +907,7 @@ def _run_wizard(
     cfihos_integration_owner_name = ""
     cfihos_integration_owner_email = ""
     if variant == "cfihos_oil_and_gas_extension":
-        _section("CFIHOS Data Model — Owner Configuration")
+        _section("CFIHOS Data Model — Data Model Owner Configuration")
         _hint("Configures admin_user, integrationOwnerName, and integrationOwnerEmail")
         _hint("in the cfihos_oil_and_gas_extension module. Leave blank to skip.")
 
@@ -867,13 +921,13 @@ def _run_wizard(
             _warn("Invalid email. Use format: name@domain.com")
 
         cfihos_integration_owner_name = prompt(
-            "Integration owner name",
+            "Data Model owner name",
             default=existing.get("cfihos_integration_owner_name") or None,
         ).strip()
 
         while True:
             cfihos_integration_owner_email = prompt(
-                "Integration owner email",
+                "Data Model owner email",
                 default=existing.get("cfihos_integration_owner_email") or None,
             ).strip()
             if not cfihos_integration_owner_email or re.fullmatch(
@@ -884,8 +938,9 @@ def _run_wizard(
 
     # ── Group source IDs → .env ───────────────────────────────────────────────
     _section("Group Source IDs  (Entra ID object IDs)")
-    _hint("Stored in .env and referenced as ${CONSUMER_SOURCE_ID} etc. in config.")
-    _hint("Leave blank to skip — fill .env manually later.")
+    _hint("The source ID is the group's object ID in your identity provider (e.g. Entra ID).")
+    _hint("See: https://docs.cognite.com/cdf/access/entra/guides/create_groups_oidc")
+    _hint("Values stored in .env — leave blank to fill manually later.")
     # .env always lives at repo root (same level as cdf.toml), regardless of
     # whether an organization directory is configured.
     env_path = (repo_root or REPO_ROOT) / ".env"
@@ -894,8 +949,22 @@ def _run_wizard(
 
     for persona in PERSONAS:
         var = f"{persona.upper()}_SOURCE_ID"
-        print(f"\n  {persona.capitalize()} group  →  {var}")
+        print(f"\n  {persona.capitalize()} persona group  →  {var}")
+        _hint(f"  Source ID of the '{group_name(persona, site, 'dev')}' group in your IdP.")
         prompt_env_var(var, env_vals, env_lines, env_key_idx)
+
+    # ── Extractor group source IDs (one per installed SS module) ──────────────
+    if installed_ss:
+        _section("Extractor Group Source IDs  (per source system)")
+        _hint("One scoped producer group per extractor — write access limited to its")
+        _hint("dataset, instance space, and RAW tables only (SOP Step 3c).")
+        _hint("See: https://docs.cognite.com/cdf/access/entra/guides/create_groups_oidc")
+        for module in installed_ss:
+            var = _MODULE_EXTRACTOR_ENV_VAR.get(module, "")
+            if not var:
+                continue
+            print(f"\n  {_module_label(module)}  →  {var}")
+            prompt_env_var(var, env_vals, env_lines, env_key_idx)
 
     # ── ApplicationOwner (file_annotation only) ───────────────────────────────
     app_owner = ""
@@ -915,8 +984,22 @@ def _run_wizard(
                 break
             _warn("One or more addresses look invalid. Use format: name@domain.com")
 
+    # ── Synthetic data (CFIHOS only) ─────────────────────────────────────────
+    keep_synthetic = True  # default: keep; only asked for CFIHOS
+    if variant == "cfihos_oil_and_gas_extension":
+        _section("Synthetic / Example Data  (CFIHOS)")
+        _hint("cfihos_oil_and_gas_extension contains synthetic data in upload_data/,")
+        _hint("raw/, workflows/, and transformations/ — not needed in production.")
+        keep_synthetic = prompt_yes_no(
+            "Keep synthetic data and example files?", default=False
+        )
+
     # ── Review summary ────────────────────────────────────────────────────────
-    env_dirty = any(
+    extractor_dirty = any(
+        env_vals.get(v) != original_env_vals.get(v)
+        for v in _MODULE_EXTRACTOR_ENV_VAR.values()
+    )
+    env_dirty = extractor_dirty or any(
         env_vals.get(f"{p.upper()}_SOURCE_ID") != original_env_vals.get(f"{p.upper()}_SOURCE_ID")
         for p in PERSONAS
     )
@@ -945,6 +1028,11 @@ def _run_wizard(
             cfihos_admin_user=cfihos_admin_user,
             cfihos_integration_owner_name=cfihos_integration_owner_name,
             cfihos_integration_owner_email=cfihos_integration_owner_email,
+            extractor_group_source_ids={
+                m: _MODULE_EXTRACTOR_ENV_VAR[m]
+                for m in installed_ss
+                if m in _MODULE_EXTRACTOR_ENV_VAR
+            },
             repo_root=repo_root,
         )
         if write_config(path, env, project_names[env], overlay):
@@ -968,6 +1056,13 @@ def _run_wizard(
     removed = remove_redundant_auth_files(repo_root)
     patched = patch_cfihos_auth_for_missing_search(repo_root)
 
+    # ── Remove synthetic data (if user opted out) ─────────────────────────────
+    synthetic_removed = 0
+    if not keep_synthetic:
+        synthetic_removed = remove_synthetic_data(repo_root)
+        if synthetic_removed:
+            _ok(f"Removed {synthetic_removed} synthetic data file(s) from upload_data/ directories.")
+
     # ── CI/CD generation ──────────────────────────────────────────────────────
     cicd_files = _run_cicd_wizard(pack_root)
 
@@ -980,6 +1075,8 @@ def _run_wizard(
         _ok(f"{len(patched)} cfihos auth file(s) patched (search_space removed).")
     if env_dirty:
         _ok(".env updated with group source IDs.")
+    if synthetic_removed:
+        _ok(f"{synthetic_removed} synthetic data file(s) removed.")
     if cicd_files:
         _ok(f"{len(cicd_files)} CI/CD workflow file(s) generated.")
     print()

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -151,8 +151,10 @@ _MODULE_CATEGORY_FALLBACK: dict[str, str] = {
     "cdf_opcua_foundation":      "sourcesystem",
     "cdf_db_foundation":         "sourcesystem",
     "cdf_files_foundation":      "sourcesystem",
-    "isa_manufacturing_extension":    "datamodels",
-    "cfihos_oil_and_gas_extension":   "datamodels",
+    "isa_manufacturing_extension":         "datamodels",
+    "isa_manufacturing_extension_search":  "datamodels",
+    "cfihos_oil_and_gas_extension":        "datamodels",
+    "cfihos_oil_and_gas_extension_search": "datamodels",
 }
 
 # Keys that are stale in an existing config when cdf_project_foundation is
@@ -342,6 +344,15 @@ def build_overlay(
     else:
         # ISA variant — static variables (isaSchemaSpace, isaInstanceSpace).
         modules_vars[variant] = DATA_MODELS_MODULE_VARIABLES[variant]
+
+        # If the ISA search solution module is also installed, keep its
+        # instance_space in sync with the enterprise module.
+        data_models_dir = get_data_models_dir(repo_root)
+        if (data_models_dir / "isa_manufacturing_extension_search").is_dir():
+            modules_vars["isa_manufacturing_extension_search"] = {
+                "instance_space": "inst_isa_manufacturing",
+                "environment": env,
+            }
 
     return {"variables": {"modules": modules_vars}}
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -455,8 +455,7 @@ def remove_redundant_auth_files(repo_root: Path | None = None) -> list[Path]:
     tools/apps modules (qualitizer) whose standalone auth becomes redundant
     once the foundation persona groups are deployed.
     """
-    from _pack_config import REPO_ROOT as _REPO_ROOT
-    modules_root = (_REPO_ROOT if repo_root is None else repo_root) / "modules"
+    modules_root = get_pack_root(repo_root) / "modules"
     removed: list[Path] = []
 
     # Contextualization modules.

--- a/modules/contextualization/cdf_entity_matching/data_sets/timeseries.DataSet.yaml
+++ b/modules/contextualization/cdf_entity_matching/data_sets/timeseries.DataSet.yaml
@@ -2,15 +2,5 @@ externalId: 'ds_timeseries_{{location_name}}'
 name:  'timeseries:{{location_name}}'
 description: 'TimeSeries data for {{location_name}}'
 metadata:
-  consoleSource:
-    names:
-      - '{{source_name}}'
-  rawTables:
-    - databaseName: '{{ dbName }}'
-      tableName: 'contextualization_good'
-    - databaseName: '{{ dbName }}'
-      tableName: 'contextualization_bad'
-    - databaseName: '{{ dbName }}'
-      tableName: 'contextualization_manual_input'
-    - databaseName: '{{ dbName }}'
-      tableName: 'contextualization_state_store'
+  consoleSource: '{"names": ["{{source_name}}"]}'
+  rawTables: '[{"databaseName": "{{ dbName }}", "tableName": "contextualization_good"}, {"databaseName": "{{ dbName }}", "tableName": "contextualization_bad"}, {"databaseName": "{{ dbName }}", "tableName": "contextualization_manual_input"}, {"databaseName": "{{ dbName }}", "tableName": "contextualization_state_store"}]'

--- a/modules/datamodels/cfihos_oil_and_gas_extension/data_sets/data_sets.DataSet.yaml
+++ b/modules/datamodels/cfihos_oil_and_gas_extension/data_sets/data_sets.DataSet.yaml
@@ -6,6 +6,6 @@
     consoleCreatedBy: '{"username": "{{admin_user}}"}'
     consoleGoverned: '{{governed}}'
     consoleLabels: '["OIL AND GAS", "DOMAIN MODEL", "CFIHOS", "ISO 14224"]'
-    consoleOwners: '["{{integrationOwnerEmail}}", "{{integrationOwnerName}}"]'
+    consoleOwners: '[{"email": "{{integrationOwnerEmail}}", "name": "{{integrationOwnerName}}"}]'
     rawTables: '[]'
     transformations: '[]'

--- a/modules/datamodels/cfihos_oil_and_gas_extension/data_sets/data_sets.DataSet.yaml
+++ b/modules/datamodels/cfihos_oil_and_gas_extension/data_sets/data_sets.DataSet.yaml
@@ -1,18 +1,11 @@
 - description: Dataset containing CDF resources that are used for `oil and gas` model
   externalId: "{{dataset_external_id}}"
-  metadata:
-    consoleCreatedBy:
-      username: "{{admin_user}}"
-    consoleGoverned: "{{governed}}"
-    consoleLabels:
-      - OIL AND GAS
-      - DOMAIN MODEL
-      - CFIHOS
-      - ISO 14224
-    consoleOwners:
-      - email: "{{integrationOwnerEmail}}"
-        name: "{{integrationOwnerName}}"
-    rawTables: []
-    transformations: []
   name: "{{dataset_name}}"
   writeProtected: "{{write_protected}}"
+  metadata:
+    consoleCreatedBy: '{"username": "{{admin_user}}"}'
+    consoleGoverned: '{{governed}}'
+    consoleLabels: '["OIL AND GAS", "DOMAIN MODEL", "CFIHOS", "ISO 14224"]'
+    consoleOwners: '["{{integrationOwnerEmail}}", "{{integrationOwnerName}}"]'
+    rawTables: '[]'
+    transformations: '[]'

--- a/modules/packages.toml
+++ b/modules/packages.toml
@@ -137,6 +137,7 @@ description = "Quick-start foundation for CDF projects with modular data models,
 canCherryPick = true
 modules = [
     "datamodels/isa_manufacturing_extension",
+    "datamodels/isa_manufacturing_extension_search",
     "datamodels/cfihos_oil_and_gas_extension",
     "datamodels/cfihos_oil_and_gas_extension_search",
     "sourcesystem/cdf_pi_foundation",

--- a/modules/packages.toml
+++ b/modules/packages.toml
@@ -147,6 +147,7 @@ modules = [
     "common/cdf_project_foundation",
     "contextualization/cdf_file_annotation",
     "contextualization/cdf_entity_matching",
+    "tools/apps/qualitizer",
 ]
 
 [packages.custom]

--- a/modules/sourcesystem/cdf_db_foundation/auth/producer.ep.db.Group.yaml
+++ b/modules/sourcesystem/cdf_db_foundation/auth/producer.ep.db.Group.yaml
@@ -1,0 +1,38 @@
+name: producer-ep-db-{{environment}}
+sourceId: {{extractor_group_source_id}}
+capabilities:
+  - sessionsAcl:
+      actions: [CREATE]
+      scope:
+        all: {}
+  - datasetsAcl:
+      actions: [READ]
+      scope:
+        idScope:
+          ids: ["{{dataset}}"]
+  - rawAcl:
+      actions: [READ, WRITE, LIST]
+      scope:
+        tableScope:
+          dbsToTables:
+            db_postgres: []
+  - dataModelInstancesAcl:
+      actions: [READ, WRITE, WRITE_PROPERTIES]
+      scope:
+        spaceIdScope:
+          spaceIds: ["{{instanceSpace}}"]
+  - extractionPipelinesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionConfigsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionRunsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]

--- a/modules/sourcesystem/cdf_db_foundation/auth/producer.ep.db.Group.yaml
+++ b/modules/sourcesystem/cdf_db_foundation/auth/producer.ep.db.Group.yaml
@@ -15,7 +15,7 @@ capabilities:
       scope:
         tableScope:
           dbsToTables:
-            db_postgres: []
+            db_{{location}}_db_postgres: []
   - dataModelInstancesAcl:
       actions: [READ, WRITE, WRITE_PROPERTIES]
       scope:

--- a/modules/sourcesystem/cdf_db_foundation/default.config.yaml
+++ b/modules/sourcesystem/cdf_db_foundation/default.config.yaml
@@ -16,3 +16,7 @@ integration_owner_email: ""
 # Populated by setup_project.py wizard.
 data_owner_name: ""
 data_owner_email: ""
+# Extractor group source ID — one scoped producer group per extractor.
+extractor_group_source_id: ""
+# Deployment environment — populated per environment by setup_project.py.
+environment: dev

--- a/modules/sourcesystem/cdf_files_foundation/auth/producer.ep.files.Group.yaml
+++ b/modules/sourcesystem/cdf_files_foundation/auth/producer.ep.files.Group.yaml
@@ -1,0 +1,37 @@
+name: producer-ep-files-{{environment}}
+sourceId: {{extractor_group_source_id}}
+capabilities:
+  - sessionsAcl:
+      actions: [CREATE]
+      scope:
+        all: {}
+  - datasetsAcl:
+      actions: [READ]
+      scope:
+        idScope:
+          ids: ["{{dataset}}"]
+  - filesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - dataModelInstancesAcl:
+      actions: [READ, WRITE, WRITE_PROPERTIES]
+      scope:
+        spaceIdScope:
+          spaceIds: ["{{instanceSpace}}"]
+  - extractionPipelinesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionConfigsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionRunsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]

--- a/modules/sourcesystem/cdf_files_foundation/default.config.yaml
+++ b/modules/sourcesystem/cdf_files_foundation/default.config.yaml
@@ -20,3 +20,7 @@ integration_owner_email: ""
 # Populated by setup_project.py wizard.
 data_owner_name: ""
 data_owner_email: ""
+# Extractor group source ID — one scoped producer group per extractor.
+extractor_group_source_id: ""
+# Deployment environment — populated per environment by setup_project.py.
+environment: dev

--- a/modules/sourcesystem/cdf_opcua_foundation/auth/producer.ep.opcua.Group.yaml
+++ b/modules/sourcesystem/cdf_opcua_foundation/auth/producer.ep.opcua.Group.yaml
@@ -15,7 +15,7 @@ capabilities:
       scope:
         tableScope:
           dbsToTables:
-            db_opcua: []
+            db_{{location}}_opcua: []
   - timeSeriesAcl:
       actions: [READ, WRITE]
       scope:

--- a/modules/sourcesystem/cdf_opcua_foundation/auth/producer.ep.opcua.Group.yaml
+++ b/modules/sourcesystem/cdf_opcua_foundation/auth/producer.ep.opcua.Group.yaml
@@ -1,0 +1,43 @@
+name: producer-ep-opcua-{{environment}}
+sourceId: {{extractor_group_source_id}}
+capabilities:
+  - sessionsAcl:
+      actions: [CREATE]
+      scope:
+        all: {}
+  - datasetsAcl:
+      actions: [READ]
+      scope:
+        idScope:
+          ids: ["{{dataset}}"]
+  - rawAcl:
+      actions: [READ, WRITE, LIST]
+      scope:
+        tableScope:
+          dbsToTables:
+            db_opcua: []
+  - timeSeriesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - dataModelInstancesAcl:
+      actions: [READ, WRITE, WRITE_PROPERTIES]
+      scope:
+        spaceIdScope:
+          spaceIds: ["{{instanceSpace}}"]
+  - extractionPipelinesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionConfigsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionRunsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]

--- a/modules/sourcesystem/cdf_opcua_foundation/default.config.yaml
+++ b/modules/sourcesystem/cdf_opcua_foundation/default.config.yaml
@@ -20,3 +20,9 @@ integration_owner_email: ""
 # Populated by setup_project.py wizard.
 data_owner_name: ""
 data_owner_email: ""
+
+# Extractor group source ID — one scoped producer group per extractor.
+extractor_group_source_id: ""
+
+# Deployment environment — populated per environment by setup_project.py.
+environment: dev

--- a/modules/sourcesystem/cdf_pi_foundation/auth/producer.ep.pi.Group.yaml
+++ b/modules/sourcesystem/cdf_pi_foundation/auth/producer.ep.pi.Group.yaml
@@ -1,0 +1,37 @@
+name: producer-ep-pi-{{environment}}
+sourceId: {{extractor_group_source_id}}
+capabilities:
+  - sessionsAcl:
+      actions: [CREATE]
+      scope:
+        all: {}
+  - datasetsAcl:
+      actions: [READ]
+      scope:
+        idScope:
+          ids: ["{{dataset}}"]
+  - timeSeriesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - dataModelInstancesAcl:
+      actions: [READ, WRITE, WRITE_PROPERTIES]
+      scope:
+        spaceIdScope:
+          spaceIds: ["{{instanceSpace}}"]
+  - extractionPipelinesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionConfigsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionRunsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]

--- a/modules/sourcesystem/cdf_pi_foundation/default.config.yaml
+++ b/modules/sourcesystem/cdf_pi_foundation/default.config.yaml
@@ -22,3 +22,9 @@ integration_owner_email: ""
 # Populated by setup_project.py wizard.
 data_owner_name: ""
 data_owner_email: ""
+
+# Extractor group source ID — one scoped producer group per extractor.
+extractor_group_source_id: ""
+
+# Deployment environment — populated per environment by setup_project.py.
+environment: dev

--- a/modules/sourcesystem/cdf_sap_foundation/auth/producer.ep.sap.Group.yaml
+++ b/modules/sourcesystem/cdf_sap_foundation/auth/producer.ep.sap.Group.yaml
@@ -15,7 +15,7 @@ capabilities:
       scope:
         tableScope:
           dbsToTables:
-            db_sap: []
+            db_{{location}}_sap: []
   - dataModelInstancesAcl:
       actions: [READ, WRITE, WRITE_PROPERTIES]
       scope:

--- a/modules/sourcesystem/cdf_sap_foundation/auth/producer.ep.sap.Group.yaml
+++ b/modules/sourcesystem/cdf_sap_foundation/auth/producer.ep.sap.Group.yaml
@@ -1,0 +1,38 @@
+name: producer-ep-sap-{{environment}}
+sourceId: {{extractor_group_source_id}}
+capabilities:
+  - sessionsAcl:
+      actions: [CREATE]
+      scope:
+        all: {}
+  - datasetsAcl:
+      actions: [READ]
+      scope:
+        idScope:
+          ids: ["{{dataset}}"]
+  - rawAcl:
+      actions: [READ, WRITE, LIST]
+      scope:
+        tableScope:
+          dbsToTables:
+            db_sap: []
+  - dataModelInstancesAcl:
+      actions: [READ, WRITE, WRITE_PROPERTIES]
+      scope:
+        spaceIdScope:
+          spaceIds: ["{{instanceSpace}}"]
+  - extractionPipelinesAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionConfigsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]
+  - extractionRunsAcl:
+      actions: [READ, WRITE]
+      scope:
+        datasetScope:
+          ids: ["{{dataset}}"]

--- a/modules/sourcesystem/cdf_sap_foundation/default.config.yaml
+++ b/modules/sourcesystem/cdf_sap_foundation/default.config.yaml
@@ -27,3 +27,9 @@ integration_owner_email: ""
 # Populated by setup_project.py wizard.
 data_owner_name: ""
 data_owner_email: ""
+
+# Extractor group source ID — one scoped producer group per extractor.
+extractor_group_source_id: ""
+
+# Deployment environment — populated per environment by setup_project.py.
+environment: dev

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -7,7 +7,8 @@ Covers:
   - setup_project: group_name, build_foundation_vars, build_overlay,
                    _migrate_staging_to_test, _write_config_fresh,
                    _write_config_update, remove_redundant_auth_files,
-                   patch_cfihos_auth_for_missing_search, _read_existing_values
+                   patch_cfihos_auth_for_missing_search, remove_synthetic_data,
+                   _read_existing_values
 """
 
 from __future__ import annotations
@@ -692,6 +693,88 @@ class TestPatchCfihosAuthForMissingSearch:
         f.write_text("  - cdf_cdm\n  - {{space}}\n")
         patched = patch_cfihos_auth_for_missing_search(tmp_path)
         assert patched == []
+
+
+# ── setup_project — synthetic data removal ────────────────────────────────────
+
+class TestRemoveSyntheticData:
+    """remove_synthetic_data targets only cfihos_oil_and_gas_extension."""
+
+    def _cfihos_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "modules" / "datamodels" / "cfihos_oil_and_gas_extension"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _make_files(self, directory: Path, *names: str) -> list[Path]:
+        directory.mkdir(parents=True, exist_ok=True)
+        files = []
+        for name in names:
+            f = directory / name
+            f.write_text("example")
+            files.append(f)
+        return files
+
+    def test_removes_upload_data(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        self._make_files(cfihos / "upload_data", "data.csv", "manifest.yaml")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 2
+        assert not (cfihos / "upload_data").exists()
+
+    def test_removes_raw(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        self._make_files(cfihos / "raw", "db.Database.yaml")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 1
+        assert not (cfihos / "raw").exists()
+
+    def test_removes_workflows(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        self._make_files(cfihos / "workflows", "example.Workflow.yaml")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 1
+        assert not (cfihos / "workflows").exists()
+
+    def test_removes_transformations(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        self._make_files(cfihos / "transformations", "populate.sql")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 1
+        assert not (cfihos / "transformations").exists()
+
+    def test_removes_all_four_dirs(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        self._make_files(cfihos / "upload_data", "a.csv")
+        self._make_files(cfihos / "raw", "b.yaml")
+        self._make_files(cfihos / "workflows", "c.yaml")
+        self._make_files(cfihos / "transformations", "d.sql")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 4
+        for d in ("upload_data", "raw", "workflows", "transformations"):
+            assert not (cfihos / d).exists()
+
+    def test_no_op_when_cfihos_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        assert remove_synthetic_data(tmp_path) == 0
+
+    def test_idempotent_when_dirs_already_removed(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        self._cfihos_dir(tmp_path)  # module dir exists but no synthetic dirs
+        assert remove_synthetic_data(tmp_path) == 0
+
+    def test_does_not_touch_other_cfihos_dirs(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        self._make_files(cfihos / "data_modeling", "model.datamodel.yaml")
+        self._make_files(cfihos / "auth", "group.yaml")
+        remove_synthetic_data(tmp_path)
+        assert (cfihos / "data_modeling").exists()
+        assert (cfihos / "auth").exists()
 
 
 # ── setup_project — read_existing_values ─────────────────────────────────────

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -303,7 +303,8 @@ class TestBuildFoundationVars:
         from setup_project import build_foundation_vars
         vars_ = build_foundation_vars("isa_manufacturing_extension", "dev", "oslo")
         assert vars_["dataModelVariant"] == "isa_manufacturing_extension"
-        assert vars_["schemaSpace"] == "sp_isa_manufacturing"
+        assert vars_["schemaSpace"] == "dm_dom_isa_manufacturing"
+        assert vars_["instanceSpace"] == "inst_isa_manufacturing"
         assert vars_["site"] == "oslo"
         assert vars_["consumerGroupName"] == "consumer-oslo-dev"
         assert vars_["producerGroupName"] == "producer-oslo-dev"
@@ -328,10 +329,7 @@ class TestBuildOverlay:
         overlay = build_overlay("isa_manufacturing_extension", "dev", "", [])
         mods = overlay["variables"]["modules"]
         assert "cdf_project_foundation" in mods
-        assert "isa_manufacturing_extension" in mods
-        dm = mods["isa_manufacturing_extension"]
-        assert dm["isaSchemaSpace"] == "sp_isa_manufacturing"
-        assert dm["isaInstanceSpace"] == "sp_isa_instance_space"
+        assert "isa_manufacturing_extension" not in mods
 
     def test_cfihos_overlay_has_no_isa_keys(self) -> None:
         from setup_project import build_overlay


### PR DESCRIPTION
  ### What's New
  - **Per-extractor access groups** — scoped `auth/producer.ep.<name>.Group.yaml`
    added to all 5 source system foundation modules (PI, SAP, OPC-UA, DB, Files); wizard prompts for one
    extractor group source ID per module and writes to `.env`
  - **`extractor_group_source_id` and `environment`** added to each source system module's `default.config.yaml`
  - **ISA search variant** — `isa_manufacturing_extension_search` added to `packages.toml`; setup script auto-populates `instance_space` and `environment` when installed alongside `isa_manufacturing_extension`
  - **Synthetic data removal** — wizard prompts to remove `upload_data/`, `raw/`, `workflows/`,
    `transformations/` from `cfihos_oil_and_gas_extension`; shown only when CFIHOS variant selected
  - **`source_name`** in `cdf_entity_matching` now set from the site/location input alongside `location_name`

  ### Documentation
  - **README module links** — all module selection tables now link to each module's README;
    updated to use renamed `datamodels/` path; ISA and CFIHOS solution extensions consolidated into a single table
  - **SOP link** updated to Handbook URL

  ### Tests
  8 new tests in `TestRemoveSyntheticData` covering per-directory removal, no-op when CFIHOS
  absent, idempotency, and non-synthetic dirs left untouched.

Build happened without any consistency error model syntax errors. Some neat validation though which needs to be fixed from Neat side:
<img width="1057" height="818" alt="Screenshot 2026-06-18 at 10 42 52 AM" src="https://github.com/user-attachments/assets/7fbf1485-4356-47b3-9f8e-da61270c10d4" />

Deploy happened without any errors:
<img width="1052" height="694" alt="Screenshot 2026-06-18 at 10 44 13 AM" src="https://github.com/user-attachments/assets/e753345f-0b40-43bb-b4bc-27694b8ba912" />

