### PR TITLE
[AT-59] Part 1: remove redundant diagram-annotation pipeline when file annotation is installed 🧹

### DIFF
--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -846,7 +846,7 @@ def diagram_annotation_stale_paths(repo_root: Path | None = None) -> list[Path]:
     workflow_path = _ingestion_workflow_path(repo_root)
     if workflow_path.exists():
         text = workflow_path.read_text()
-        if any(f"{{{{ {var} }}}}" in text for var in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS):
+        if any(re.search(r"\\{\\{\\s*" + var + r"\\s*\\}\\}", text) for var in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS):
             stale.append(workflow_path)
 
     config_path = _ingestion_config_path(repo_root)

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -847,7 +847,7 @@ def diagram_annotation_stale_paths(repo_root: Path | None = None) -> list[Path]:
     workflow_path = _ingestion_workflow_path(repo_root)
     if workflow_path.exists():
         text = workflow_path.read_text()
-        if any(re.search(r"\\{\\{\\s*" + var + r"\\s*\\}\\}", text) for var in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS):
+        if any(re.search(r"{{\s*" + var + r"\s*}}", text) for var in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS):
             stale.append(workflow_path)
 
     config_path = _ingestion_config_path(repo_root)

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -801,7 +801,8 @@ def _remove_ingestion_diagram_annotation_tasks(lines: list[str]) -> int:
     transformation var is one of ``_INGESTION_DIAGRAM_ANNOTATION_TASK_VARS``.
 
     A block runs from its ``- externalId:`` line up to (but not including) the next
-    sibling task at the same indentation, or the next top-level (unindented) key.
+    sibling task at the same indentation (any first key, not just ``externalId:`` —
+    YAML doesn't guarantee key order), or the next top-level (unindented) key.
     Returns the number of task blocks removed.
     """
     marker_re = re.compile(r"^    - externalId:\s*\{\{\s*(\w+)\s*\}\}\s*$")
@@ -812,7 +813,7 @@ def _remove_ingestion_diagram_annotation_tasks(lines: list[str]) -> int:
         if match and match.group(1) in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS:
             start = i
             j = i + 1
-            while j < len(lines) and not re.match(r"^    - externalId:", lines[j]) and not re.match(r"^\S", lines[j]):
+            while j < len(lines) and not re.match(r"^    - ", lines[j]) and not re.match(r"^\S", lines[j]):
                 j += 1
             ranges.append((start, j))
             i = j

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -38,6 +38,7 @@ from _pack_config import (
     get_data_models_dir,
     get_org_dir_name,
     get_pack_root,
+    get_sourcesystem_dir,
     list_installed_contextualization_modules,
     list_installed_source_system_modules,
     load_yaml,
@@ -748,6 +749,156 @@ def remove_synthetic_data(variant: str, repo_root: Path | None = None) -> int:
     return total
 
 
+# ── Diagram-annotation redundancy ───────────────────────────────────────────────
+#
+# cdf_sharepoint_data_dump ships a standalone synthetic diagram-annotation pipeline
+# (RAW rows + transformations + its own workflow) that produces CogniteDiagramAnnotation
+# edges without needing cdf_file_annotation at all. It stays fully supported and
+# deployable on its own. It only becomes redundant when cdf_file_annotation (the real
+# annotation pipeline) is *also* installed in the same project — at that point both
+# pipelines would write competing annotation edges, so the wizard removes the synthetic
+# one from this project's copy only. The library module itself is never touched.
+
+_DIAGRAM_ANNOTATION_MODULE = "cdf_sharepoint_data_dump"
+_FILE_ANNOTATION_MODULE = "cdf_file_annotation"
+
+_DIAGRAM_ANNOTATION_FILES: tuple[str, ...] = (
+    "raw/diagram_annotation.Table.yaml",
+    "upload_data/diagram_annotation.Manifest.yaml",
+    "upload_data/diagram_annotation.RawRows.csv",
+    "transformations/tr_diagram_annotation_all_to_cognite_diagram_annotation.Transformation.yaml",
+    "transformations/tr_diagram_annotation_all_to_cognite_diagram_annotation.Transformation.sql",
+    "transformations/tr_diagram_annotation_all_to_file_tag_connection.Transformation.yaml",
+    "transformations/tr_diagram_annotation_all_to_file_tag_connection.Transformation.sql",
+    "transformations/tr_diagram_annotation_all_to_file_equipment_connection.Transformation.yaml",
+    "transformations/tr_diagram_annotation_all_to_file_equipment_connection.Transformation.sql",
+    "workflows/wf_diagram_annotation.Workflow.yaml",
+    "workflows/wf_diagram_annotation.WorkflowVersion.yaml",
+    "workflows/wf_diagram_annotation.WorkflowTrigger.yaml",
+)
+
+# cdf_ingestion task/config vars driving the 3 synthetic-annotation transformations
+# above (see modules/common/cdf_ingestion/workflows/v1.WorkflowVersion.yaml and its
+# default.config.yaml). The sibling "File" task (fileTransformationExternalId) stays.
+_INGESTION_DIAGRAM_ANNOTATION_TASK_VARS: tuple[str, ...] = (
+    "diagramAnnotationTransformationExternalId",
+    "fileTagConnectionTransformationExternalId",
+    "fileEquipmentConnectionTransformationExternalId",
+)
+
+
+def diagram_annotation_is_redundant(repo_root: Path | None = None) -> bool:
+    """True when both the synthetic and real annotation pipelines are installed."""
+    sourcesystem_dir = get_sourcesystem_dir(repo_root)
+    ctx_dir = get_contextualization_dir(repo_root)
+    return (sourcesystem_dir / _DIAGRAM_ANNOTATION_MODULE).is_dir() and (
+        ctx_dir / _FILE_ANNOTATION_MODULE
+    ).is_dir()
+
+
+def _remove_ingestion_diagram_annotation_tasks(lines: list[str]) -> int:
+    """Remove ``tasks:`` list items (indent-4 ``- externalId: {{ VAR }}`` blocks) whose
+    transformation var is one of ``_INGESTION_DIAGRAM_ANNOTATION_TASK_VARS``.
+
+    A block runs from its ``- externalId:`` line up to (but not including) the next
+    sibling task at the same indentation, or the next top-level (unindented) key.
+    Returns the number of task blocks removed.
+    """
+    marker_re = re.compile(r"^    - externalId:\s*\{\{\s*(\w+)\s*\}\}\s*$")
+    ranges: list[tuple[int, int]] = []
+    i = 0
+    while i < len(lines):
+        match = marker_re.match(lines[i])
+        if match and match.group(1) in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS:
+            start = i
+            j = i + 1
+            while j < len(lines) and not re.match(r"^    - externalId:", lines[j]) and not re.match(r"^\S", lines[j]):
+                j += 1
+            ranges.append((start, j))
+            i = j
+        else:
+            i += 1
+    for start, end in reversed(ranges):
+        del lines[start:end]
+    return len(ranges)
+
+
+def _ingestion_workflow_path(repo_root: Path | None = None) -> Path:
+    return get_pack_root(repo_root) / "modules" / "common" / "cdf_ingestion" / "workflows" / "v1.WorkflowVersion.yaml"
+
+
+def _ingestion_config_path(repo_root: Path | None = None) -> Path:
+    return get_pack_root(repo_root) / "modules" / "common" / "cdf_ingestion" / "default.config.yaml"
+
+
+def diagram_annotation_stale_paths(repo_root: Path | None = None) -> list[Path]:
+    """Diagram-annotation paths that should have been removed but are still present."""
+    if not diagram_annotation_is_redundant(repo_root):
+        return []
+
+    stale: list[Path] = []
+    module_dir = get_sourcesystem_dir(repo_root) / _DIAGRAM_ANNOTATION_MODULE
+    for rel_path in _DIAGRAM_ANNOTATION_FILES:
+        f = module_dir / rel_path
+        if f.exists():
+            stale.append(f)
+
+    workflow_path = _ingestion_workflow_path(repo_root)
+    if workflow_path.exists():
+        text = workflow_path.read_text()
+        if any(f"{{{{ {var} }}}}" in text for var in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS):
+            stale.append(workflow_path)
+
+    config_path = _ingestion_config_path(repo_root)
+    if config_path.exists():
+        text = config_path.read_text()
+        if any(f"{var}:" in text for var in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS):
+            stale.append(config_path)
+
+    return stale
+
+
+def remove_redundant_diagram_annotation(repo_root: Path | None = None) -> list[Path]:
+    """Remove the synthetic diagram-annotation pipeline from this project's copy of
+    cdf_sharepoint_data_dump, and the 3 corresponding tasks/vars from cdf_ingestion,
+    but only when cdf_file_annotation (the real pipeline) is also installed.
+
+    No-op otherwise — the synthetic pipeline remains fully supported standalone, and
+    nothing is ever deleted from the library module itself. Idempotent.
+    """
+    removed: list[Path] = []
+    if not diagram_annotation_is_redundant(repo_root):
+        return removed
+
+    modules_root = get_pack_root(repo_root) / "modules"
+    module_dir = get_sourcesystem_dir(repo_root) / _DIAGRAM_ANNOTATION_MODULE
+    for rel_path in _DIAGRAM_ANNOTATION_FILES:
+        f = module_dir / rel_path
+        if f.exists():
+            f.unlink()
+            removed.append(f)
+            _ok(f"Removed redundant diagram-annotation file: {f.relative_to(modules_root)}")
+
+    workflow_path = _ingestion_workflow_path(repo_root)
+    if workflow_path.exists():
+        lines = workflow_path.read_text().splitlines(keepends=True)
+        task_count = _remove_ingestion_diagram_annotation_tasks(lines)
+        if task_count:
+            workflow_path.write_text("".join(lines))
+            removed.append(workflow_path)
+            _ok(f"Removed {task_count} redundant diagram-annotation task(s) from cdf_ingestion workflow.")
+
+    config_path = _ingestion_config_path(repo_root)
+    if config_path.exists():
+        lines = config_path.read_text().splitlines(keepends=True)
+        changed = [_yaml_delete_key(lines, var) for var in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS]
+        if any(changed):
+            config_path.write_text("".join(lines))
+            removed.append(config_path)
+
+    return removed
+
+
 # ── Data model auth patching ──────────────────────────────────────────────────
 
 def patch_cfihos_auth_for_missing_search(repo_root: Path | None = None) -> list[Path]:
@@ -1332,6 +1483,7 @@ def _finalize_wizard(
     patched = patch_cfihos_auth_for_missing_search(repo_root)
     created_cdm_space = restore_cdm_space_file(variant, repo_root)
     _cleanup_file_annotation_module(repo_root)
+    diagram_annotation_removed = remove_redundant_diagram_annotation(repo_root)
 
     synthetic_removed = 0
     if not keep_synthetic:
@@ -1353,6 +1505,11 @@ def _finalize_wizard(
         _ok(".env updated with group source IDs.")
     if synthetic_removed:
         _ok(f"{synthetic_removed} synthetic data file(s) removed.")
+    if diagram_annotation_removed:
+        _ok(
+            f"{len(diagram_annotation_removed)} redundant diagram-annotation file(s) "
+            "removed (cdf_file_annotation is installed)."
+        )
     if cicd_files:
         _ok(f"{len(cicd_files)} CI/CD workflow file(s) generated.")
     print()
@@ -1570,6 +1727,8 @@ def _run_check(
         get_pack_root(repo_root) / _CDM_INSTANCE_SPACE_REL_PATH
     ).exists()
 
+    stale_diagram_annotation = diagram_annotation_stale_paths(repo_root)
+
     if all_errors:
         print(f"ERROR: Config file(s) out of sync with variant '{variant}':\n")
         for filename, errs in all_errors.items():
@@ -1589,6 +1748,15 @@ def _run_check(
             f"ERROR: CDM instance space file missing for variant '{variant}':\n"
             f"  {_CDM_INSTANCE_SPACE_REL_PATH}"
         )
+        print("\n  Run: python scripts/setup_project.py -y")
+        sys.exit(1)
+    if stale_diagram_annotation:
+        print(
+            "ERROR: Redundant diagram-annotation file(s) still present "
+            "(superseded by cdf_file_annotation):"
+        )
+        for p in stale_diagram_annotation:
+            print(f"  {p.relative_to(get_pack_root(repo_root))}")
         print("\n  Run: python scripts/setup_project.py -y")
         sys.exit(1)
     print(f"OK: All config file(s) match variant '{variant}'. No stale auth files.")

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -801,11 +801,11 @@ def _remove_ingestion_diagram_annotation_tasks(lines: list[str]) -> int:
     transformation var is one of ``_INGESTION_DIAGRAM_ANNOTATION_TASK_VARS``.
 
     A block runs from its ``- externalId:`` line up to (but not including) the next
-    sibling task at the same indentation (any first key, not just ``externalId:`` —
-    YAML doesn't guarantee key order), or the next top-level (unindented) key.
-    Returns the number of task blocks removed.
+    line indented 4 spaces or less (any sibling task, regardless of its first key since
+    YAML doesn't guarantee key order; any sibling key of ``tasks:`` itself; or the next
+    top-level key). Returns the number of task blocks removed.
     """
-    marker_re = re.compile(r"^    - externalId:\s*\{\{\s*(\w+)\s*\}\}\s*$")
+    marker_re = re.compile(r"^    - externalId:\s*['\"]?\{\{\s*(\w+)\s*\}\}['\"]?\s*$")
     ranges: list[tuple[int, int]] = []
     i = 0
     while i < len(lines):
@@ -813,7 +813,7 @@ def _remove_ingestion_diagram_annotation_tasks(lines: list[str]) -> int:
         if match and match.group(1) in _INGESTION_DIAGRAM_ANNOTATION_TASK_VARS:
             start = i
             j = i + 1
-            while j < len(lines) and not re.match(r"^    - ", lines[j]) and not re.match(r"^\S", lines[j]):
+            while j < len(lines) and not re.match(r"^ {0,4}\S", lines[j]):
                 j += 1
             ranges.append((start, j))
             i = j

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -8,10 +8,12 @@ Covers:
                    _migrate_staging_to_test, _write_config_fresh,
                    _write_config_update, remove_redundant_auth_files,
                    patch_cfihos_auth_for_missing_search, remove_synthetic_data,
-                   _read_existing_values
+                   _read_existing_values, remove_redundant_diagram_annotation,
+                   diagram_annotation_stale_paths
 """
 
 
+import re
 import sys
 import textwrap
 from pathlib import Path
@@ -1049,6 +1051,263 @@ class TestRemoveSyntheticData:
         self._make_files(isa / "data_modeling", "model.datamodel.yaml")
         remove_synthetic_data(self._ISA, tmp_path)
         assert (isa / "data_modeling").exists()
+
+
+# ── setup_project — diagram-annotation redundancy ─────────────────────────────
+
+class TestRemoveRedundantDiagramAnnotation:
+    """remove_redundant_diagram_annotation only acts when both cdf_sharepoint_data_dump
+    and cdf_file_annotation are installed in the same project — otherwise the synthetic
+    pipeline is the only annotation mechanism present and must be left alone."""
+
+    _DIAGRAM_ANNOTATION_FILES = (
+        "raw/diagram_annotation.Table.yaml",
+        "upload_data/diagram_annotation.Manifest.yaml",
+        "upload_data/diagram_annotation.RawRows.csv",
+        "transformations/tr_diagram_annotation_all_to_cognite_diagram_annotation.Transformation.yaml",
+        "transformations/tr_diagram_annotation_all_to_cognite_diagram_annotation.Transformation.sql",
+        "transformations/tr_diagram_annotation_all_to_file_tag_connection.Transformation.yaml",
+        "transformations/tr_diagram_annotation_all_to_file_tag_connection.Transformation.sql",
+        "transformations/tr_diagram_annotation_all_to_file_equipment_connection.Transformation.yaml",
+        "transformations/tr_diagram_annotation_all_to_file_equipment_connection.Transformation.sql",
+        "workflows/wf_diagram_annotation.Workflow.yaml",
+        "workflows/wf_diagram_annotation.WorkflowVersion.yaml",
+        "workflows/wf_diagram_annotation.WorkflowTrigger.yaml",
+    )
+
+    _WORKFLOW_YAML = """\
+        workflowExternalId: {{ workflow }}
+        version: v1
+        workflowDefinition:
+          tasks:
+            - externalId: {{ fileTransformationExternalId }}
+              type: 'transformation'
+              parameters:
+                transformation:
+                  externalId: {{ fileTransformationExternalId }}
+                  concurrencyPolicy: fail
+              name: 'File'
+              description: Create File nodes with asset references
+              retries: 3
+              timeout: 3600
+              onFailure: 'skipTask'
+              dependsOn:
+                - externalId: {{ heatExchangerTransformationExternalId }}
+
+            - externalId: {{ diagramAnnotationTransformationExternalId }}
+              type: 'transformation'
+              parameters:
+                transformation:
+                  externalId: {{ diagramAnnotationTransformationExternalId }}
+                  concurrencyPolicy: fail
+              name: 'Diagram annotation'
+              description: Create CogniteDiagramAnnotation edges from RAW diagram annotation rows
+              retries: 3
+              timeout: 3600
+              onFailure: 'skipTask'
+              dependsOn:
+                - externalId: {{ fileTransformationExternalId }}
+                - externalId: {{ assetTransformationExternalId }}
+
+            - externalId: {{ fileTagConnectionTransformationExternalId }}
+              type: 'transformation'
+              parameters:
+                transformation:
+                  externalId: {{ fileTagConnectionTransformationExternalId }}
+                  concurrencyPolicy: fail
+              name: 'File to tag connection from diagram annotation'
+              description: Connect Files.assets to Tag using diagram annotation AssetLink rows
+              retries: 3
+              timeout: 3600
+              onFailure: 'skipTask'
+              dependsOn:
+                - externalId: {{ fileTransformationExternalId }}
+                - externalId: {{ assetTransformationExternalId }}
+
+            - externalId: {{ fileEquipmentConnectionTransformationExternalId }}
+              type: 'transformation'
+              parameters:
+                transformation:
+                  externalId: {{ fileEquipmentConnectionTransformationExternalId }}
+                  concurrencyPolicy: fail
+              name: 'File to equipment connection via tags'
+              description: Connect Equipment.files by matching Equipment.asset against Files.assets
+              retries: 3
+              timeout: 3600
+              onFailure: 'skipTask'
+              dependsOn:
+                - externalId: {{ fileTagConnectionTransformationExternalId }}
+                - externalId: {{ equipmentTransformationExternalId }}
+
+            - externalId: {{ timeseriesTransformationExternalId }}
+              type: 'transformation'
+              parameters:
+                transformation:
+                  externalId: {{ timeseriesTransformationExternalId }}
+                  concurrencyPolicy: fail
+              name: 'Time series data'
+        """
+
+    _CONFIG_YAML = """\
+        fileTransformationExternalId: tr_file_all_to_file
+        diagramAnnotationTransformationExternalId: tr_diagram_annotation_all_to_cognite_diagram_annotation
+        fileTagConnectionTransformationExternalId: tr_diagram_annotation_all_to_file_tag_connection
+        fileEquipmentConnectionTransformationExternalId: tr_diagram_annotation_all_to_file_equipment_connection
+        timeseriesTransformationExternalId: tr_timeseries_all_to_timeseries_data
+        """
+
+    def _make_sharepoint_data_dump(self, tmp_path: Path) -> Path:
+        module_dir = tmp_path / "modules" / "sourcesystem" / "cdf_sharepoint_data_dump"
+        for rel_path in self._DIAGRAM_ANNOTATION_FILES:
+            f = module_dir / rel_path
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("example")
+        # Non-diagram-annotation file that must never be touched.
+        keep = module_dir / "transformations" / "tr_file_all_to_file.Transformation.yaml"
+        keep.parent.mkdir(parents=True, exist_ok=True)
+        keep.write_text("example")
+        return module_dir
+
+    def _make_file_annotation(self, tmp_path: Path) -> Path:
+        module_dir = tmp_path / "modules" / "contextualization" / "cdf_file_annotation"
+        module_dir.mkdir(parents=True, exist_ok=True)
+        return module_dir
+
+    def _make_ingestion(self, tmp_path: Path) -> tuple[Path, Path]:
+        ingestion_dir = tmp_path / "modules" / "common" / "cdf_ingestion"
+        workflow_path = ingestion_dir / "workflows" / "v1.WorkflowVersion.yaml"
+        config_path = ingestion_dir / "default.config.yaml"
+        workflow_path.parent.mkdir(parents=True, exist_ok=True)
+        workflow_path.write_text(textwrap.dedent(self._WORKFLOW_YAML))
+        config_path.write_text(textwrap.dedent(self._CONFIG_YAML))
+        return workflow_path, config_path
+
+    def test_no_op_when_file_annotation_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        module_dir = self._make_sharepoint_data_dump(tmp_path)
+        removed = remove_redundant_diagram_annotation(tmp_path)
+        assert removed == []
+        for rel_path in self._DIAGRAM_ANNOTATION_FILES:
+            assert (module_dir / rel_path).exists()
+
+    def test_no_op_when_sharepoint_data_dump_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        self._make_file_annotation(tmp_path)
+        assert remove_redundant_diagram_annotation(tmp_path) == []
+
+    def test_removes_files_when_both_installed(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        module_dir = self._make_sharepoint_data_dump(tmp_path)
+        self._make_file_annotation(tmp_path)
+        removed = remove_redundant_diagram_annotation(tmp_path)
+        assert len(removed) >= len(self._DIAGRAM_ANNOTATION_FILES)
+        for rel_path in self._DIAGRAM_ANNOTATION_FILES:
+            assert not (module_dir / rel_path).exists()
+
+    def test_keeps_tr_file_all_to_file(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        module_dir = self._make_sharepoint_data_dump(tmp_path)
+        self._make_file_annotation(tmp_path)
+        remove_redundant_diagram_annotation(tmp_path)
+        assert (module_dir / "transformations" / "tr_file_all_to_file.Transformation.yaml").exists()
+
+    def test_removes_ingestion_workflow_tasks(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        self._make_sharepoint_data_dump(tmp_path)
+        self._make_file_annotation(tmp_path)
+        workflow_path, config_path = self._make_ingestion(tmp_path)
+        remove_redundant_diagram_annotation(tmp_path)
+
+        workflow_text = workflow_path.read_text()
+        assert "diagramAnnotationTransformationExternalId" not in workflow_text
+        assert "fileTagConnectionTransformationExternalId" not in workflow_text
+        assert "fileEquipmentConnectionTransformationExternalId" not in workflow_text
+        # Untouched sibling tasks stay, including their own dependsOn blocks.
+        assert "fileTransformationExternalId" in workflow_text
+        assert "timeseriesTransformationExternalId" in workflow_text
+        assert "heatExchangerTransformationExternalId" in workflow_text
+
+        config_text = config_path.read_text()
+        assert "diagramAnnotationTransformationExternalId" not in config_text
+        assert "fileTagConnectionTransformationExternalId" not in config_text
+        assert "fileEquipmentConnectionTransformationExternalId" not in config_text
+        assert "fileTransformationExternalId: tr_file_all_to_file" in config_text
+        assert "timeseriesTransformationExternalId" in config_text
+
+    def test_workflow_yaml_stays_parseable_after_removal(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        self._make_sharepoint_data_dump(tmp_path)
+        self._make_file_annotation(tmp_path)
+        workflow_path, _ = self._make_ingestion(tmp_path)
+        remove_redundant_diagram_annotation(tmp_path)
+
+        # Strip the {{ jinja }} placeholders so plain yaml.safe_load can parse the
+        # structural skeleton (tasks/parameters/dependsOn) that must remain intact.
+        text = re.sub(r"\{\{.*?\}\}", "PLACEHOLDER", workflow_path.read_text())
+        parsed = yaml.safe_load(text)
+        tasks = parsed["workflowDefinition"]["tasks"]
+        assert len(tasks) == 2
+        assert [t["name"] for t in tasks] == ["File", "Time series data"]
+
+    def test_no_op_when_ingestion_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        self._make_sharepoint_data_dump(tmp_path)
+        self._make_file_annotation(tmp_path)
+        # No modules/common/cdf_ingestion at all — must not raise.
+        removed = remove_redundant_diagram_annotation(tmp_path)
+        assert len(removed) == len(self._DIAGRAM_ANNOTATION_FILES)
+
+    def test_idempotent_on_second_run(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_diagram_annotation
+        self._make_sharepoint_data_dump(tmp_path)
+        self._make_file_annotation(tmp_path)
+        self._make_ingestion(tmp_path)
+        first = remove_redundant_diagram_annotation(tmp_path)
+        assert first != []
+        second = remove_redundant_diagram_annotation(tmp_path)
+        assert second == []
+
+
+class TestDiagramAnnotationStalePaths:
+    """diagram_annotation_stale_paths backs --check: it must report leftover
+    synthetic-pipeline files/tasks only when both modules are installed."""
+
+    def test_empty_when_file_annotation_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import diagram_annotation_stale_paths
+        TestRemoveRedundantDiagramAnnotation()._make_sharepoint_data_dump(tmp_path)
+        assert diagram_annotation_stale_paths(tmp_path) == []
+
+    def test_flags_leftover_files_when_both_installed(self, tmp_path: Path) -> None:
+        from setup_project import diagram_annotation_stale_paths
+        helper = TestRemoveRedundantDiagramAnnotation()
+        helper._make_sharepoint_data_dump(tmp_path)
+        helper._make_file_annotation(tmp_path)
+        stale = diagram_annotation_stale_paths(tmp_path)
+        assert len(stale) >= len(helper._DIAGRAM_ANNOTATION_FILES)
+
+    def test_empty_after_cleanup(self, tmp_path: Path) -> None:
+        from setup_project import diagram_annotation_stale_paths, remove_redundant_diagram_annotation
+        helper = TestRemoveRedundantDiagramAnnotation()
+        helper._make_sharepoint_data_dump(tmp_path)
+        helper._make_file_annotation(tmp_path)
+        helper._make_ingestion(tmp_path)
+        remove_redundant_diagram_annotation(tmp_path)
+        assert diagram_annotation_stale_paths(tmp_path) == []
+
+    def test_flags_stale_ingestion_workflow_when_files_removed_but_workflow_not_patched(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards against a partial cleanup: module files gone but the ingestion
+        workflow still references the retired tasks."""
+        from setup_project import diagram_annotation_stale_paths
+        helper = TestRemoveRedundantDiagramAnnotation()
+        module_dir = helper._make_sharepoint_data_dump(tmp_path)
+        helper._make_file_annotation(tmp_path)
+        helper._make_ingestion(tmp_path)
+        for rel_path in helper._DIAGRAM_ANNOTATION_FILES:
+            (module_dir / rel_path).unlink()
+        stale = diagram_annotation_stale_paths(tmp_path)
+        assert any("v1.WorkflowVersion.yaml" in str(p) for p in stale)
 
 
 # ── setup_project — replicate config from existing ───────────────────────────

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -1060,7 +1060,7 @@ class TestRemoveRedundantDiagramAnnotation:
     and cdf_file_annotation are installed in the same project — otherwise the synthetic
     pipeline is the only annotation mechanism present and must be left alone."""
 
-    _DIAGRAM_ANNOTATION_FILES = (
+    _DIAGRAM_ANNOTATION_FILES: tuple[str, ...] = (
         "raw/diagram_annotation.Table.yaml",
         "upload_data/diagram_annotation.Manifest.yaml",
         "upload_data/diagram_annotation.RawRows.csv",
@@ -1075,7 +1075,7 @@ class TestRemoveRedundantDiagramAnnotation:
         "workflows/wf_diagram_annotation.WorkflowTrigger.yaml",
     )
 
-    _WORKFLOW_YAML = """\
+    _WORKFLOW_YAML: str = """\
         workflowExternalId: {{ workflow }}
         version: v1
         workflowDefinition:
@@ -1148,7 +1148,7 @@ class TestRemoveRedundantDiagramAnnotation:
               name: 'Time series data'
         """
 
-    _CONFIG_YAML = """\
+    _CONFIG_YAML: str = """\
         fileTransformationExternalId: tr_file_all_to_file
         diagramAnnotationTransformationExternalId: tr_diagram_annotation_all_to_cognite_diagram_annotation
         fileTagConnectionTransformationExternalId: tr_diagram_annotation_all_to_file_tag_connection


### PR DESCRIPTION
This PR is Chunk A of the "Unified Foundation/Demo setup script" plan (Chunking is done to make code changes < 500 lines for easy & efficient review). It's currently dormant in practice: `common/cdf_project_foundation` (which ships this script) is only in the Foundation pack today, and Foundation never installs `cdf_sharepoint_data_dump`. It becomes live once a later chunk adds `cdf_project_foundation` to the Demo pack.

## Changes

- Adds `remove_redundant_diagram_annotation()`, `diagram_annotation_is_redundant()`, and `diagram_annotation_stale_paths()` to `setup_project.py`. The synthetic diagram-annotation pipeline shipped in `cdf_sharepoint_data_dump` is a fully supported, standalone annotation mechanism and is **never touched in the library** — this only cleans up a *consuming project's own copy*, and only when `contextualization/cdf_file_annotation` is also installed, since at that point the two pipelines would write competing `CogniteDiagramAnnotation` edges.

- Wires the cleanup into the wizard's finalize step (`_finalize_wizard`) and into `--check` mode (`_run_check`), following the existing `remove_redundant_auth_files` / `remove_synthetic_data` conventions — idempotent, reported in the wizard summary, and flagged as out-of-sync by `--check` if left in a partially-cleaned state.

- `tr_file_all_to_file` (populates `Files`) is never removed by either path.

## Tests

- [x] 12 new tests in `tests/test_foundation_setup_wizard.py` (`TestRemoveRedundantDiagramAnnotation`, `TestDiagramAnnotationStalePaths`): no-op when either module is absent, correct removal when both are installed, `tr_file_all_to_file` preserved, removed workflow YAML re-parses cleanly with the expected 2 remaining tasks, idempotency on a second run, `--check` detects both full and partially-cleaned stale state.
- [x] `python validate_packages.py` — all 12 packages validate (no `packages.toml` changes in this PR).