### PR TITLE
[Improvement] Foundation DP — Wizard Improvements & Module Cleanup 🧹

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -30,7 +30,7 @@ Ensure the following are in place:
   ```
   See the [Toolkit authentication docs](https://docs.cognite.com/cdf/deploy/cdf_toolkit/guides/auth).
 
-> **Important:** Keep all client IDs and secrets as environment variables — never hardcode them in config files.
+> **Important:** Group source IDs (Entra group object IDs) are stored in `.env` by the setup wizard. Client IDs, client secrets, and other credentials should use interactive or device-code login as per the SOP — never hardcode secrets in config files or `.env`.
 
 ---
 
@@ -43,6 +43,8 @@ cdf modules init
 ```
 
 Select **Foundation Deployment Pack** from the list.
+
+> **Note:** The Toolkit selector shows display titles (e.g. "Foundation Deployment Pack"). The actual module IDs used in config files and referenced in the tables below are the directory names shown in each table (e.g. `cdf_project_foundation`, `isa_manufacturing_extension`).
 
 > **Module selector controls:** use **Space** to select / deselect a module, **Enter** to confirm.
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -457,9 +457,10 @@ def _write_config_update(
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         backup = path.with_suffix(f".{timestamp}.bak")
         shutil.copy2(path, backup)
+    path.write_text("".join(lines))
+    if not skip_backup:
         from _style import _C
         _ok(f"Updated  {path.name}  {_C.DIM}(backup: {backup.name}){_C.RESET}")
-    path.write_text("".join(lines))
     return True
 
 
@@ -1069,7 +1070,7 @@ def _run_wizard(
                 break
             _warn("One or more addresses look invalid. Use format: name@domain.com")
 
-    # ── Synthetic data (CFIHOS only) ─────────────────────────────────────────
+    # ── Synthetic data ────────────────────────────────────────────────────────
     _section("Synthetic / Example Data")
     _hint("Data model modules contain synthetic data, example files, and diagram images")
     _hint("that are not needed in production deployments.")
@@ -1136,13 +1137,11 @@ def _run_wizard(
         env_path.write_text("".join(env_lines))
 
     # ── Delete config files for deselected environments ──────────────────────
-    deleted_envs: list[str] = []
     for env in ENVIRONMENTS:
         if env not in selected_envs:
             path = pack_root / f"config.{env}.yaml"
             if path.exists():
                 path.unlink()
-                deleted_envs.append(path.name)
                 _ok(f"Deleted  {path.name}  (not in selected environments)")
 
     # ── Remove redundant auth files ───────────────────────────────────────────

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -459,9 +459,42 @@ def _write_config_update(path: Path, project: str, overlay: dict) -> bool:
     return True
 
 
+def _replicate_config_from_existing(
+    pack_root: Path, env: str, project: str
+) -> Path | None:
+    """Find an existing config in pack_root and copy it as config.<env>.yaml.
+
+    Updates environment.name and environment.validation-type in-place.
+    Returns the new path if created, None if no source config was found.
+    """
+    # Find any existing config to replicate from
+    source: Path | None = None
+    for candidate_env in ENVIRONMENTS:
+        candidate = pack_root / f"config.{candidate_env}.yaml"
+        if candidate.exists() and candidate_env != env:
+            source = candidate
+            break
+    if source is None:
+        return None
+
+    dest = pack_root / f"config.{env}.yaml"
+    shutil.copy2(source, dest)
+    lines = dest.read_text().splitlines(keepends=True)
+    _yaml_set_value(lines, "environment.name", env)
+    _yaml_set_value(lines, "environment.validation-type", ENVIRONMENT_VALIDATION_TYPE.get(env, "dev"))
+    _yaml_set_value(lines, "environment.project", project)
+    dest.write_text("".join(lines))
+    return dest
+
+
 def write_config(path: Path, env: str, project: str, overlay: dict) -> bool:
     """Create or update a config file. Returns ``True`` if the file changed."""
     if not path.exists():
+        # Try to replicate from an existing env config first; fall back to fresh skeleton.
+        replicated = _replicate_config_from_existing(path.parent, env, project)
+        if replicated:
+            _ok(f"Created  {path.name}  (replicated from existing config)")
+            return _write_config_update(path, project, overlay)
         _write_config_fresh(path, env, project, overlay)
         return True
     return _write_config_update(path, project, overlay)
@@ -538,8 +571,6 @@ def _migrate_staging_to_test(pack_root: Path) -> bool:
 
 # ── Synthetic data removal ────────────────────────────────────────────────────
 
-# Directories in cfihos_oil_and_gas_extension that contain synthetic / example data
-# and should be removed when the user opts out.
 _CFIHOS_SYNTHETIC_DIRS: tuple[str, ...] = (
     "upload_data",
     "raw",
@@ -547,27 +578,54 @@ _CFIHOS_SYNTHETIC_DIRS: tuple[str, ...] = (
     "transformations",
 )
 
+_ISA_SYNTHETIC_DIRS: tuple[str, ...] = (
+    "files",
+    "raw",
+    "transformations",
+    "workflows",
+)
+
+# Image/diagram files to remove from DM modules (not needed in production deployments).
+_DM_IMAGE_PATTERNS: tuple[str, ...] = ("*.png", "*.svg", "*.drawio", "*.ipynb")
+
 
 def remove_synthetic_data(repo_root: Path | None = None) -> int:
-    """Delete synthetic data directories from ``cfihos_oil_and_gas_extension``.
+    """Delete synthetic data directories and diagram files from data model modules.
 
-    Only the CFIHOS DM module contains synthetic/example data (upload_data,
-    raw, workflows, transformations).  No other Foundation DP module requires
-    this cleanup.
+    - CFIHOS: upload_data/, raw/, workflows/, transformations/ + image files
+    - ISA: files/, raw/, transformations/, workflows/ + image files
 
     Returns the total number of files removed.
     """
     data_models_dir = get_data_models_dir(repo_root)
-    cfihos_dir = data_models_dir / "cfihos_oil_and_gas_extension"
-    if not cfihos_dir.is_dir():
-        return 0
-
     total = 0
-    for dir_name in _CFIHOS_SYNTHETIC_DIRS:
-        target = cfihos_dir / dir_name
-        if target.is_dir():
-            total += sum(1 for f in target.rglob("*") if f.is_file())
-            shutil.rmtree(target)
+
+    def _remove_dirs(module_dir: Path, dirs: tuple[str, ...]) -> int:
+        count = 0
+        for dir_name in dirs:
+            target = module_dir / dir_name
+            if target.is_dir():
+                count += sum(1 for f in target.rglob("*") if f.is_file())
+                shutil.rmtree(target)
+        return count
+
+    def _remove_images(module_dir: Path) -> int:
+        count = 0
+        for pattern in _DM_IMAGE_PATTERNS:
+            for f in module_dir.glob(pattern):
+                f.unlink()
+                count += 1
+        return count
+
+    cfihos_dir = data_models_dir / "cfihos_oil_and_gas_extension"
+    if cfihos_dir.is_dir():
+        total += _remove_dirs(cfihos_dir, _CFIHOS_SYNTHETIC_DIRS)
+        total += _remove_images(cfihos_dir)
+
+    isa_dir = data_models_dir / "isa_manufacturing_extension"
+    if isa_dir.is_dir():
+        total += _remove_dirs(isa_dir, _ISA_SYNTHETIC_DIRS)
+        total += _remove_images(isa_dir)
 
     return total
 
@@ -767,6 +825,24 @@ def _prompt_source_system_ownership(
     return integration_owners, data_owners
 
 
+def _cleanup_file_annotation_module(repo_root: Path | None = None) -> None:
+    """Remove developer-facing files from cdf_file_annotation that are not needed
+    in production deployments (CONTRIBUTING.md, DEPLOYMENT.md, detailed_guides/).
+    Runs silently — not reported in the wizard summary.
+    """
+    ctx_dir = get_contextualization_dir(repo_root)
+    fa_dir = ctx_dir / "cdf_file_annotation"
+    if not fa_dir.is_dir():
+        return
+    for name in ("CONTRIBUTING.md", "DEPLOYMENT.md"):
+        f = fa_dir / name
+        if f.exists():
+            f.unlink()
+    guides = fa_dir / "detailed_guides"
+    if guides.is_dir():
+        shutil.rmtree(guides)
+
+
 def _run_cicd_wizard(pack_root: Path) -> list[Path]:
     """Run the CI/CD generation step.  Returns the list of files written (empty if skipped)."""
     _section("CI/CD Pipeline Generation")
@@ -854,6 +930,15 @@ def _run_wizard(
     # Migrate config.staging.yaml → config.test.yaml only when test env is selected.
     if "test" in selected_envs:
         _migrate_staging_to_test(pack_root)
+
+    # Delete config files for environments that are no longer selected.
+    _section("Environment Config Cleanup")
+    for env in ENVIRONMENTS:
+        if env not in selected_envs:
+            path = pack_root / f"config.{env}.yaml"
+            if path.exists():
+                path.unlink()
+                _ok(f"Deleted  {path.name}  (not in selected environments)")
 
     # Load existing values from config files to pre-fill prompts on re-runs.
     existing = _read_existing_values(pack_root, selected_envs, installed_ss)
@@ -986,14 +1071,12 @@ def _run_wizard(
             _warn("One or more addresses look invalid. Use format: name@domain.com")
 
     # ── Synthetic data (CFIHOS only) ─────────────────────────────────────────
-    keep_synthetic = True  # default: keep; only asked for CFIHOS
-    if variant == "cfihos_oil_and_gas_extension":
-        _section("Synthetic / Example Data  (CFIHOS)")
-        _hint("cfihos_oil_and_gas_extension contains synthetic data in upload_data/,")
-        _hint("raw/, workflows/, and transformations/ — not needed in production.")
-        keep_synthetic = prompt_yes_no(
-            "Keep synthetic data and example files?", default=False
-        )
+    _section("Synthetic / Example Data")
+    _hint("Data model modules contain synthetic data, example files, and diagram images")
+    _hint("that are not needed in production deployments.")
+    keep_synthetic = prompt_yes_no(
+        "Keep synthetic data, example files, and diagram images?", default=False
+    )
 
     # ── Review summary ────────────────────────────────────────────────────────
     extractor_dirty = any(
@@ -1056,6 +1139,7 @@ def _run_wizard(
     # ── Remove redundant auth files ───────────────────────────────────────────
     removed = remove_redundant_auth_files(repo_root)
     patched = patch_cfihos_auth_for_missing_search(repo_root)
+    _cleanup_file_annotation_module(repo_root)
 
     # ── Remove synthetic data (if user opted out) ─────────────────────────────
     synthetic_removed = 0

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -399,10 +399,13 @@ def _write_config_fresh(path: Path, env: str, project: str, overlay: dict) -> No
     _ok(f"Created  {path.name}")
 
 
-def _write_config_update(path: Path, project: str, overlay: dict) -> bool:
+def _write_config_update(
+    path: Path, project: str, overlay: dict, skip_backup: bool = False
+) -> bool:
     """Update an existing config file in-place, preserving comments and blank lines.
 
     Returns ``True`` when at least one value changed.
+    Set ``skip_backup=True`` when the file was just created (no prior version to back up).
     """
     lines = path.read_text().splitlines(keepends=True)
     changed = False
@@ -450,12 +453,13 @@ def _write_config_update(path: Path, project: str, overlay: dict) -> bool:
     if not changed:
         return False
 
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    backup = path.with_suffix(f".{timestamp}.bak")
-    shutil.copy2(path, backup)
+    if not skip_backup:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        backup = path.with_suffix(f".{timestamp}.bak")
+        shutil.copy2(path, backup)
+        from _style import _C
+        _ok(f"Updated  {path.name}  {_C.DIM}(backup: {backup.name}){_C.RESET}")
     path.write_text("".join(lines))
-    from _style import _C  # local import avoids circular dependency at module level
-    _ok(f"Updated  {path.name}  {_C.DIM}(backup: {backup.name}){_C.RESET}")
     return True
 
 
@@ -494,7 +498,11 @@ def write_config(path: Path, env: str, project: str, overlay: dict) -> bool:
         replicated = _replicate_config_from_existing(path.parent, env, project)
         if replicated:
             _ok(f"Created  {path.name}  (replicated from existing config)")
-            return _write_config_update(path, project, overlay)
+            # Apply the overlay in-place. Skip backup — the file was just created.
+            # Always return True regardless of whether the overlay changed anything,
+            # since the file itself is new.
+            _write_config_update(path, project, overlay, skip_backup=True)
+            return True
         _write_config_fresh(path, env, project, overlay)
         return True
     return _write_config_update(path, project, overlay)
@@ -931,15 +939,6 @@ def _run_wizard(
     if "test" in selected_envs:
         _migrate_staging_to_test(pack_root)
 
-    # Delete config files for environments that are no longer selected.
-    _section("Environment Config Cleanup")
-    for env in ENVIRONMENTS:
-        if env not in selected_envs:
-            path = pack_root / f"config.{env}.yaml"
-            if path.exists():
-                path.unlink()
-                _ok(f"Deleted  {path.name}  (not in selected environments)")
-
     # Load existing values from config files to pre-fill prompts on re-runs.
     existing = _read_existing_values(pack_root, selected_envs, installed_ss)
     targets = target_config_paths(pack_root, selected_envs)
@@ -1135,6 +1134,16 @@ def _run_wizard(
         else:
             _ok("Created .env")
         env_path.write_text("".join(env_lines))
+
+    # ── Delete config files for deselected environments ──────────────────────
+    deleted_envs: list[str] = []
+    for env in ENVIRONMENTS:
+        if env not in selected_envs:
+            path = pack_root / f"config.{env}.yaml"
+            if path.exists():
+                path.unlink()
+                deleted_envs.append(path.name)
+                _ok(f"Deleted  {path.name}  (not in selected environments)")
 
     # ── Remove redundant auth files ───────────────────────────────────────────
     removed = remove_redundant_auth_files(repo_root)

--- a/modules/sourcesystem/cdf_db_foundation/README.md
+++ b/modules/sourcesystem/cdf_db_foundation/README.md
@@ -11,7 +11,6 @@ cdf_db_foundation/
 │   └── ep_db_postgres.ExtractionPipeline.Config.yaml   # DB Extractor runtime config (queries, ODBC)
 ├── raw/
 │   └── db_postgres.Database.yaml                       # db_{{location}}_db_postgres
-├── default.config.yaml
 └── module.toml
 ```
 
@@ -35,7 +34,7 @@ DB Extractor
 
 ## Configuration
 
-All variables are declared locally in `default.config.yaml` (no inheritance):
+All variables are declared locally in `config.<env>.yaml` (no inheritance):
 
 ```yaml
 variables:

--- a/modules/sourcesystem/cdf_files_foundation/README.md
+++ b/modules/sourcesystem/cdf_files_foundation/README.md
@@ -9,7 +9,6 @@ cdf_files_foundation/
 ├── extraction_pipelines/
 │   ├── ep_files_sharepoint.ExtractionPipeline.yaml         # Pipeline definition (contacts, schedule, source)
 │   └── ep_files_sharepoint.ExtractionPipeline.Config.yaml  # Files Extractor runtime config (file provider, paths, filters)
-├── default.config.yaml
 └── module.toml
 ```
 
@@ -38,7 +37,7 @@ Files Extractor   (destination-mode: cdm)
 
 ## Configuration
 
-All variables are declared locally in `default.config.yaml` (no inheritance):
+All variables are declared locally in `config.<env>.yaml` (no inheritance):
 
 ```yaml
 variables:

--- a/modules/sourcesystem/cdf_opcua_foundation/README.md
+++ b/modules/sourcesystem/cdf_opcua_foundation/README.md
@@ -14,7 +14,6 @@ cdf_opcua_foundation/
 │   └── ep_opcua.ExtractionPipeline.Config.yaml   # Full OPC-UA Extractor config template
 ├── raw/
 │   └── db_opcua.Database.yaml                    # db_{{location}}_opcua
-├── default.config.yaml
 └── module.toml
 ```
 
@@ -48,7 +47,7 @@ OPC-UA Extractor
 
 ## Configuration
 
-All variables are declared locally in `default.config.yaml` (no inheritance):
+All variables are declared locally in `config.<env>.yaml` (no inheritance):
 
 ```yaml
 variables:

--- a/modules/sourcesystem/cdf_pi_foundation/README.md
+++ b/modules/sourcesystem/cdf_pi_foundation/README.md
@@ -9,7 +9,6 @@ cdf_pi_foundation/
 ├── extraction_pipelines/
 │   ├── ep_pi.ExtractionPipeline.yaml          # Pipeline definition (contacts, schedule, source)
 │   └── ep_pi.ExtractionPipeline.Config.yaml   # Full PI .NET Extractor config template (CDM destination)
-├── default.config.yaml
 └── module.toml
 ```
 
@@ -33,7 +32,7 @@ PI .NET Extractor   (time-series.space-id: {{instanceSpace}})
 
 ## Configuration
 
-All variables are declared locally in `default.config.yaml` (no inheritance):
+All variables are declared locally in `config.<env>.yaml` (no inheritance):
 
 ```yaml
 variables:

--- a/modules/sourcesystem/cdf_sap_foundation/README.md
+++ b/modules/sourcesystem/cdf_sap_foundation/README.md
@@ -18,7 +18,6 @@ cdf_sap_foundation/
 │   ├── worktask.Table.yaml                     # SAP ExOperationsSet  (operations, daily)
 │   ├── workitem.Table.yaml                     # SAP ExNotifheader    (notifications, daily)
 │   └── state_store.Table.yaml                  # Extractor state (managed by extractor)
-├── default.config.yaml
 └── module.toml
 ```
 
@@ -50,7 +49,7 @@ SAP OData Extractor (single pipeline, 6 entity queries)
 
 ## Configuration
 
-All variables are declared locally in `default.config.yaml` (no inheritance):
+All variables are declared locally in `config.<env>.yaml` (no inheritance):
 
 ```yaml
 variables:

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -696,7 +696,7 @@ class TestPatchCfihosAuthForMissingSearch:
 # ── setup_project — synthetic data removal ────────────────────────────────────
 
 class TestRemoveSyntheticData:
-    """remove_synthetic_data targets only cfihos_oil_and_gas_extension."""
+    """remove_synthetic_data covers cfihos_oil_and_gas_extension and isa_manufacturing_extension."""
 
     def _cfihos_dir(self, tmp_path: Path) -> Path:
         d = tmp_path / "modules" / "datamodels" / "cfihos_oil_and_gas_extension"
@@ -773,6 +773,129 @@ class TestRemoveSyntheticData:
         remove_synthetic_data(tmp_path)
         assert (cfihos / "data_modeling").exists()
         assert (cfihos / "auth").exists()
+
+    # ── ISA DM cleanup ────────────────────────────────────────────────────────
+
+    def _isa_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "modules" / "datamodels" / "isa_manufacturing_extension"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_isa_removes_files_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        isa = self._isa_dir(tmp_path)
+        self._make_files(isa / "files", "sample.pdf")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 1
+        assert not (isa / "files").exists()
+
+    def test_isa_removes_raw(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        isa = self._isa_dir(tmp_path)
+        self._make_files(isa / "raw", "db.Database.yaml")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 1
+        assert not (isa / "raw").exists()
+
+    def test_isa_removes_transformations_and_workflows(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        isa = self._isa_dir(tmp_path)
+        self._make_files(isa / "transformations", "tr.sql")
+        self._make_files(isa / "workflows", "wf.yaml")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 2
+        assert not (isa / "transformations").exists()
+        assert not (isa / "workflows").exists()
+
+    def test_isa_no_op_when_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        assert remove_synthetic_data(tmp_path) == 0
+
+    # ── Image / diagram file removal ──────────────────────────────────────────
+
+    def test_removes_png_from_cfihos(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        (cfihos / "data_model_views.png").write_text("img")
+        (cfihos / "dm-workflow.png").write_text("img")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 2
+        assert not (cfihos / "data_model_views.png").exists()
+        assert not (cfihos / "dm-workflow.png").exists()
+
+    def test_removes_svg_from_isa(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        isa = self._isa_dir(tmp_path)
+        (isa / "diagram.svg").write_text("svg")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 1
+        assert not (isa / "diagram.svg").exists()
+
+    def test_removes_images_from_both_modules(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        cfihos = self._cfihos_dir(tmp_path)
+        isa = self._isa_dir(tmp_path)
+        (cfihos / "model.png").write_text("img")
+        (isa / "isa.png").write_text("img")
+        count = remove_synthetic_data(tmp_path)
+        assert count == 2
+
+    def test_data_modeling_dir_not_touched(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        isa = self._isa_dir(tmp_path)
+        self._make_files(isa / "data_modeling", "model.datamodel.yaml")
+        remove_synthetic_data(tmp_path)
+        assert (isa / "data_modeling").exists()
+
+
+# ── setup_project — replicate config from existing ───────────────────────────
+
+class TestReplicateConfigFromExisting:
+    def _write_config(self, path: Path, env: str, project: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            f"environment:\n  name: {env}\n  project: {project}\n"
+            "  validation-type: dev\n  selected:\n  - modules\n"
+            "variables:\n  modules:\n    cdf_project_foundation:\n      site: oslo\n"
+        )
+
+    def test_happy_path_replicates_and_patches(self, tmp_path: Path) -> None:
+        import yaml as _yaml
+        from setup_project import ENVIRONMENT_VALIDATION_TYPE, _replicate_config_from_existing
+        
+        self._write_config(tmp_path / "config.dev.yaml", "dev", "acme-dev")
+        result = _replicate_config_from_existing(tmp_path, "prod", "acme-prod")
+        assert result is not None
+        assert result == tmp_path / "config.prod.yaml"
+        assert result.exists()
+        data = _yaml.safe_load(result.read_text())
+        assert data["environment"]["name"] == "prod"
+        assert data["environment"]["project"] == "acme-prod"
+        assert data["environment"]["validation-type"] == ENVIRONMENT_VALIDATION_TYPE["prod"]
+
+    def test_preserves_existing_variables(self, tmp_path: Path) -> None:
+        from setup_project import _replicate_config_from_existing
+        self._write_config(tmp_path / "config.dev.yaml", "dev", "acme-dev")
+        result = _replicate_config_from_existing(tmp_path, "test", "acme-test")
+        assert result is not None
+        content = result.read_text()
+        # Variables section from source should be preserved
+        assert "site: oslo" in content
+
+    def test_no_source_returns_none(self, tmp_path: Path) -> None:
+        from setup_project import _replicate_config_from_existing
+        # No existing configs at all
+        result = _replicate_config_from_existing(tmp_path, "prod", "acme-prod")
+        assert result is None
+        assert not (tmp_path / "config.prod.yaml").exists()
+
+    def test_does_not_replicate_from_same_env(self, tmp_path: Path) -> None:
+        from setup_project import _replicate_config_from_existing
+        # Only config.prod.yaml exists — must not use it as source for prod itself
+        self._write_config(tmp_path / "config.prod.yaml", "prod", "acme-prod")
+        result = _replicate_config_from_existing(tmp_path, "prod", "acme-prod-new")
+        # Should return None since the only existing file is the target env itself
+        assert result is None
 
 
 # ── setup_project — read_existing_values ─────────────────────────────────────


### PR DESCRIPTION
  ### Wizard: Environment Lifecycle Management
  - **Delete unused env configs** — after environment selection, config files for
    deselected environments are automatically removed (e.g. selecting dev-only
    deletes `config.test.yaml` and `config.prod.yaml`)
  - **Replicate existing config for new envs** — when a newly-selected environment
    has no config file, the wizard replicates an existing config and patches
    `environment.name`, `environment.validation-type`, and `environment.project`
    rather than creating a bare skeleton

  ### Wizard: Extended Synthetic Data Cleanup
  - **ISA DM cleanup added** — `remove_synthetic_data` now covers both data model
    variants; ISA removes `files/`, `raw/`, `transformations/`, `workflows/`; CFIHOS
    removes `upload_data/`, `raw/`, `workflows/`, `transformations/`
  - **Diagram/image files removed** — `*.png`, `*.svg`, `*.drawio`, `*.ipynb` files
    are deleted from both DM module roots
  - Prompt is now shown for all variants (was previously CFIHOS-only)

  ### Wizard: File Annotation Module Cleanup
  - `CONTRIBUTING.md`, `DEPLOYMENT.md`, and `detailed_guides/` are silently removed
    from `cdf_file_annotation` when present — not reported in the Done summary

  ### README Updates
  - **`.env` guidance corrected** — replaced "keep client IDs and secrets as env vars"
    with precise guidance: group source IDs (Entra ID object IDs) go to `.env` via the
    wizard; credentials use interactive/device-code login per SOP — never hardcoded
  - **Toolkit menu alignment** — added callout in Step 1 clarifying that the Toolkit
    selector shows display titles while the actual module IDs match the directory names
    in the selection tables
  - **SS module READMEs** — updated "variables declared in `default.config.yaml`" →
    `config.<env>.yaml` across all 5 source system foundation modules, since Toolkit
    deletes `default.config.yaml` after consuming it