### PR TITLE
[Improvement] Foundation DP — Wizard UX, Cleanup & README Improvements 🛠️

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -90,7 +90,9 @@ The module selector presents all available modules. Make selections carefully:
 
 **Common module** — always include:
 
-- `cdf_project_foundation` ← this module (access groups, extractor groups, setup wizard)
+| Module | Description |
+|--------|-------------|
+| `cdf_project_foundation` | This module — persona access groups, per-extractor groups, and the interactive setup wizard. |
 
 **Project observability** — recommended:
 
@@ -102,7 +104,11 @@ The module selector presents all available modules. Make selections carefully:
 
 ### Step 3 — Run the setup wizard
 
-From the Toolkit project root, run the interactive setup wizard. It prompts for CDF project names, site/location, Entra ID group source IDs, source system owner contacts, and ApplicationOwner (if file annotation is installed), then writes all `config.<env>.yaml` files and `.env` in one pass:
+From the Toolkit project root, run the interactive setup wizard. It prompts for CDF project names, site/location, Entra ID group source IDs, source system owner contacts, and ApplicationOwner (if file annotation is installed), then writes all `config.<env>.yaml` files and `.env` in one pass.
+
+> **Environment selection — first prompt:** Toolkit creates `dev`, `prod`, and `staging` (= test) config files during `cdf modules init`. The wizard detects these and asks:
+> *"You selected dev and prod while installing the DP. Continue with current selection (dev, prod)?"*
+> Answer **Y** to proceed with the detected environments, or **N** to modify the selection. Config files for deselected environments are removed after you confirm all changes.
 
 ```bash
 python modules/common/cdf_project_foundation/scripts/setup_project.py

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -9,7 +9,7 @@ The **Foundation Deployment Pack** (`dp:foundation`) is the recommended starting
 - **Highly extensible** — simple to plug in your own data sources and processing logic
 - **Reliable** — everything included works out of the box
 
-This module provides the **project-level foundation** of the pack: three persona-based access groups and a project setup wizard, aligned with the [project-setup SOP](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup).
+This module provides the **project-level foundation** of the pack: three persona-based access groups and a project setup wizard, aligned with the [project-setup SOP](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G)).*
 
 ---
 
@@ -17,7 +17,7 @@ This module provides the **project-level foundation** of the pack: three persona
 
 ### Step 0 — Prerequisites
 
-> 📖 Before starting, read the [project-setup SOP](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup) — it is required reading before any deployment step.
+> 📖 Before starting, read the [project-setup SOP](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G))* — it is required reading before any deployment step.
 
 Ensure the following are in place:
 
@@ -291,7 +291,7 @@ adminSourceId: "${ADMIN_SOURCE_ID}"
 
 Self-contained. The group ACLs reference `{{ dataset }}`, `{{ instanceSpace }}`, and `{{ schemaSpace }}`, which must match the values used by the deployed source-system and data-model modules.
 
-See the [project-setup SOP](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup) for the authoritative procedure covering environments, Entra ID integration, CI/CD, and sign-off.
+See the [project-setup SOP](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G))* for the authoritative procedure covering environments, Entra ID integration, CI/CD, and sign-off.
 
 ---
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -912,29 +912,51 @@ def _run_wizard(
 
     # ── Environment selection ─────────────────────────────────────────────────
     _section("Environment Selection")
-    print("  Which environments would you like to set up?\n")
-    choice = prompt_choice(
-        [
-            "All three — dev, test, prod  (recommended)",
-            "dev only",
-            "dev + prod  (skip test / staging)",
-            "Custom — choose individually",
-        ],
-        default=1,
-    )
-    if choice == 1:
-        selected_envs: tuple[str, ...] = ("dev", "test", "prod")
-    elif choice == 2:
-        selected_envs = ("dev",)
-    elif choice == 3:
-        selected_envs = ("dev", "prod")
+    installed_envs = _detect_installed_envs(pack_root)
+
+    if installed_envs:
+        # Environments already set up by Toolkit — confirm or let user modify.
+        env_list = ", ".join(installed_envs)
+        _hint(f"You selected {env_list} while installing the DP.")
+        _hint("(staging = test; dev/prod/test are the three supported environments.)")
+        print()
+        if prompt_yes_no(
+            f"  Continue with current selection ({env_list})?", default=True
+        ):
+            selected_envs: tuple[str, ...] = installed_envs
+        else:
+            _hint("Select which environments to set up:")
+            selected_envs = tuple(
+                env for env in ENVIRONMENTS
+                if prompt_yes_no(f"  Include '{env}'?", default=(env in installed_envs))
+            )
+            if not selected_envs:
+                raise SystemExit("No environments selected — nothing to do.")
     else:
-        selected_envs = tuple(
-            env for env in ENVIRONMENTS
-            if prompt_yes_no(f"  Include environment '{env}'?", default=True)
+        # No existing configs — show full selection prompt.
+        print("  Which environments would you like to set up?\n")
+        choice = prompt_choice(
+            [
+                "All three — dev, test, prod  (recommended)",
+                "dev only",
+                "dev + prod  (skip test / staging)",
+                "Custom — choose individually",
+            ],
+            default=1,
         )
-        if not selected_envs:
-            raise SystemExit("No environments selected — nothing to do.")
+        if choice == 1:
+            selected_envs = ("dev", "test", "prod")
+        elif choice == 2:
+            selected_envs = ("dev",)
+        elif choice == 3:
+            selected_envs = ("dev", "prod")
+        else:
+            selected_envs = tuple(
+                env for env in ENVIRONMENTS
+                if prompt_yes_no(f"  Include environment '{env}'?", default=True)
+            )
+            if not selected_envs:
+                raise SystemExit("No environments selected — nothing to do.")
 
     # Migrate config.staging.yaml → config.test.yaml only when test env is selected.
     if "test" in selected_envs:
@@ -1245,6 +1267,21 @@ def check_config_file(
         if actual != expected_value:
             errors.append(f"    {dotted}: got {actual!r}, expected {expected_value!r}")
     return errors
+
+
+def _detect_installed_envs(pack_root: Path) -> tuple[str, ...]:
+    """Return the environments that already have a config file in pack_root.
+
+    ``config.staging.yaml`` is treated as the test environment (Toolkit uses
+    'staging' as the name; the Foundation DP normalises it to 'test').
+    """
+    detected: list[str] = []
+    for env in ENVIRONMENTS:
+        if (pack_root / f"config.{env}.yaml").exists():
+            detected.append(env)
+        elif env == "test" and (pack_root / "config.staging.yaml").exists():
+            detected.append(env)
+    return tuple(detected)
 
 
 def _read_check_context(pack_root: Path) -> tuple[str, list[str]]:

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -700,6 +700,9 @@ def _read_existing_values(
     }
     for env in envs:
         path = pack_root / f"config.{env}.yaml"
+        # For test, fall back to config.staging.yaml if migration hasn't run yet.
+        if not path.exists() and env == "test":
+            path = pack_root / "config.staging.yaml"
         if not path.exists():
             continue
         cfg = load_yaml(path)
@@ -958,17 +961,8 @@ def _run_wizard(
             if not selected_envs:
                 raise SystemExit("No environments selected — nothing to do.")
 
-    # Migrate config.staging.yaml → config.test.yaml when test is selected;
-    # remove it when test is not selected so it doesn't linger as an orphan.
-    if "test" in selected_envs:
-        _migrate_staging_to_test(pack_root)
-    else:
-        staging_path = pack_root / "config.staging.yaml"
-        if staging_path.exists():
-            staging_path.unlink()
-            _ok("Deleted  config.staging.yaml  (test not in selected environments)")
-
     # Load existing values from config files to pre-fill prompts on re-runs.
+    # _read_existing_values falls back to config.staging.yaml for test if needed.
     existing = _read_existing_values(pack_root, selected_envs, installed_ss)
     targets = target_config_paths(pack_root, selected_envs)
 
@@ -1163,6 +1157,16 @@ def _run_wizard(
         else:
             _ok("Created .env")
         env_path.write_text("".join(env_lines))
+
+    # ── Staging migration / cleanup (after confirmation) ─────────────────────
+    # Done here — not before prompts — so no file is touched if the user aborts.
+    if "test" in selected_envs:
+        _migrate_staging_to_test(pack_root)
+    else:
+        staging_path = pack_root / "config.staging.yaml"
+        if staging_path.exists():
+            staging_path.unlink()
+            _ok("Deleted  config.staging.yaml  (test not in selected environments)")
 
     # ── Delete config files for deselected environments ──────────────────────
     for env in ENVIRONMENTS:

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -890,6 +890,21 @@ def _run_cicd_wizard(pack_root: Path) -> list[Path]:
 
 # ── Main wizard ────────────────────────────────────────────────────────────────
 
+def _detect_installed_envs(pack_root: Path) -> tuple[str, ...]:
+    """Return the environments that already have a config file in pack_root.
+
+    ``config.staging.yaml`` is treated as the test environment (Toolkit uses
+    'staging' as the name; the Foundation DP normalises it to 'test').
+    """
+    detected: list[str] = []
+    for env in ENVIRONMENTS:
+        if (pack_root / f"config.{env}.yaml").exists():
+            detected.append(env)
+        elif env == "test" and (pack_root / "config.staging.yaml").exists():
+            detected.append(env)
+    return tuple(detected)
+
+
 def _run_wizard(
     args_variant: str | None,
     args_yes: bool,
@@ -1277,21 +1292,6 @@ def check_config_file(
         if actual != expected_value:
             errors.append(f"    {dotted}: got {actual!r}, expected {expected_value!r}")
     return errors
-
-
-def _detect_installed_envs(pack_root: Path) -> tuple[str, ...]:
-    """Return the environments that already have a config file in pack_root.
-
-    ``config.staging.yaml`` is treated as the test environment (Toolkit uses
-    'staging' as the name; the Foundation DP normalises it to 'test').
-    """
-    detected: list[str] = []
-    for env in ENVIRONMENTS:
-        if (pack_root / f"config.{env}.yaml").exists():
-            detected.append(env)
-        elif env == "test" and (pack_root / "config.staging.yaml").exists():
-            detected.append(env)
-    return tuple(detected)
 
 
 def _read_check_context(pack_root: Path) -> tuple[str, list[str]]:

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -958,9 +958,15 @@ def _run_wizard(
             if not selected_envs:
                 raise SystemExit("No environments selected — nothing to do.")
 
-    # Migrate config.staging.yaml → config.test.yaml only when test env is selected.
+    # Migrate config.staging.yaml → config.test.yaml when test is selected;
+    # remove it when test is not selected so it doesn't linger as an orphan.
     if "test" in selected_envs:
         _migrate_staging_to_test(pack_root)
+    else:
+        staging_path = pack_root / "config.staging.yaml"
+        if staging_path.exists():
+            staging_path.unlink()
+            _ok("Deleted  config.staging.yaml  (test not in selected environments)")
 
     # Load existing values from config files to pre-fill prompts on re-runs.
     existing = _read_existing_values(pack_root, selected_envs, installed_ss)

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -2,7 +2,7 @@
 
 Generated from committed Toolkit environment configs.
 
-This follows the [CDF Foundation Setup guide](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup) Step 5.
+This follows the [CDF Foundation Setup guide](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G))* — Step 5.
 
 ## Branching model
 

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -2,7 +2,7 @@
 
 Generated from committed Toolkit environment configs.
 
-This follows [sop-cdf-project-setup.md](https://github.com/cognitedata/library/blob/main/sop-cdf-project-setup.md) Step 5.
+This follows the [CDF Foundation Setup guide](https://cogdocs-feat-cdf-project-setup-docs.mintlify.app/gvd/cdf-project-setup/cdf-foundation-setup) Step 5.
 
 ## Branching model
 

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -1016,6 +1016,59 @@ class TestReadExistingValues:
         assert existing["dataset"] == []
 
 
+# ── setup_project — detect installed envs ────────────────────────────────────
+
+class TestDetectInstalledEnvs:
+    def test_returns_empty_when_no_configs(self, tmp_path: Path) -> None:
+        from setup_project import _detect_installed_envs
+        assert _detect_installed_envs(tmp_path) == ()
+
+    def test_detects_single_env(self, tmp_path: Path) -> None:
+        from setup_project import _detect_installed_envs
+        (tmp_path / "config.dev.yaml").write_text("environment:\n  name: dev\n")
+        assert _detect_installed_envs(tmp_path) == ("dev",)
+
+    def test_detects_dev_and_prod(self, tmp_path: Path) -> None:
+        from setup_project import _detect_installed_envs
+        (tmp_path / "config.dev.yaml").write_text("environment:\n  name: dev\n")
+        (tmp_path / "config.prod.yaml").write_text("environment:\n  name: prod\n")
+        result = _detect_installed_envs(tmp_path)
+        assert "dev" in result
+        assert "prod" in result
+        assert "test" not in result
+
+    def test_detects_all_three(self, tmp_path: Path) -> None:
+        from setup_project import _detect_installed_envs
+        for env in ("dev", "test", "prod"):
+            (tmp_path / f"config.{env}.yaml").write_text(f"environment:\n  name: {env}\n")
+        result = _detect_installed_envs(tmp_path)
+        assert set(result) == {"dev", "test", "prod"}
+
+    def test_staging_maps_to_test(self, tmp_path: Path) -> None:
+        from setup_project import _detect_installed_envs
+        (tmp_path / "config.dev.yaml").write_text("environment:\n  name: dev\n")
+        (tmp_path / "config.staging.yaml").write_text("environment:\n  name: staging\n")
+        result = _detect_installed_envs(tmp_path)
+        assert "test" in result
+        assert "staging" not in result
+
+    def test_staging_not_returned_when_test_config_exists(self, tmp_path: Path) -> None:
+        from setup_project import _detect_installed_envs
+        (tmp_path / "config.test.yaml").write_text("environment:\n  name: test\n")
+        (tmp_path / "config.staging.yaml").write_text("environment:\n  name: staging\n")
+        result = _detect_installed_envs(tmp_path)
+        # test appears once, not twice
+        assert result.count("test") == 1
+
+    def test_preserves_environment_order(self, tmp_path: Path) -> None:
+        from setup_project import _detect_installed_envs
+        for env in ("prod", "dev", "test"):  # write in non-canonical order
+            (tmp_path / f"config.{env}.yaml").write_text(f"environment:\n  name: {env}\n")
+        result = _detect_installed_envs(tmp_path)
+        # Should always follow ENVIRONMENTS order: dev, test, prod
+        assert result == ("dev", "test", "prod")
+
+
 # ── setup_project — .env path resolution ─────────────────────────────────────
 
 class TestGetOrgDirName:


### PR DESCRIPTION
  ### Wizard
  - **Smart env selection** — detects envs from existing configs and asks *"You selected dev and prod while installing the DP. Continue with current selection?"* instead of always showing the full menu; falls back to full menu on first
  install

  ### README
  - Step 3 updated to explain env selection is a confirmation of what was set up during Toolkit init
  - Common module (`cdf_project_foundation`) now in table format consistent with all other modules
  - CI/CD guide template: SOP link updated to Mintlify URL

  ### Tests
  - 19 new tests covering `_detect_installed_envs`, `TestRemoveSyntheticData` (ISA + image removal), and `TestReplicateConfigFromExisting`

<img width="949" height="150" alt="Screenshot 2026-06-24 at 1 45 08 PM" src="https://github.com/user-attachments/assets/896299f1-7fa5-42ca-817a-55043394bf18" />
