### PR TITLE
fix: rename Quickstart DP and fix P&ID annotation workflow config

### DIFF
--- a/modules/contextualization/cdf_p_and_id_annotation/default.config.yaml
+++ b/modules/contextualization/cdf_p_and_id_annotation/default.config.yaml
@@ -21,7 +21,7 @@ assetInstanceSpace: springfield_instances
 functionClientId: ${IDP_CLIENT_ID}
 functionClientSecret: ${IDP_CLIENT_SECRET}
 
-workflow: entity_matching
+workflow: p_and_id_annotation
 
 # source ID from Entra ID for the corresponding groups, ex 'c74797ce-9191-4a4a-9186-8fe21c54c3de'
 files_location_processing_group_source_id: <not set>

--- a/modules/packages.toml
+++ b/modules/packages.toml
@@ -29,7 +29,7 @@ modules = [
 [packages.quickstartdp]
 id = "dp:quickstart"
 title = "Foundation Deployment Pack Demo"
-description = "Showcase end-to-end CDF: ingestion, contextualization, and dashboards. Use this to explore the platform; for production deployments use the Foundation Deployment Pack."
+description = "Showcase end-to-end CDF: ingestion, contextualization, and dashboards. Use this to explore CDF; for production deployments use the Foundation Deployment Pack."
 canCherryPick = false
 modules = [
     "common/cdf_common",

--- a/modules/packages.toml
+++ b/modules/packages.toml
@@ -28,8 +28,8 @@ modules = [
 
 [packages.quickstartdp]
 id = "dp:quickstart"
-title = "Quickstart Deployment Pack"
-description = "Showcase end-to-end CDF: ingestion, contextualization, and dashboards."
+title = "Foundation Deployment Pack Demo"
+description = "Showcase end-to-end CDF: ingestion, contextualization, and dashboards. Use this to explore the platform; for production deployments use the Foundation Deployment Pack."
 canCherryPick = false
 modules = [
     "common/cdf_common",


### PR DESCRIPTION
**Summary**:

- Renamed the Quickstart Deployment Pack to "Foundation Deployment Pack Demo" and updated the description to clarify it's for exploration, not production
- Fixed incorrect workflow value in cdf_p_and_id_annotation/default.config.yaml — was pointing to entity_matching, corrected to p_and_id_annotation
