### PR TITLE
fix(sourcesystem): escape template vars and fix doc links in extraction pipeline configs

### DIFF
--- a/modules/sourcesystem/cdf_db_extractor/extraction_pipelines/ep_db_postgres.ExtractionPipeline.yaml
+++ b/modules/sourcesystem/cdf_db_extractor/extraction_pipelines/ep_db_postgres.ExtractionPipeline.yaml
@@ -24,6 +24,10 @@ notificationConfig:
   # DB Extractor runs queries on a schedule; alert if not seen for >2 hours
   allowedNotSeenRangeInMinutes: 120
 createdBy: cognite-toolkit
+# The sample config.yml below uses $${VAR} (not ${VAR}): Toolkit substitutes ${VAR} from
+# .env anywhere in this file, so a single $ would leak real secret values into the
+# deployed pipeline's documentation. $${VAR} renders as literal ${VAR}, which is what the
+# extractor host should read from its own environment.
 documentation: |
   ## Database (DB Extractor) extraction pipeline
 
@@ -69,14 +73,14 @@ documentation: |
      version: 1
      type: remote
      cognite:
-       project: ${CDF_PROJECT}
-       host: ${CDF_URL}
+       project: $${CDF_PROJECT}
+       host: $${CDF_URL}
        idp-authentication:
-         tenant: ${IDP_TENANT_ID}
-         client-id: ${IDP_CLIENT_ID}
-         secret: ${IDP_CLIENT_SECRET}
+         tenant: $${IDP_TENANT_ID}
+         client-id: $${IDP_CLIENT_ID}
+         secret: $${IDP_CLIENT_SECRET}
          scopes:
-           - ${CDF_URL}/.default
+           - $${CDF_URL}/.default
        extraction-pipeline:
          pipeline-id: ep_{{location}}_db_postgres
      ```

--- a/modules/sourcesystem/cdf_files_extractor/README.md
+++ b/modules/sourcesystem/cdf_files_extractor/README.md
@@ -129,6 +129,6 @@ Check that uploaded documents appear under the `{{dataset}}` data set in CDF Dat
 
 ## References
 
-* Files Extractor docs: <https://docs.cognite.com/cdf/integration/guides/extraction/files_extractor/>
-* Files Extractor configuration reference: <https://docs.cognite.com/cdf/integration/guides/extraction/configuration/files_extractor>
+* Files Extractor docs: <https://docs.cognite.com/cdf/integration/guides/extraction/file>
+* Files Extractor configuration reference: <https://docs.cognite.com/cdf/integration/guides/extraction/configuration/file-extractor>
 * SharePoint setup guide: <https://docs.cognite.com/cdf/integration/guides/extraction/file/file_sharepoint_setup>

--- a/modules/sourcesystem/cdf_files_extractor/extraction_pipelines/ep_files_sharepoint.ExtractionPipeline.yaml
+++ b/modules/sourcesystem/cdf_files_extractor/extraction_pipelines/ep_files_sharepoint.ExtractionPipeline.yaml
@@ -21,6 +21,10 @@ notificationConfig:
   # Files Extractor runs on a schedule; alert if not seen for >2 hours
   allowedNotSeenRangeInMinutes: 120
 createdBy: cognite-toolkit
+# The sample config.yml below uses $${VAR} (not ${VAR}): Toolkit substitutes ${VAR} from
+# .env anywhere in this file, so a single $ would leak real secret values into the
+# deployed pipeline's documentation. $${VAR} renders as literal ${VAR}, which is what the
+# extractor host should read from its own environment.
 documentation: |
   ## SharePoint Online (Files Extractor) extraction pipeline
 
@@ -73,20 +77,20 @@ documentation: |
      version: 1
      type: remote
      cognite:
-       project: ${CDF_PROJECT}
-       host: ${CDF_URL}
+       project: $${CDF_PROJECT}
+       host: $${CDF_URL}
        idp-authentication:
-         tenant: ${IDP_TENANT_ID}
-         client-id: ${IDP_CLIENT_ID}
-         secret: ${IDP_CLIENT_SECRET}
+         tenant: $${IDP_TENANT_ID}
+         client-id: $${IDP_CLIENT_ID}
+         secret: $${IDP_CLIENT_SECRET}
          scopes:
-           - ${CDF_URL}/.default
+           - $${CDF_URL}/.default
        extraction-pipeline:
          pipeline-id: ep_{{location}}_files_sharepoint
      ```
 
   ### References
 
-  * Files Extractor docs: <https://docs.cognite.com/cdf/integration/guides/extraction/files_extractor/>
-  * Files Extractor configuration reference: <https://docs.cognite.com/cdf/integration/guides/extraction/configuration/files_extractor>
+  * Files Extractor docs: <https://docs.cognite.com/cdf/integration/guides/extraction/file>
+  * Files Extractor configuration reference: <https://docs.cognite.com/cdf/integration/guides/extraction/configuration/file-extractor>
   * SharePoint setup guide: <https://docs.cognite.com/cdf/integration/guides/extraction/file/file_sharepoint_setup>

--- a/modules/sourcesystem/cdf_opcua_extractor/extraction_pipelines/ep_opcua.ExtractionPipeline.yaml
+++ b/modules/sourcesystem/cdf_opcua_extractor/extraction_pipelines/ep_opcua.ExtractionPipeline.yaml
@@ -40,6 +40,10 @@ notificationConfig:
   allowedNotSeenRangeInMinutes: 30
 source: OPCUA
 createdBy: cognite-toolkit
+# The sample config.yml below uses $${VAR} (not ${VAR}): Toolkit substitutes ${VAR} from
+# .env anywhere in this file, so a single $ would leak real secret values into the
+# deployed pipeline's documentation. $${VAR} renders as literal ${VAR}, which is what the
+# extractor host should read from its own environment.
 documentation: |
   ## OPC-UA extraction pipeline
 
@@ -80,14 +84,14 @@ documentation: |
      version: 1
      type: remote
      cognite:
-       project: ${CDF_PROJECT}
-       host: ${CDF_URL}
+       project: $${CDF_PROJECT}
+       host: $${CDF_URL}
        idp-authentication:
-         tenant: ${IDP_TENANT_ID}
-         client-id: ${IDP_CLIENT_ID}
-         secret: ${IDP_CLIENT_SECRET}
+         tenant: $${IDP_TENANT_ID}
+         client-id: $${IDP_CLIENT_ID}
+         secret: $${IDP_CLIENT_SECRET}
          scopes:
-           - ${CDF_URL}/.default
+           - $${CDF_URL}/.default
        extraction-pipeline:
          pipeline-id: ep_{{location}}_opcua
      ```

--- a/modules/sourcesystem/cdf_pi_extractor/extraction_pipelines/ep_pi.ExtractionPipeline.yaml
+++ b/modules/sourcesystem/cdf_pi_extractor/extraction_pipelines/ep_pi.ExtractionPipeline.yaml
@@ -21,6 +21,10 @@ notificationConfig:
   # PI extractor streams continuously; alert if not seen for >2 hours
   allowedNotSeenRangeInMinutes: 120
 createdBy: cognite-toolkit
+# The sample config.yml below uses $${VAR} (not ${VAR}): Toolkit substitutes ${VAR} from
+# .env anywhere in this file, so a single $ would leak real secret values into the
+# deployed pipeline's documentation. $${VAR} renders as literal ${VAR}, which is what the
+# extractor host should read from its own environment.
 documentation: |
   ## PI extraction pipeline
 
@@ -65,14 +69,14 @@ documentation: |
      version: 3
      type: remote
      cognite:
-       project: ${CDF_PROJECT}
-       host: ${CDF_URL}
+       project: $${CDF_PROJECT}
+       host: $${CDF_URL}
        idp-authentication:
-         tenant: ${IDP_TENANT_ID}
-         client-id: ${IDP_CLIENT_ID}
-         secret: ${IDP_CLIENT_SECRET}
+         tenant: $${IDP_TENANT_ID}
+         client-id: $${IDP_CLIENT_ID}
+         secret: $${IDP_CLIENT_SECRET}
          scopes:
-           - ${CDF_URL}/.default
+           - $${CDF_URL}/.default
        extraction-pipeline:
          external-id: ep_{{location}}_pi
      ```

--- a/modules/sourcesystem/cdf_sap_extractor/extraction_pipelines/ep_sap.ExtractionPipeline.yaml
+++ b/modules/sourcesystem/cdf_sap_extractor/extraction_pipelines/ep_sap.ExtractionPipeline.yaml
@@ -36,6 +36,10 @@ notificationConfig:
   # Longest endpoint cadence is weekly (Funcloc/Equipment masters) — 8 days + buffer
   allowedNotSeenRangeInMinutes: 12960
 createdBy: cognite-toolkit
+# The sample config.yml below uses $${VAR} (not ${VAR}): Toolkit substitutes ${VAR} from
+# .env anywhere in this file, so a single $ would leak real secret values into the
+# deployed pipeline's documentation. $${VAR} renders as literal ${VAR}, which is what the
+# extractor host should read from its own environment.
 documentation: |
   ## SAP OData extraction pipeline
 
@@ -84,14 +88,14 @@ documentation: |
      version: 1
      type: remote
      cognite:
-       project: ${CDF_PROJECT}
-       host: ${CDF_URL}
+       project: $${CDF_PROJECT}
+       host: $${CDF_URL}
        idp-authentication:
-         tenant: ${IDP_TENANT_ID}
-         client-id: ${IDP_CLIENT_ID}
-         secret: ${IDP_CLIENT_SECRET}
+         tenant: $${IDP_TENANT_ID}
+         client-id: $${IDP_CLIENT_ID}
+         secret: $${IDP_CLIENT_SECRET}
          scopes:
-           - ${CDF_URL}/.default
+           - $${CDF_URL}/.default
        extraction-pipeline:
          external-id: ep_{{location}}_sap
      ```


### PR DESCRIPTION
## Summary

- Escaped `${VAR}` → `$${VAR}` in the sample `config.yml` snippets embedded in the extraction pipeline `documentation` fields (DB/Postgres, SharePoint, OPC-UA, PI, SAP). Without escaping, Toolkit substitutes `${VAR}` from `.env` anywhere in the file, so it would leak real secret values into the deployed pipeline's documentation instead of leaving the literal `${VAR}` for the extractor host to resolve from its own environment.
- Added a short comment above each `documentation:` block explaining why `$${VAR}` is required, so it isn't "fixed" back to `${VAR}` in a future edit.
- Fixed broken/incorrect reference links in `cdf_files_extractor/README.md` and the SharePoint extraction pipeline doc (Files Extractor docs and configuration reference URLs).

## Why

Addresses review comments on the extraction pipeline docs: variable substitution could leak secrets into deployed documentation, and a couple of doc links were pointing to the wrong path.

## Test plan

- [ ] `python validate_packages.py` passes
- [ ] Manually inspect the rendered `documentation` field for one pipeline (e.g. `ep_pi`) to confirm `$${VAR}` renders as literal `${VAR}` and is not substituted
- [ ] Confirm updated links resolve correctly