### PR TITLE
[AT-59] Part 2: auto-detect Foundation vs Demo pack kind 🕵🏻‍♂️

### DIFF
--- a/modules/common/cdf_project_foundation/scripts/_pack_config.py
+++ b/modules/common/cdf_project_foundation/scripts/_pack_config.py
@@ -2,6 +2,7 @@
 
 import tomllib
 from pathlib import Path
+from typing import Literal
 
 import yaml
 
@@ -43,6 +44,21 @@ SOURCE_SYSTEM_MODULE_DIRS: tuple[str, ...] = (
     "cdf_db_extractor",
     "cdf_files_extractor",
 )
+
+# Demo-pack (dp:quickstartdp) counterparts of SOURCE_SYSTEM_MODULE_DIRS — synthetic
+# data-dump modules instead of real extractors. Used only to detect which pack a
+# project is set up for (see detect_pack_kind); not consulted by the variant/auth
+# helpers above.
+DEMO_SOURCE_SYSTEM_MODULE_DIRS: tuple[str, ...] = (
+    "cdf_pi_data_dump",
+    "cdf_sap_data_dump",
+    "cdf_sharepoint_data_dump",
+)
+
+# "foundation": only *_extractor modules installed.
+# "demo": only *_data_dump modules installed.
+# "ambiguous": both kinds installed (cherry-picked mix) or neither — caller must ask.
+PackKind = Literal["foundation", "demo", "ambiguous"]
 
 # Contextualization modules whose standalone auth groups become redundant when
 # cdf_foundation is present (it covers all required capabilities).
@@ -181,6 +197,27 @@ def detect_data_model_variant(data_models_dir: Path) -> str:
             "  or pass --variant to select one explicitly."
         )
     return present[0]
+
+
+def detect_pack_kind(sourcesystem_dir: Path) -> PackKind:
+    """Detect whether the installed sourcesystem modules match the Foundation pack
+    (``*_extractor`` modules) or the Demo pack (``*_data_dump`` modules).
+
+    Returns ``"ambiguous"`` when both kinds are installed (a cherry-picked mix) or
+    when neither is installed — the caller should prompt the user in that case and
+    default the prompt itself to Foundation.
+    """
+    if not sourcesystem_dir.is_dir():
+        return "ambiguous"
+
+    has_extractor = any((sourcesystem_dir / name).is_dir() for name in SOURCE_SYSTEM_MODULE_DIRS)
+    has_data_dump = any((sourcesystem_dir / name).is_dir() for name in DEMO_SOURCE_SYSTEM_MODULE_DIRS)
+
+    if has_data_dump and not has_extractor:
+        return "demo"
+    if has_extractor and not has_data_dump:
+        return "foundation"
+    return "ambiguous"
 
 
 def load_yaml(path: Path) -> dict:

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 import yaml
 from _env_io import parse_env_file
@@ -33,6 +34,7 @@ from _pack_config import (
     TOOLS_REDUNDANT_AUTH,
     deep_merge,
     detect_data_model_variant,
+    detect_pack_kind,
     find_env_configs,
     get_contextualization_dir,
     get_data_models_dir,
@@ -430,6 +432,42 @@ def resolve_variant(args_variant: str | None, data_models_dir: Path) -> str:
             )
         return args_variant
     return detect_data_model_variant(data_models_dir)
+
+
+def resolve_pack_kind(sourcesystem_dir: Path) -> Literal["foundation", "demo"]:
+    """Resolve which pack (Foundation or Demo) this project is set up for.
+
+    Always derived from the installed sourcesystem modules (see
+    ``detect_pack_kind``) — there is no override flag, since every cleanup
+    function downstream already makes its own decision from installed module
+    directories rather than from this value. When detection is ``"ambiguous"``
+    (neither or both kinds present), prompt the user, defaulting to Foundation.
+    """
+    detected = detect_pack_kind(sourcesystem_dir)
+    if detected == "ambiguous":
+        return _prompt_pack_kind()
+    return detected
+
+
+def resolve_pack_kind_for_check(sourcesystem_dir: Path) -> Literal["foundation", "demo"]:
+    """Non-interactive counterpart of ``resolve_pack_kind`` for ``--check`` (CI) mode.
+
+    CI must never block on a prompt, so an ambiguous detection raises ``SystemExit``
+    instead — same shape as ``detect_data_model_variant``'s multiple-data-models error.
+    There is no override flag: a project with both extractor and data-dump modules
+    installed (or neither) is a malformed module selection that must be fixed, not
+    papered over.
+    """
+    detected = detect_pack_kind(sourcesystem_dir)
+    if detected == "ambiguous":
+        raise SystemExit(
+            "ERROR: Could not determine deployment pack kind from installed sourcesystem "
+            "modules under 'modules/sourcesystem/'\n"
+            "  (found both extractor and data-dump modules, or neither).\n"
+            "  A project should have either *_extractor modules (Foundation) or\n"
+            "  *_data_dump modules (Demo), not both or neither — fix the module selection."
+        )
+    return detected
 
 
 # ── Config file writers ────────────────────────────────────────────────────────
@@ -1168,8 +1206,10 @@ def _print_wizard_header(
     variant: str,
     pack_root: Path,
     installed_ctx: list[str],
+    pack_kind: Literal["foundation", "demo"],
 ) -> None:
     _banner("Foundation Deployment Pack — Project Setup")
+    _ok(f"Deployment pack    : {pack_kind}")
     _ok(f"Data model variant : {variant}")
     _ok(f"Pack root          : {pack_root}")
     org_dir = get_org_dir_name()
@@ -1362,6 +1402,22 @@ def _prompt_synthetic_data() -> bool:
     return prompt_yes_no("Keep synthetic data, example files, and diagram images?", default=False)
 
 
+def _prompt_pack_kind() -> Literal["foundation", "demo"]:
+    """Ask which pack this project is set up for when auto-detection is ambiguous
+    (both extractor and data-dump sourcesystem modules installed, or neither)."""
+    _section("Deployment Pack")
+    _hint("Could not determine from the installed sourcesystem modules whether this")
+    _hint("project is set up for the Foundation pack or the Demo pack.")
+    choice = prompt_choice(
+        [
+            "Foundation project (no synthetic data)",
+            "Demo project with synthetic data (recreated transformations and workflows)",
+        ],
+        default=1,
+    )
+    return "foundation" if choice == 1 else "demo"
+
+
 def _env_values_dirty(
     env_vals: dict[str, str],
     original_env_vals: dict[str, str],
@@ -1536,10 +1592,11 @@ def _run_wizard(
 ) -> None:
     pack_root = get_pack_root(repo_root)
     variant = resolve_variant(args_variant, get_data_models_dir(repo_root))
+    pack_kind = resolve_pack_kind(get_sourcesystem_dir(repo_root))
     installed_ctx = list_installed_contextualization_modules(repo_root)
     installed_ss = list_installed_source_system_modules(repo_root)
 
-    _print_wizard_header(variant, pack_root, installed_ctx)
+    _print_wizard_header(variant, pack_root, installed_ctx, pack_kind)
 
     selected_envs = _prompt_environments(pack_root)
     existing = _read_existing_values(pack_root, selected_envs, installed_ss)
@@ -1693,6 +1750,7 @@ def _run_check(
 ) -> None:
     pack_root = get_pack_root(repo_root)
     variant = resolve_variant(args_variant, get_data_models_dir(repo_root))
+    resolve_pack_kind_for_check(get_sourcesystem_dir(repo_root))
     # Read site and datasets from existing configs so user-configured values
     # (group names, location, dataset list) don't produce false positives.
     site, datasets = _read_check_context(pack_root)

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -9,7 +9,9 @@ Covers:
                    _write_config_update, remove_redundant_auth_files,
                    patch_cfihos_auth_for_missing_search, remove_synthetic_data,
                    _read_existing_values, remove_redundant_diagram_annotation,
-                   diagram_annotation_stale_paths
+                   diagram_annotation_stale_paths, resolve_pack_kind,
+                   resolve_pack_kind_for_check
+  - _pack_config  : detect_data_model_variant, detect_pack_kind
 """
 
 
@@ -18,6 +20,7 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT   = Path(__file__).resolve().parents[1]
@@ -1587,6 +1590,123 @@ class TestDetectDataModelVariant:
         (data_models_dir / "cfihos_oil_and_gas_extension").mkdir(parents=True)
         try:
             detect_data_model_variant(data_models_dir)
+            raise AssertionError("expected SystemExit")
+        except SystemExit:
+            pass
+
+
+# ── _pack_config — pack-kind detection ────────────────────────────────────────
+
+class TestDetectPackKind:
+    """detect_pack_kind distinguishes Foundation (*_extractor) from Demo
+    (*_data_dump) sourcesystem modules, or reports "ambiguous" when the signal
+    isn't clean — the caller decides how to handle ambiguity (see TestResolvePackKind)."""
+
+    def test_missing_sourcesystem_dir_is_ambiguous(self, tmp_path: Path) -> None:
+        from _pack_config import detect_pack_kind
+        assert detect_pack_kind(tmp_path / "modules" / "sourcesystem") == "ambiguous"
+
+    def test_empty_sourcesystem_dir_is_ambiguous(self, tmp_path: Path) -> None:
+        from _pack_config import detect_pack_kind
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        sourcesystem_dir.mkdir(parents=True)
+        assert detect_pack_kind(sourcesystem_dir) == "ambiguous"
+
+    def test_extractor_only_is_foundation(self, tmp_path: Path) -> None:
+        from _pack_config import detect_pack_kind
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        (sourcesystem_dir / "cdf_pi_extractor").mkdir(parents=True)
+        (sourcesystem_dir / "cdf_sap_extractor").mkdir(parents=True)
+        assert detect_pack_kind(sourcesystem_dir) == "foundation"
+
+    def test_data_dump_only_is_demo(self, tmp_path: Path) -> None:
+        from _pack_config import detect_pack_kind
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        (sourcesystem_dir / "cdf_pi_data_dump").mkdir(parents=True)
+        (sourcesystem_dir / "cdf_sharepoint_data_dump").mkdir(parents=True)
+        assert detect_pack_kind(sourcesystem_dir) == "demo"
+
+    def test_mixed_extractor_and_data_dump_is_ambiguous(self, tmp_path: Path) -> None:
+        from _pack_config import detect_pack_kind
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        (sourcesystem_dir / "cdf_pi_extractor").mkdir(parents=True)
+        (sourcesystem_dir / "cdf_sharepoint_data_dump").mkdir(parents=True)
+        assert detect_pack_kind(sourcesystem_dir) == "ambiguous"
+
+    def test_unrelated_module_only_is_ambiguous(self, tmp_path: Path) -> None:
+        """cdf_sharepoint / cdf_sap_assets / etc. are neither extractor nor
+        data-dump modules — their presence alone must not resolve either way."""
+        from _pack_config import detect_pack_kind
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        (sourcesystem_dir / "cdf_sharepoint").mkdir(parents=True)
+        assert detect_pack_kind(sourcesystem_dir) == "ambiguous"
+
+
+# ── setup_project — pack-kind resolution ──────────────────────────────────────
+
+class TestResolvePackKind:
+    """resolve_pack_kind: always auto-detected — no override flag, since every
+    cleanup function downstream already decides from installed module
+    directories rather than from this value. Prompts only when detection is
+    ambiguous (mirrors resolve_variant/detect_data_model_variant)."""
+
+    def test_unambiguous_demo_detected_without_prompting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import setup_project
+        from setup_project import resolve_pack_kind
+
+        def _fail_if_prompted() -> str:
+            raise AssertionError("must not prompt when detection is unambiguous")
+
+        monkeypatch.setattr(setup_project, "_prompt_pack_kind", _fail_if_prompted)
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        (sourcesystem_dir / "cdf_sharepoint_data_dump").mkdir(parents=True)
+        assert resolve_pack_kind(sourcesystem_dir) == "demo"
+
+    def test_unambiguous_foundation_detected_without_prompting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import setup_project
+        from setup_project import resolve_pack_kind
+
+        def _fail_if_prompted() -> str:
+            raise AssertionError("must not prompt when detection is unambiguous")
+
+        monkeypatch.setattr(setup_project, "_prompt_pack_kind", _fail_if_prompted)
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        (sourcesystem_dir / "cdf_pi_extractor").mkdir(parents=True)
+        assert resolve_pack_kind(sourcesystem_dir) == "foundation"
+
+    def test_ambiguous_detection_prompts_and_uses_answer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import setup_project
+        from setup_project import resolve_pack_kind
+
+        monkeypatch.setattr(setup_project, "_prompt_pack_kind", lambda: "demo")
+        # Sourcesystem dir missing entirely -> ambiguous.
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        assert resolve_pack_kind(sourcesystem_dir) == "demo"
+
+
+class TestResolvePackKindForCheck:
+    """--check must never block on a prompt: ambiguous detection raises SystemExit.
+    No override flag — a mismatch between installed modules and the expected pack
+    shape is a malformed module selection to fix, not something to override."""
+
+    def test_unambiguous_detection_resolved(self, tmp_path: Path) -> None:
+        from setup_project import resolve_pack_kind_for_check
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        (sourcesystem_dir / "cdf_sap_extractor").mkdir(parents=True)
+        assert resolve_pack_kind_for_check(sourcesystem_dir) == "foundation"
+
+    def test_ambiguous_detection_raises_without_prompting(self, tmp_path: Path) -> None:
+        from setup_project import resolve_pack_kind_for_check
+        # Sourcesystem dir missing entirely -> ambiguous.
+        sourcesystem_dir = tmp_path / "modules" / "sourcesystem"
+        try:
+            resolve_pack_kind_for_check(sourcesystem_dir)
             raise AssertionError("expected SystemExit")
         except SystemExit:
             pass


### PR DESCRIPTION
This is Chunk B of the "Unified Foundation/Demo setup script" plan (`PLAN.md`) — purely additive, no behavior change for existing Foundation DP users beyond a new header line (`Deployment pack : foundation`).

## Changes

- Adds `DEMO_SOURCE_SYSTEM_MODULE_DIRS` and `detect_pack_kind(sourcesystem_dir)` to `_pack_config.py`: distinguishes Foundation (`*_extractor` modules) from Demo (`*_data_dump` modules) installations, returning `"ambiguous"` when both or neither are present.
- Adds `resolve_pack_kind()` / `resolve_pack_kind_for_check()` / `_prompt_pack_kind()` to `setup_project.py`, wired into `_run_wizard` and `_run_check`. Detection is always auto-derived — the wizard only prompts (defaulting to Foundation) when detection is genuinely ambiguous; `--check` never prompts and instead fails fast with a clear message telling the user to fix their module selection.

## Test plan

- [x] New tests in `tests/test_foundation_setup_wizard.py`: `TestDetectPackKind` (all four detection combinations: extractor-only, data-dump-only, mixed, and neither/missing), `TestResolvePackKind` (unambiguous cases resolve without prompting — asserted via `monkeypatch` failing the test if `_prompt_pack_kind` is called; ambiguous case prompts and uses the answer), `TestResolvePackKindForCheck` (unambiguous resolves; ambiguous raises `SystemExit` without prompting).
- [x] `python validate_packages.py` — all 12 packages validate.