### PR TITLE
At 79

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -31,11 +31,13 @@ jobs:
       uses: jakebailey/pyright-action@v2
 
     - name: Run tests
+      env:
+        PYTHONPATH: .
       run: |
         uv run pytest tests/ -q
-        uv run pytest modules/contextualization/cdf_entity_matching/functions/fn_dm_context_timeseries_entity_matching/ -q
-        uv run pytest modules/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/test_metadata_optimizations.py -q
-        uv run pytest modules/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_annotation/ -q
+        uv run pytest modules/contextualization/cdf_entity_matching/functions/fn_dm_context_timeseries_entity_matching/ --rootdir=. -q
+        uv run pytest modules/contextualization/cdf_entity_matching/functions/fn_dm_context_metadata_update/test_metadata_optimizations.py --rootdir=. -q
+        uv run pytest modules/contextualization/cdf_p_and_id_annotation/functions/fn_dm_context_files_annotation/ --rootdir=. -q
 
     - name: Validate packages.toml
       run: |

--- a/conftest.py
+++ b/conftest.py
@@ -20,6 +20,15 @@ def _disable_cognite_pypi_version_check() -> None:
         from cognite.client.config import global_config
 
         global_config.disable_pypi_version_check = True
+        try:
+            from cognite.client.utils import _version_checker
+
+            def _no_version_check() -> None:
+                return None
+
+            _version_checker.check_client_is_running_latest_version = _no_version_check
+        except ImportError:
+            pass
     except ImportError:
         # cognite-sdk is optional for some test environments; nothing to disable when absent.
         pass

--- a/conftest.py
+++ b/conftest.py
@@ -27,11 +27,13 @@ def _disable_cognite_pypi_version_check() -> None:
                 return None
 
             _version_checker.check_client_is_running_latest_version = _no_version_check
-        except ImportError:
-            pass
+        except (AttributeError, ImportError):
+            # Older cognite-sdk versions may not expose the internal helper;
+            # the public global_config flag above is enough in that case.
+            return
     except ImportError:
         # cognite-sdk is optional for some test environments; nothing to disable when absent.
-        pass
+        return
 
 
 _disable_cognite_pypi_version_check()

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -3,9 +3,9 @@
 Generate GitHub Actions CI/CD for a Toolkit project using the Foundation Deployment Pack.
 
 Implements the branching model and workflows from sop-cdf-project-setup.md (Step 5):
-  - PR to dev, and PR to main when config.test.yaml exists → dry-run
+  - PR to dev, and PR to main when config.test.yaml or config.staging.yaml exists → dry-run
   - Push to dev → deploy to config.dev.yaml's environment.project
-  - Push to main → deploy to config.test.yaml's environment.project when present
+  - Push to main → deploy to the detected test/staging environment.project when present
   - Release published from main → deploy to config.prod.yaml's environment.project
 
 Run from the Toolkit project root after `cdf modules add -d dp:foundation`:
@@ -29,9 +29,9 @@ except ImportError:
 
 MODULE_DIR = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = MODULE_DIR / "templates" / "github"
-ENVIRONMENTS = ("dev", "test", "prod")
-DEPLOY_BRANCHES = {"dev": "dev", "test": "main"}
-ENV_LABELS = {"dev": "Dev", "test": "Test"}
+ENVIRONMENTS = ("dev", "test", "staging", "prod")
+DEPLOY_BRANCHES = {"dev": "dev", "test": "main", "staging": "main"}
+ENV_LABELS = {"dev": "Dev", "test": "Test", "staging": "Staging"}
 CONFIG_FLAG_MIN_VERSION = (0, 8, 0)
 
 
@@ -180,7 +180,7 @@ def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str,
 
 
 def deployable_envs(projects: dict[str, str]) -> list[str]:
-    return [env for env in ("dev", "test") if env in projects]
+    return [env for env in ("dev", "test", "staging") if env in projects]
 
 
 def workflow_file_list(projects: dict[str, str]) -> str:
@@ -199,7 +199,8 @@ def branch_envs(projects: dict[str, str]) -> dict[str, str]:
         branch = DEPLOY_BRANCHES[env]
         if branch in envs_by_branch:
             raise ValueError(
-                f"Both {envs_by_branch[branch]!r} and {env!r} map to branch {branch!r}."
+                f"Both {envs_by_branch[branch]!r} and {env!r} map to branch {branch!r}. "
+                "Use either config.test.yaml or config.staging.yaml, not both."
             )
         envs_by_branch[branch] = env
     return envs_by_branch
@@ -366,7 +367,7 @@ def main() -> None:
     if not deploy_template.is_file():
         print(f"Missing template: {deploy_template}", file=sys.stderr)
         sys.exit(1)
-    for env in ("dev", "test"):
+    for env in ("dev", "test", "staging"):
         if env not in projects:
             remove_file(repo_root / ".github" / "workflows" / f"deploy-{env}.yml")
             continue

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -217,6 +217,8 @@ def dry_run_environment(projects: dict[str, str]) -> str:
     if len(branches) == 1:
         env = next(iter(branches.values()))
         return f"{env}-toolkit-credentials"
+    if len(branches) > 2:
+        raise ValueError(f"Unsupported number of deployable branches: {len(branches)}")
     first_branch, first_env = next(iter(branches.items()))
     fallback_env = next(env for branch, env in branches.items() if branch != first_branch)
     return (

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -30,7 +30,8 @@ except ImportError:
 MODULE_DIR = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = MODULE_DIR / "templates" / "github"
 ENVIRONMENTS = ("dev", "test", "prod")
-REQUIRED_ENVIRONMENTS = ("dev", "prod")
+DEPLOY_BRANCHES = {"dev": "dev", "test": "main"}
+ENV_LABELS = {"dev": "Dev", "test": "Test"}
 CONFIG_FLAG_MIN_VERSION = (0, 8, 0)
 
 
@@ -158,10 +159,6 @@ def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str,
     for env in ENVIRONMENTS:
         path = config_path(repo_root, org_dir, env)
         if not path.is_file():
-            if env in REQUIRED_ENVIRONMENTS:
-                raise FileNotFoundError(
-                    f"Missing {path.relative_to(repo_root)}. Run setup_project.py before generating workflows."
-                )
             continue
 
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
@@ -175,46 +172,101 @@ def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str,
         if not project:
             raise ValueError(f"{path.relative_to(repo_root)} is missing environment.project.")
         projects[env] = str(project)
+    if not projects:
+        raise FileNotFoundError(
+            "No config.<env>.yaml files found. Run setup_project.py before generating workflows."
+        )
     return projects
 
 
-def workflow_file_list(include_test: bool) -> str:
-    files = [
-        '".github/workflows/dry-run.yml"',
-        '".github/workflows/deploy-dev.yml"',
-    ]
-    if include_test:
-        files.append('".github/workflows/deploy-test.yml"')
-    files.append('".github/workflows/deploy-prod.yml"')
+def deployable_envs(projects: dict[str, str]) -> list[str]:
+    return [env for env in ("dev", "test") if env in projects]
+
+
+def workflow_file_list(projects: dict[str, str]) -> str:
+    files: list[str] = []
+    if deployable_envs(projects):
+        files.append('".github/workflows/dry-run.yml"')
+    files.extend(f'".github/workflows/deploy-{env}.yml"' for env in deployable_envs(projects))
+    if "prod" in projects:
+        files.append('".github/workflows/deploy-prod.yml"')
     return "\n".join(f"              {path}," for path in files)
 
 
-def pr_branches(include_test: bool) -> str:
-    branches = ["dev"]
-    if include_test:
-        branches.append("main")
+def branch_envs(projects: dict[str, str]) -> dict[str, str]:
+    envs_by_branch: dict[str, str] = {}
+    for env in deployable_envs(projects):
+        branch = DEPLOY_BRANCHES[env]
+        if branch in envs_by_branch:
+            raise ValueError(
+                f"Both {envs_by_branch[branch]!r} and {env!r} map to branch {branch!r}."
+            )
+        envs_by_branch[branch] = env
+    return envs_by_branch
+
+
+def pr_branches(projects: dict[str, str]) -> str:
+    branches = branch_envs(projects)
     return "\n".join(f"      - {branch}" for branch in branches)
 
 
-def dry_run_environment(include_test: bool) -> str:
-    if include_test:
-        return "${{ github.base_ref == 'dev' && 'dev-toolkit-credentials' || 'test-toolkit-credentials' }}"
-    return "dev-toolkit-credentials"
+def dry_run_environment(projects: dict[str, str]) -> str:
+    branches = branch_envs(projects)
+    if not branches:
+        return ""
+    if len(branches) == 1:
+        env = next(iter(branches.values()))
+        return f"{env}-toolkit-credentials"
+    first_branch, first_env = next(iter(branches.items()))
+    fallback_env = next(env for branch, env in branches.items() if branch != first_branch)
+    return (
+        f"${{{{ github.base_ref == '{first_branch}' && "
+        f"'{first_env}-toolkit-credentials' || '{fallback_env}-toolkit-credentials' }}}}"
+    )
 
 
-def dry_run_build_script(toolkit_version: str, org_dir: str | None, include_test: bool) -> str:
-    dev_build = f"cdf build {build_args(toolkit_version, org_dir, 'dev')} | tee build-output.txt"
-    if not include_test:
-        return dev_build
-    test_build = f"cdf build {build_args(toolkit_version, org_dir, 'test')} | tee build-output.txt"
-    return "\n".join(
+def dry_run_build_script(toolkit_version: str, org_dir: str | None, projects: dict[str, str]) -> str:
+    branches = branch_envs(projects)
+    if not branches:
+        return ""
+    if len(branches) == 1:
+        env = next(iter(branches.values()))
+        return f"cdf build {build_args(toolkit_version, org_dir, env)} | tee build-output.txt"
+    cases: list[str] = ['case "${{ github.base_ref }}" in']
+    for branch, env in branches.items():
+        cases.extend(
+            [
+                f"  {branch})",
+                f"    cdf build {build_args(toolkit_version, org_dir, env)} | tee build-output.txt",
+                "    ;;",
+            ]
+        )
+    cases.extend(
         [
-            'if [ "${{ github.base_ref }}" = "dev" ]; then',
-            f"  {dev_build}",
-            "else",
-            f"  {test_build}",
-            "fi",
+            "  *)",
+            '    echo "::error::Unsupported base branch ${{ github.base_ref }}"',
+            "    exit 1",
+            "    ;;",
+            "esac",
         ]
+    )
+    return "\n".join(cases)
+
+
+def branching_rows(projects: dict[str, str]) -> str:
+    rows: list[str] = []
+    for env in deployable_envs(projects):
+        branch = DEPLOY_BRANCHES[env]
+        rows.extend(
+            [
+                f"| PR → `{branch}` | `{projects[env]}` | Dry-run (`cdf build`, `cdf deploy --dry-run`) |",
+                f"| Push to `{branch}` | `{projects[env]}` | Deploy |",
+            ]
+        )
+    if "prod" in projects:
+        rows.append(f"| GitHub Release (tag `vX.Y.Z` from `main`) | `{projects['prod']}` | Deploy |")
+    return "\n".join(
+        rows or ["| *(none)* | *(none)* | No CI/CD workflows generated |"]
     )
 
 
@@ -223,21 +275,14 @@ def indent(text: str, spaces: int) -> str:
     return "\n".join(f"{prefix}{line}" if line else line for line in text.splitlines())
 
 
-def test_branching_rows(projects: dict[str, str]) -> str:
-    if "test" not in projects:
-        return ""
-    return "\n".join(
-        [
-            f"| PR → `main` | `{projects['test']}` | Dry-run |",
-            f"| Push to `main` | `{projects['test']}` | Deploy |",
-        ]
-    )
-
-
-def test_environment_row(projects: dict[str, str]) -> str:
-    if "test" not in projects:
-        return ""
-    return f"| `test-toolkit-credentials` | PR → main, push `main` | `{projects['test']}` |"
+def environment_rows(projects: dict[str, str]) -> str:
+    rows: list[str] = []
+    for env in deployable_envs(projects):
+        branch = DEPLOY_BRANCHES[env]
+        rows.append(f"| `{env}-toolkit-credentials` | PR → {branch}, push `{branch}` | `{projects[env]}` |")
+    if "prod" in projects:
+        rows.append(f"| `prod-toolkit-credentials` | Release published | `{projects['prod']}` |")
+    return "\n".join(rows)
 
 
 def env_config_list(projects: dict[str, str]) -> str:
@@ -245,6 +290,11 @@ def env_config_list(projects: dict[str, str]) -> str:
     if len(configs) == 1:
         return configs[0]
     return ", ".join(configs[:-1]) + f", or {configs[-1]}"
+
+
+def example_build_args(toolkit_version: str, org_dir: str | None, projects: dict[str, str]) -> str:
+    env = next(env for env in ENVIRONMENTS if env in projects)
+    return build_args(toolkit_version, org_dir, env)
 
 
 def main() -> None:
@@ -264,57 +314,67 @@ def main() -> None:
     cdf = load_cdf_toml(repo_root)
     org_dir: str | None = args.org_dir or cdf.get("cdf", {}).get("default_organization_dir") or None
     projects = load_environment_projects(repo_root, org_dir)
-    include_test = "test" in projects
 
     toolkit_version = cdf.get("modules", {}).get("version", "0.7.220")
     resolve_modules_root(repo_root, org_dir)
 
     base_values: dict[str, str] = {
-        "DEV_PROJECT": projects["dev"],
-        "PROD_PROJECT": projects["prod"],
-        "DEV_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "dev"),
-        "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
-        "WORKFLOW_FILES": workflow_file_list(include_test),
-        "PR_BRANCHES": pr_branches(include_test),
-        "DRY_RUN_ENVIRONMENT": dry_run_environment(include_test),
-        "DRY_RUN_BUILD_SCRIPT": indent(dry_run_build_script(str(toolkit_version), org_dir, include_test), 10),
-        "TEST_BRANCHING_ROWS": test_branching_rows(projects),
-        "TEST_ENVIRONMENT_ROW": test_environment_row(projects),
+        "WORKFLOW_FILES": workflow_file_list(projects),
+        "PR_BRANCHES": pr_branches(projects),
+        "DRY_RUN_ENVIRONMENT": dry_run_environment(projects),
+        "DRY_RUN_BUILD_SCRIPT": indent(dry_run_build_script(str(toolkit_version), org_dir, projects), 10),
+        "BRANCHING_ROWS": branching_rows(projects),
+        "ENVIRONMENT_ROWS": environment_rows(projects),
+        "EXAMPLE_BUILD_ARGS": example_build_args(str(toolkit_version), org_dir, projects),
         "ENV_CONFIG_LIST": env_config_list(projects),
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
     }
-    if include_test:
-        base_values.update(
-            {
-                "TEST_PROJECT": projects["test"],
-                "TEST_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "test"),
-            }
-        )
 
-    for name in ("dry-run.yml", "deploy-prod.yml"):
-        template = TEMPLATES_DIR / name
+    if deployable_envs(projects):
+        template = TEMPLATES_DIR / "dry-run.yml"
         if not template.is_file():
             print(f"Missing template: {template}", file=sys.stderr)
             sys.exit(1)
-        out = repo_root / ".github" / "workflows" / name
-        write_file(out, render_template(template, base_values), args.force)
+        write_file(
+            repo_root / ".github" / "workflows" / "dry-run.yml",
+            render_template(template, base_values),
+            args.force,
+        )
+    else:
+        remove_file(repo_root / ".github" / "workflows" / "dry-run.yml")
+
+    if "prod" in projects:
+        deploy_prod_template = TEMPLATES_DIR / "deploy-prod.yml"
+        if not deploy_prod_template.is_file():
+            print(f"Missing template: {deploy_prod_template}", file=sys.stderr)
+            sys.exit(1)
+        prod_values = {
+            **base_values,
+            "PROD_PROJECT": projects["prod"],
+            "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
+        }
+        write_file(
+            repo_root / ".github" / "workflows" / "deploy-prod.yml",
+            render_template(deploy_prod_template, prod_values),
+            args.force,
+        )
+    else:
+        remove_file(repo_root / ".github" / "workflows" / "deploy-prod.yml")
 
     deploy_template = TEMPLATES_DIR / "deploy.yml"
     if not deploy_template.is_file():
         print(f"Missing template: {deploy_template}", file=sys.stderr)
         sys.exit(1)
-    deploy_envs = [("dev", "dev", "Dev")]
-    if include_test:
-        deploy_envs.append(("test", "main", "Test"))
-    else:
-        remove_file(repo_root / ".github" / "workflows" / "deploy-test.yml")
-    for env, branch, label in deploy_envs:
+    for env in ("dev", "test"):
+        if env not in projects:
+            remove_file(repo_root / ".github" / "workflows" / f"deploy-{env}.yml")
+            continue
         merged = {
             **base_values,
             "ENV": env,
-            "BRANCH": branch,
-            "ENV_LABEL": label,
+            "BRANCH": DEPLOY_BRANCHES[env],
+            "ENV_LABEL": ENV_LABELS[env],
             "PROJECT": projects[env],
             "BUILD_ARGS": build_args(str(toolkit_version), org_dir, env),
         }
@@ -329,15 +389,14 @@ def main() -> None:
     )
 
     print()
-    environments = ["dev-toolkit-credentials"]
-    if include_test:
-        environments.append("test-toolkit-credentials")
-    environments.append("prod-toolkit-credentials")
+    environments = [f"{env}-toolkit-credentials" for env in ENVIRONMENTS if env in projects]
     print("Next steps:")
     print(f"  1. Create GitHub Environments: {', '.join(environments)}")
     print("     (see docs/FOUNDATION_CICD.md)")
     print("  2. Create and protect the branches used by the generated workflows")
-    print("  3. Open a PR to dev to validate dry-run.yml")
+    if deployable_envs(projects):
+        branches = ", ".join(branch_envs(projects))
+        print(f"  3. Open a PR to {branches} to validate dry-run.yml")
 
 
 if __name__ == "__main__":

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -3,9 +3,9 @@
 Generate GitHub Actions CI/CD for a Toolkit project using the Foundation Deployment Pack.
 
 Implements the branching model and workflows from sop-cdf-project-setup.md (Step 5):
-  - PR to dev, and PR to main when config.test.yaml or config.staging.yaml exists → dry-run
+  - PR to dev, and PR to main when config.test.yaml exists → dry-run
   - Push to dev → deploy to config.dev.yaml's environment.project
-  - Push to main → deploy to the detected test/staging environment.project when present
+  - Push to main → deploy to config.test.yaml's environment.project when present
   - Release published from main → deploy to config.prod.yaml's environment.project
 
 Run from the Toolkit project root after `cdf modules add -d dp:foundation`:
@@ -29,9 +29,9 @@ except ImportError:
 
 MODULE_DIR = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = MODULE_DIR / "templates" / "github"
-ENVIRONMENTS = ("dev", "test", "staging", "prod")
-DEPLOY_BRANCHES = {"dev": "dev", "test": "main", "staging": "main"}
-ENV_LABELS = {"dev": "Dev", "test": "Test", "staging": "Staging"}
+ENVIRONMENTS = ("dev", "test", "prod")
+DEPLOY_BRANCHES = {"dev": "dev", "test": "main"}
+ENV_LABELS = {"dev": "Dev", "test": "Test"}
 CONFIG_FLAG_MIN_VERSION = (0, 8, 0)
 
 
@@ -180,7 +180,7 @@ def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str,
 
 
 def deployable_envs(projects: dict[str, str]) -> list[str]:
-    return [env for env in ("dev", "test", "staging") if env in projects]
+    return [env for env in ("dev", "test") if env in projects]
 
 
 def workflow_file_list(projects: dict[str, str]) -> str:
@@ -199,8 +199,7 @@ def branch_envs(projects: dict[str, str]) -> dict[str, str]:
         branch = DEPLOY_BRANCHES[env]
         if branch in envs_by_branch:
             raise ValueError(
-                f"Both {envs_by_branch[branch]!r} and {env!r} map to branch {branch!r}. "
-                "Use either config.test.yaml or config.staging.yaml, not both."
+                f"Both {envs_by_branch[branch]!r} and {env!r} map to branch {branch!r}."
             )
         envs_by_branch[branch] = env
     return envs_by_branch
@@ -233,7 +232,7 @@ def dry_run_build_script(toolkit_version: str, org_dir: str | None, projects: di
     if len(branches) == 1:
         env = next(iter(branches.values()))
         return f"cdf build {build_args(toolkit_version, org_dir, env)} | tee build-output.txt"
-    cases: list[str] = ['case "${{ github.base_ref }}" in']
+    cases: list[str] = ['case "$GITHUB_BASE_REF" in']
     for branch, env in branches.items():
         cases.extend(
             [
@@ -245,7 +244,7 @@ def dry_run_build_script(toolkit_version: str, org_dir: str | None, projects: di
     cases.extend(
         [
             "  *)",
-            '    echo "::error::Unsupported base branch ${{ github.base_ref }}"',
+            '    echo "::error::Unsupported base branch $GITHUB_BASE_REF"',
             "    exit 1",
             "    ;;",
             "esac",
@@ -367,7 +366,7 @@ def main() -> None:
     if not deploy_template.is_file():
         print(f"Missing template: {deploy_template}", file=sys.stderr)
         sys.exit(1)
-    for env in ("dev", "test", "staging"):
+    for env in ("dev", "test"):
         if env not in projects:
             remove_file(repo_root / ".github" / "workflows" / f"deploy-{env}.yml")
             continue

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -8,22 +8,17 @@ This follows the [CDF Foundation Setup guide](https://cogdocs.mintlify.io/gvd) *
 
 | Git branch / event | CDF project | Trigger |
 |--------------------|-------------|---------|
-| PR → `dev` | `{{DEV_PROJECT}}` | Dry-run (`cdf build`, `cdf deploy --dry-run`) |
-| Push to `dev` | `{{DEV_PROJECT}}` | Deploy |
-{{TEST_BRANCHING_ROWS}}
-| GitHub Release (tag `vX.Y.Z` from `main`) | `{{PROD_PROJECT}}` | Deploy |
+{{BRANCHING_ROWS}}
 
-If the test environment is present, PRs to `main` must come from `dev` or `hotfix/*` only.
+If a pre-production environment is present, PRs to `main` must come from `dev` or `hotfix/*` only.
 
 ## GitHub Environments
 
-Create three environments under **Settings → Environments**:
+Create the generated environments under **Settings → Environments**:
 
 | Environment | Used by | `CDF_PROJECT` example |
 |-------------|---------|-------------------------|
-| `dev-toolkit-credentials` | PR → dev, push `dev` | `{{DEV_PROJECT}}` |
-{{TEST_ENVIRONMENT_ROW}}
-| `prod-toolkit-credentials` | Release published | `{{PROD_PROJECT}}` |
+{{ENVIRONMENT_ROWS}}
 
 Each environment needs these **variables**:
 
@@ -50,7 +45,7 @@ files together with the workflows:
 
 ```bash
 python modules/common/cdf_project_foundation/scripts/setup_project.py
-cdf build {{DEV_BUILD_ARGS}}
+cdf build {{EXAMPLE_BUILD_ARGS}}
 ```
 
 CI validates the committed configs as-is; it does not regenerate them.

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,9 +1,8 @@
 """Repository-local Python startup settings for tests and tooling."""
 
-try:
+from contextlib import suppress
+
+with suppress(ImportError):
     from cognite.client.config import global_config
 
     global_config.disable_pypi_version_check = True
-except ImportError:
-    # cognite-sdk is optional for some local tooling commands.
-    pass

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,9 @@
+"""Repository-local Python startup settings for tests and tooling."""
+
+try:
+    from cognite.client.config import global_config
+
+    global_config.disable_pypi_version_check = True
+except ImportError:
+    # cognite-sdk is optional for some local tooling commands.
+    pass

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_ROOT = REPO_ROOT / "modules" / "common" / "cdf_project_foundation"
 GENERATE_ACTIONS = MODULE_ROOT / "scripts" / "generate_actions.py"
@@ -23,6 +25,17 @@ def test_discover_foundation_modules_includes_project_foundation() -> None:
     paths = discover_foundation_module_paths(REPO_ROOT / "modules", REPO_ROOT)
     assert "common/cdf_project_foundation" in paths
     assert "sourcesystem/cdf_pi_extractor" in paths
+
+
+def test_dry_run_environment_rejects_more_than_two_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    monkeypatch.setattr(generate_actions, "deployable_envs", lambda projects: ["dev", "test", "qa"])
+    monkeypatch.setitem(generate_actions.DEPLOY_BRANCHES, "qa", "qa")
+
+    with pytest.raises(ValueError, match="Unsupported number of deployable branches: 3"):
+        generate_actions.dry_run_environment({"dev": "acme-dev", "test": "acme-test", "qa": "acme-qa"})
 
 
 def test_generate_actions_writes_workflows_and_docs(tmp_path: Path) -> None:

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -185,6 +185,8 @@ environment:
     )
     assert "cdf build -c industrial/config.dev.yaml" in dry_run
     assert "cdf build -c industrial/config.test.yaml" in dry_run
+    assert 'case "$GITHUB_BASE_REF" in' in dry_run
+    assert "Unsupported base branch $GITHUB_BASE_REF" in dry_run
     assert "cdf build --env" not in dry_run
 
     deploy_prod = (tmp_path / ".github" / "workflows" / "deploy-prod.yml").read_text(
@@ -283,10 +285,8 @@ environment:
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
     stale_test_workflow = workflows / "deploy-test.yml"
-    stale_staging_workflow = workflows / "deploy-staging.yml"
     stale_prod_workflow = workflows / "deploy-prod.yml"
     stale_test_workflow.write_text("stale\n", encoding="utf-8")
-    stale_staging_workflow.write_text("stale\n", encoding="utf-8")
     stale_prod_workflow.write_text("stale\n", encoding="utf-8")
 
     subprocess.run(
@@ -302,110 +302,42 @@ environment:
     assert (workflows / "dry-run.yml").is_file()
     assert (workflows / "deploy-dev.yml").is_file()
     assert not stale_test_workflow.exists()
-    assert not stale_staging_workflow.exists()
     assert not stale_prod_workflow.exists()
 
     dry_run = (workflows / "dry-run.yml").read_text(encoding="utf-8")
     assert "      - dev" in dry_run
     assert "      - main" not in dry_run
     assert "deploy-test.yml" not in dry_run
-    assert "deploy-staging.yml" not in dry_run
     assert "deploy-prod.yml" not in dry_run
     assert "test-toolkit-credentials" not in dry_run
-    assert "staging-toolkit-credentials" not in dry_run
     assert "prod-toolkit-credentials" not in dry_run
     assert "config.test.yaml" not in dry_run
-    assert "config.staging.yaml" not in dry_run
     assert "config.prod.yaml" not in dry_run
     assert "cdf build -c config.dev.yaml" in dry_run
 
     cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
     assert "`acme-dev`" in cicd_docs
     assert "`acme-test`" not in cicd_docs
-    assert "`acme-staging`" not in cicd_docs
     assert "`acme-prod`" not in cicd_docs
     assert "config.test.yaml" not in cicd_docs
-    assert "config.staging.yaml" not in cicd_docs
     assert "config.prod.yaml" not in cicd_docs
-
-
-def test_generate_actions_uses_staging_when_staging_config_exists(tmp_path: Path) -> None:
-    (tmp_path / "cdf.toml").write_text(
-        """
-[modules]
-version = "0.8.0"
-""".strip(),
-        encoding="utf-8",
-    )
-    modules = tmp_path / "modules" / "common" / "cdf_project_foundation"
-    modules.mkdir(parents=True)
-    (modules / "module.toml").write_text(
-        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
-        encoding="utf-8",
-    )
-    for env in ("dev", "staging", "prod"):
-        (tmp_path / f"config.{env}.yaml").write_text(
-            f"""
-environment:
-  name: {env}
-  project: acme-{env}
-""".lstrip(),
-            encoding="utf-8",
-        )
-
-    subprocess.run(
-        [
-            sys.executable,
-            str(GENERATE_ACTIONS),
-            "--force",
-        ],
-        check=True,
-        cwd=tmp_path,
-    )
-
-    workflows = tmp_path / ".github" / "workflows"
-    assert (workflows / "deploy-staging.yml").is_file()
-    assert not (workflows / "deploy-test.yml").exists()
-
-    dry_run = (workflows / "dry-run.yml").read_text(encoding="utf-8")
-    assert "deploy-staging.yml" in dry_run
-    assert "deploy-test.yml" not in dry_run
-    assert "staging-toolkit-credentials" in dry_run
-    assert "test-toolkit-credentials" not in dry_run
-    assert "cdf build -c config.staging.yaml" in dry_run
-    assert "cdf build -c config.test.yaml" not in dry_run
-
-    deploy_staging = (workflows / "deploy-staging.yml").read_text(encoding="utf-8")
-    assert "name: Deploy to acme-staging" in deploy_staging
-    assert "environment: staging-toolkit-credentials" in deploy_staging
-    assert "run: cdf build -c config.staging.yaml" in deploy_staging
-
-    cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
-    assert "`staging-toolkit-credentials`" in cicd_docs
-    assert "`config.staging.yaml`" in cicd_docs
-    assert "`config.test.yaml`" not in cicd_docs
 
 
 def test_generate_actions_supports_selected_environment_combinations(tmp_path: Path) -> None:
     cases = [
         ("dev",),
         ("test",),
-        ("staging",),
         ("prod",),
         ("dev", "test"),
-        ("dev", "staging"),
         ("dev", "prod"),
         ("test", "prod"),
-        ("staging", "prod"),
         ("dev", "test", "prod"),
-        ("dev", "staging", "prod"),
     ]
-    deployable = {"dev", "test", "staging"}
+    deployable = {"dev", "test"}
     all_workflows = {
         "dry-run.yml",
         "deploy-dev.yml",
         "deploy-test.yml",
-        "deploy-staging.yml",
         "deploy-prod.yml",
     }
 
@@ -467,6 +399,6 @@ environment:
         for env in envs:
             assert f"`acme-{env}`" in docs
             assert f"`config.{env}.yaml`" in docs
-        for env in {"dev", "test", "staging", "prod"} - set(envs):
+        for env in {"dev", "test", "prod"} - set(envs):
             assert f"`acme-{env}`" not in docs
             assert f"`config.{env}.yaml`" not in docs

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -283,8 +283,10 @@ environment:
     workflows = tmp_path / ".github" / "workflows"
     workflows.mkdir(parents=True)
     stale_test_workflow = workflows / "deploy-test.yml"
+    stale_staging_workflow = workflows / "deploy-staging.yml"
     stale_prod_workflow = workflows / "deploy-prod.yml"
     stale_test_workflow.write_text("stale\n", encoding="utf-8")
+    stale_staging_workflow.write_text("stale\n", encoding="utf-8")
     stale_prod_workflow.write_text("stale\n", encoding="utf-8")
 
     subprocess.run(
@@ -300,42 +302,110 @@ environment:
     assert (workflows / "dry-run.yml").is_file()
     assert (workflows / "deploy-dev.yml").is_file()
     assert not stale_test_workflow.exists()
+    assert not stale_staging_workflow.exists()
     assert not stale_prod_workflow.exists()
 
     dry_run = (workflows / "dry-run.yml").read_text(encoding="utf-8")
     assert "      - dev" in dry_run
     assert "      - main" not in dry_run
     assert "deploy-test.yml" not in dry_run
+    assert "deploy-staging.yml" not in dry_run
     assert "deploy-prod.yml" not in dry_run
     assert "test-toolkit-credentials" not in dry_run
+    assert "staging-toolkit-credentials" not in dry_run
     assert "prod-toolkit-credentials" not in dry_run
     assert "config.test.yaml" not in dry_run
+    assert "config.staging.yaml" not in dry_run
     assert "config.prod.yaml" not in dry_run
     assert "cdf build -c config.dev.yaml" in dry_run
 
     cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
     assert "`acme-dev`" in cicd_docs
     assert "`acme-test`" not in cicd_docs
+    assert "`acme-staging`" not in cicd_docs
     assert "`acme-prod`" not in cicd_docs
     assert "config.test.yaml" not in cicd_docs
+    assert "config.staging.yaml" not in cicd_docs
     assert "config.prod.yaml" not in cicd_docs
+
+
+def test_generate_actions_uses_staging_when_staging_config_exists(tmp_path: Path) -> None:
+    (tmp_path / "cdf.toml").write_text(
+        """
+[modules]
+version = "0.8.0"
+""".strip(),
+        encoding="utf-8",
+    )
+    modules = tmp_path / "modules" / "common" / "cdf_project_foundation"
+    modules.mkdir(parents=True)
+    (modules / "module.toml").write_text(
+        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+        encoding="utf-8",
+    )
+    for env in ("dev", "staging", "prod"):
+        (tmp_path / f"config.{env}.yaml").write_text(
+            f"""
+environment:
+  name: {env}
+  project: acme-{env}
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(GENERATE_ACTIONS),
+            "--force",
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    workflows = tmp_path / ".github" / "workflows"
+    assert (workflows / "deploy-staging.yml").is_file()
+    assert not (workflows / "deploy-test.yml").exists()
+
+    dry_run = (workflows / "dry-run.yml").read_text(encoding="utf-8")
+    assert "deploy-staging.yml" in dry_run
+    assert "deploy-test.yml" not in dry_run
+    assert "staging-toolkit-credentials" in dry_run
+    assert "test-toolkit-credentials" not in dry_run
+    assert "cdf build -c config.staging.yaml" in dry_run
+    assert "cdf build -c config.test.yaml" not in dry_run
+
+    deploy_staging = (workflows / "deploy-staging.yml").read_text(encoding="utf-8")
+    assert "name: Deploy to acme-staging" in deploy_staging
+    assert "environment: staging-toolkit-credentials" in deploy_staging
+    assert "run: cdf build -c config.staging.yaml" in deploy_staging
+
+    cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    assert "`staging-toolkit-credentials`" in cicd_docs
+    assert "`config.staging.yaml`" in cicd_docs
+    assert "`config.test.yaml`" not in cicd_docs
 
 
 def test_generate_actions_supports_selected_environment_combinations(tmp_path: Path) -> None:
     cases = [
         ("dev",),
         ("test",),
+        ("staging",),
         ("prod",),
         ("dev", "test"),
+        ("dev", "staging"),
         ("dev", "prod"),
         ("test", "prod"),
+        ("staging", "prod"),
         ("dev", "test", "prod"),
+        ("dev", "staging", "prod"),
     ]
-    deployable = {"dev", "test"}
+    deployable = {"dev", "test", "staging"}
     all_workflows = {
         "dry-run.yml",
         "deploy-dev.yml",
         "deploy-test.yml",
+        "deploy-staging.yml",
         "deploy-prod.yml",
     }
 
@@ -397,6 +467,6 @@ environment:
         for env in envs:
             assert f"`acme-{env}`" in docs
             assert f"`config.{env}.yaml`" in docs
-        for env in {"dev", "test", "prod"} - set(envs):
+        for env in {"dev", "test", "staging", "prod"} - set(envs):
             assert f"`acme-{env}`" not in docs
             assert f"`config.{env}.yaml`" not in docs

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -18,7 +18,7 @@ def test_generator_scripts_exist() -> None:
 
 def test_discover_foundation_modules_includes_project_foundation() -> None:
     sys.path.insert(0, str(MODULE_ROOT / "scripts"))
-    from generate_actions import discover_foundation_module_paths
+    from generate_actions import discover_foundation_module_paths  # pyright: ignore[reportMissingImports]
 
     paths = discover_foundation_module_paths(REPO_ROOT / "modules", REPO_ROOT)
     assert "common/cdf_project_foundation" in paths
@@ -256,3 +256,147 @@ environment:
     assert "`acme-prod`" in cicd_docs
     assert "`acme-test`" not in cicd_docs
     assert "config.test.yaml" not in cicd_docs
+
+
+def test_generate_actions_supports_dev_only_config(tmp_path: Path) -> None:
+    (tmp_path / "cdf.toml").write_text(
+        """
+[modules]
+version = "0.8.0"
+""".strip(),
+        encoding="utf-8",
+    )
+    modules = tmp_path / "modules" / "common" / "cdf_project_foundation"
+    modules.mkdir(parents=True)
+    (modules / "module.toml").write_text(
+        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "config.dev.yaml").write_text(
+        """
+environment:
+  name: dev
+  project: acme-dev
+""".lstrip(),
+        encoding="utf-8",
+    )
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    stale_test_workflow = workflows / "deploy-test.yml"
+    stale_prod_workflow = workflows / "deploy-prod.yml"
+    stale_test_workflow.write_text("stale\n", encoding="utf-8")
+    stale_prod_workflow.write_text("stale\n", encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(GENERATE_ACTIONS),
+            "--force",
+        ],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    assert (workflows / "dry-run.yml").is_file()
+    assert (workflows / "deploy-dev.yml").is_file()
+    assert not stale_test_workflow.exists()
+    assert not stale_prod_workflow.exists()
+
+    dry_run = (workflows / "dry-run.yml").read_text(encoding="utf-8")
+    assert "      - dev" in dry_run
+    assert "      - main" not in dry_run
+    assert "deploy-test.yml" not in dry_run
+    assert "deploy-prod.yml" not in dry_run
+    assert "test-toolkit-credentials" not in dry_run
+    assert "prod-toolkit-credentials" not in dry_run
+    assert "config.test.yaml" not in dry_run
+    assert "config.prod.yaml" not in dry_run
+    assert "cdf build -c config.dev.yaml" in dry_run
+
+    cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    assert "`acme-dev`" in cicd_docs
+    assert "`acme-test`" not in cicd_docs
+    assert "`acme-prod`" not in cicd_docs
+    assert "config.test.yaml" not in cicd_docs
+    assert "config.prod.yaml" not in cicd_docs
+
+
+def test_generate_actions_supports_selected_environment_combinations(tmp_path: Path) -> None:
+    cases = [
+        ("dev",),
+        ("test",),
+        ("prod",),
+        ("dev", "test"),
+        ("dev", "prod"),
+        ("test", "prod"),
+        ("dev", "test", "prod"),
+    ]
+    deployable = {"dev", "test"}
+    all_workflows = {
+        "dry-run.yml",
+        "deploy-dev.yml",
+        "deploy-test.yml",
+        "deploy-prod.yml",
+    }
+
+    for envs in cases:
+        case_dir = tmp_path / "-".join(envs)
+        case_dir.mkdir()
+        (case_dir / "cdf.toml").write_text(
+            """
+[modules]
+version = "0.8.0"
+""".strip(),
+            encoding="utf-8",
+        )
+        modules = case_dir / "modules" / "common" / "cdf_project_foundation"
+        modules.mkdir(parents=True)
+        (modules / "module.toml").write_text(
+            'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+            encoding="utf-8",
+        )
+        for env in envs:
+            (case_dir / f"config.{env}.yaml").write_text(
+                f"""
+environment:
+  name: {env}
+  project: acme-{env}
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+        workflows = case_dir / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        for name in all_workflows:
+            (workflows / name).write_text("stale\n", encoding="utf-8")
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(GENERATE_ACTIONS),
+                "--force",
+            ],
+            check=True,
+            cwd=case_dir,
+        )
+
+        expected = set()
+        if deployable.intersection(envs):
+            expected.add("dry-run.yml")
+        for env in envs:
+            expected.add(f"deploy-{env}.yml")
+
+        for name in all_workflows:
+            path = workflows / name
+            if name in expected:
+                assert path.is_file(), f"{envs}: expected {name}"
+            else:
+                assert not path.exists(), f"{envs}: unexpected stale {name}"
+
+        docs = (case_dir / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+        for env in envs:
+            assert f"`acme-{env}`" in docs
+            assert f"`config.{env}.yaml`" in docs
+        for env in {"dev", "test", "prod"} - set(envs):
+            assert f"`acme-{env}`" not in docs
+            assert f"`config.{env}.yaml`" not in docs


### PR DESCRIPTION
Summary
Fixed Foundation DP CI/CD generation so it follows the selected Toolkit environment configs instead of assuming both dev and prod exist.
generate_actions.py now generates workflows only for existing config.dev.yaml, config.test.yaml, and/or config.prod.yaml.
Removes stale workflows for environments that are no longer selected.
Updated generated CI/CD docs to mention only the selected environments.
Added regression tests for all supported environment combinations.