### PR TITLE
[AT-59] Part 3: close producer persona auth capability gap ahead of Demo pack unification 🛠️

### DIFF
--- a/modules/common/cdf_project_foundation/auth/producer.Group.yaml
+++ b/modules/common/cdf_project_foundation/auth/producer.Group.yaml
@@ -8,6 +8,10 @@ capabilities:
       actions: [READ, LIST]
       scope:
         all: {}
+  - groupsAcl:
+      actions: [LIST]
+      scope:
+        all: {}
   - sessionsAcl:
       actions: [CREATE]
       scope:
@@ -22,11 +26,22 @@ capabilities:
       scope:
         spaceIdScope:
           spaceIds: ["{{ schemaSpace }}", "{{ instanceSpace }}"]
+  - dataModelsAcl:
+      actions: [READ]
+      scope:
+        spaceIdScope:
+          spaceIds: {{ additionalSchemaSpaces }}
   - dataModelInstancesAcl:
-      actions: [READ, WRITE]
+      actions: [READ, WRITE, WRITE_PROPERTIES]
       scope:
         spaceIdScope:
           spaceIds: {{ instanceSpaces }}
+  - dataModelInstancesAcl:
+      actions: [READ]
+      scope:
+        spaceIdScope:
+          spaceIds:
+            - cdf_cdm
   - timeSeriesAcl:
       actions: [READ, WRITE]
       scope:
@@ -38,10 +53,18 @@ capabilities:
         datasetScope:
           ids: {{ dataset }}
   - rawAcl:
-      actions: [READ, WRITE]
+      actions: [READ, WRITE, LIST]
       scope:
         all: {}
   - transformationsAcl:
+      actions: [READ, WRITE]
+      scope:
+        all: {}
+  - functionsAcl:
+      actions: [READ, WRITE]
+      scope:
+        all: {}
+  - entitymatchingAcl:
       actions: [READ, WRITE]
       scope:
         all: {}

--- a/modules/common/cdf_project_foundation/default.config.yaml
+++ b/modules/common/cdf_project_foundation/default.config.yaml
@@ -27,6 +27,13 @@ instanceSpace: "sp_cdm_instances"
 # one per installed extractor module. Computed by setup_project.py.
 instanceSpaces: ["sp_cdm_instances"]
 
+# Additional schema spaces the producer persona reads from, in addition to
+# schemaSpace. Default (this file, and the "cdm" variant) is CDM-only.
+# setup_project.py extends this per variant with that variant's own search-solution
+# space — e.g. cfihos_oil_and_gas_extension adds dm_sol_oil_and_gas_search,
+# isa_manufacturing_extension adds dm_sol_isa_manufacturing_search.
+additionalSchemaSpaces: ["cdf_cdm", "cdf_idm", "cdf_cdm_units"]
+
 # Data model variant — controls which schema/instance spaces are synced.
 # Supported: cdm | isa_manufacturing_extension | cfihos_oil_and_gas_extension
 dataModelVariant: cdm

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -142,16 +142,15 @@ def config_arg(org_dir: str | None, env: str) -> str:
     return f"-c {config}"
 
 
-def setup_project_check_cmd(org_dir: str | None) -> str:
+def setup_project_check_cmd(repo_root: Path, org_dir: str | None) -> str:
     """Command to verify config.<env>.yaml is in sync with the installed variant
     and pack before ``cdf build`` runs — catches drift (e.g. a new variable added
     to a module since the config was last generated) with an actionable message
     instead of a raw Toolkit "undefined variable" build failure.
     """
-    script = "modules/common/cdf_project_foundation/scripts/setup_project.py"
-    if org_dir:
-        script = f"{org_dir}/{script}"
-    return f"python {script} --check"
+    modules_root = resolve_modules_root(repo_root, org_dir)
+    script_path = modules_root / "common" / "cdf_project_foundation" / "scripts" / "setup_project.py"
+    return f"python {script_path.relative_to(repo_root).as_posix()} --check"
 
 
 def build_args(toolkit_version: str, org_dir: str | None, env: str) -> str:
@@ -363,7 +362,7 @@ def main() -> None:
         "BRANCH_PROTECTION_NOTE": branch_protection_note(projects),
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
-        "SETUP_PROJECT_CHECK_CMD": setup_project_check_cmd(org_dir),
+        "SETUP_PROJECT_CHECK_CMD": setup_project_check_cmd(repo_root, org_dir),
     }
 
     if deployable_envs(projects):

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -142,6 +142,18 @@ def config_arg(org_dir: str | None, env: str) -> str:
     return f"-c {config}"
 
 
+def setup_project_check_cmd(org_dir: str | None) -> str:
+    """Command to verify config.<env>.yaml is in sync with the installed variant
+    and pack before ``cdf build`` runs — catches drift (e.g. a new variable added
+    to a module since the config was last generated) with an actionable message
+    instead of a raw Toolkit "undefined variable" build failure.
+    """
+    script = "modules/common/cdf_project_foundation/scripts/setup_project.py"
+    if org_dir:
+        script = f"{org_dir}/{script}"
+    return f"python {script} --check"
+
+
 def build_args(toolkit_version: str, org_dir: str | None, env: str) -> str:
     if parse_version(toolkit_version) >= CONFIG_FLAG_MIN_VERSION:
         return config_arg(org_dir, env)
@@ -351,6 +363,7 @@ def main() -> None:
         "BRANCH_PROTECTION_NOTE": branch_protection_note(projects),
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
+        "SETUP_PROJECT_CHECK_CMD": setup_project_check_cmd(org_dir),
     }
 
     if deployable_envs(projects):

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -97,8 +97,10 @@ VARIANT_SEARCH_SCHEMA_SPACE: dict[str, str | None] = {
 
 def additional_schema_spaces_for_variant(variant: str) -> list[str]:
     """Producer's dataModelsAcl read-only space list for the given variant."""
+    if variant not in VARIANT_SEARCH_SCHEMA_SPACE:
+        raise ValueError(f"Unknown data model variant: {variant}")
     spaces = list(BASE_ADDITIONAL_SCHEMA_SPACES)
-    extra = VARIANT_SEARCH_SCHEMA_SPACE.get(variant)
+    extra = VARIANT_SEARCH_SCHEMA_SPACE[variant]
     if extra:
         spaces.append(extra)
     return spaces

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -83,6 +83,26 @@ INGESTION_FOUNDATION_VARIABLES: dict[str, dict[str, str]] = {
     },
 }
 
+# Producer dataModelsAcl read spaces: base CDM/IDM/units; variant search space appended below.
+BASE_ADDITIONAL_SCHEMA_SPACES: list[str] = ["cdf_cdm", "cdf_idm", "cdf_cdm_units"]
+
+# Per-variant search-solution schema space appended to the base list above.
+# None for "cdm" — the base Cognite Data Model has no separate search solution module.
+VARIANT_SEARCH_SCHEMA_SPACE: dict[str, str | None] = {
+    "cdm": None,
+    "isa_manufacturing_extension": "dm_sol_isa_manufacturing_search",
+    "cfihos_oil_and_gas_extension": "dm_sol_oil_and_gas_search",
+}
+
+
+def additional_schema_spaces_for_variant(variant: str) -> list[str]:
+    """Producer's dataModelsAcl read-only space list for the given variant."""
+    spaces = list(BASE_ADDITIONAL_SCHEMA_SPACES)
+    extra = VARIANT_SEARCH_SCHEMA_SPACE.get(variant)
+    if extra:
+        spaces.append(extra)
+    return spaces
+
 
 # Per-variant overrides for contextualization modules.
 # ``None`` values are sentinels resolved to the variant's ``instanceSpace``
@@ -320,6 +340,7 @@ def build_foundation_vars(
         ingestion["instanceSpace"] = _cdm_instance_space(site)
     # Always write dataset so the key exists; empty list when no SS modules installed.
     ingestion["dataset"] = datasets if datasets is not None else []
+    ingestion["additionalSchemaSpaces"] = additional_schema_spaces_for_variant(variant)
     for persona in PERSONAS:
         ingestion[f"{persona}GroupName"] = group_name(persona, site, env)
         ingestion[f"{persona}SourceId"] = f"${{{persona.upper()}_SOURCE_ID}}"

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install Cognite Toolkit
         run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
+      - name: Verify project config is in sync
+        run: {{SETUP_PROJECT_CHECK_CMD}}
+
       - name: cdf build
         run: cdf build {{PROD_BUILD_ARGS}}
 

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Cognite Toolkit
         run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
+      - name: Verify project config is in sync
+        run: {{SETUP_PROJECT_CHECK_CMD}}
+
       - name: cdf build
         run: cdf build {{BUILD_ARGS}}
 

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Install Cognite Toolkit
         run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
+      - name: Verify project config is in sync
+        run: {{SETUP_PROJECT_CHECK_CMD}}
+
       - name: cdf build
         id: build
         run: |

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -434,3 +434,32 @@ environment:
         for env in {"dev", "test", "prod"} - set(envs):
             assert f"`acme-{env}`" not in docs
             assert f"`config.{env}.yaml`" not in docs
+
+
+def _make_foundation_module(modules_root: Path) -> None:
+    module_dir = modules_root / "common" / "cdf_project_foundation" / "scripts"
+    module_dir.mkdir(parents=True)
+    (module_dir / "setup_project.py").write_text("", encoding="utf-8")
+
+
+def test_setup_project_check_cmd_org_dir_set_but_modules_at_repo_root(tmp_path: Path) -> None:
+    """org_dir being configured in cdf.toml doesn't guarantee modules/ is nested
+    under it — resolve_modules_root checks the repo root first. The generated
+    command must point at wherever modules/ actually is, not blindly prefix org_dir."""
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    _make_foundation_module(tmp_path / "modules")
+
+    cmd = generate_actions.setup_project_check_cmd(tmp_path, "industrial")
+    assert cmd == "python modules/common/cdf_project_foundation/scripts/setup_project.py --check"
+
+
+def test_setup_project_check_cmd_modules_nested_under_org_dir(tmp_path: Path) -> None:
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    _make_foundation_module(tmp_path / "industrial" / "modules")
+
+    cmd = generate_actions.setup_project_check_cmd(tmp_path, "industrial")
+    assert cmd == "python industrial/modules/common/cdf_project_foundation/scripts/setup_project.py --check"

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -92,6 +92,12 @@ environment:
     assert "cdf build --env dev" in dry_run
     assert "cdf deploy --dry-run | tee dryrun-output.txt" in dry_run
     assert "cdf deploy --dry-run --env" not in dry_run
+    assert (
+        "run: python industrial/modules/common/cdf_project_foundation/scripts/"
+        "setup_project.py --check"
+    ) in dry_run
+    # The check step must run before the "cdf build" step, not after.
+    assert dry_run.index("Verify project config is in sync") < dry_run.index("- name: cdf build")
 
     deploy_dev = (tmp_path / ".github" / "workflows" / "deploy-dev.yml").read_text(
         encoding="utf-8"
@@ -103,6 +109,19 @@ environment:
     assert "ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}" in deploy_dev
     assert "CONSUMER_SOURCE_ID: ${{ vars.CONSUMER_SOURCE_ID }}" in deploy_dev
     assert "PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}" in deploy_dev
+    assert (
+        "run: python industrial/modules/common/cdf_project_foundation/scripts/"
+        "setup_project.py --check"
+    ) in deploy_dev
+    assert deploy_dev.index("Verify project config is in sync") < deploy_dev.index("- name: cdf build")
+
+    deploy_prod = (tmp_path / ".github" / "workflows" / "deploy-prod.yml").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        "run: python industrial/modules/common/cdf_project_foundation/scripts/"
+        "setup_project.py --check"
+    ) in deploy_prod
 
     cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
     assert "`acme-dev`" in cicd_docs

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -356,6 +356,15 @@ class TestBuildFoundationVars:
         cfihos = build_foundation_vars("cfihos_oil_and_gas_extension", "dev", "")["additionalSchemaSpaces"]
         assert cfihos == ["cdf_cdm", "cdf_idm", "cdf_cdm_units", "dm_sol_oil_and_gas_search"]
 
+    def test_additional_schema_spaces_rejects_unknown_variant(self) -> None:
+        """Guards against a variant added to INGESTION_FOUNDATION_VARIABLES without a
+        matching entry in VARIANT_SEARCH_SCHEMA_SPACE — must fail loudly rather than
+        silently omit the variant's search-solution space."""
+        from setup_project import additional_schema_spaces_for_variant
+
+        with pytest.raises(ValueError, match="Unknown data model variant"):
+            additional_schema_spaces_for_variant("not_a_real_variant")
+
 
 class TestCdmInstanceSpace:
     def test_uses_site_when_set(self) -> None:

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -339,6 +339,23 @@ class TestBuildFoundationVars:
         vars_ = build_foundation_vars("cdm", "dev", "oslo")
         assert vars_["instanceSpace"] == "sp_oslo_instances"
 
+    def test_additional_schema_spaces_present_for_every_variant(self) -> None:
+        """additionalSchemaSpaces backs producer.Group.yaml's second dataModelsAcl
+        entry — must always be present, regardless of variant, so the Jinja var is
+        never undefined at build time. Base CDM/IDM spaces are universal; each
+        variant additionally gets only its own search-solution space, not every
+        variant's."""
+        from setup_project import build_foundation_vars
+
+        cdm_only = build_foundation_vars("cdm", "dev", "")["additionalSchemaSpaces"]
+        assert cdm_only == ["cdf_cdm", "cdf_idm", "cdf_cdm_units"]
+
+        isa = build_foundation_vars("isa_manufacturing_extension", "dev", "")["additionalSchemaSpaces"]
+        assert isa == ["cdf_cdm", "cdf_idm", "cdf_cdm_units", "dm_sol_isa_manufacturing_search"]
+
+        cfihos = build_foundation_vars("cfihos_oil_and_gas_extension", "dev", "")["additionalSchemaSpaces"]
+        assert cfihos == ["cdf_cdm", "cdf_idm", "cdf_cdm_units", "dm_sol_oil_and_gas_search"]
+
 
 class TestCdmInstanceSpace:
     def test_uses_site_when_set(self) -> None:


### PR DESCRIPTION
Chunk C of the "Unified Foundation/Demo setup script" plan. Closes the capability gap between `common/cdf_ingestion`'s own auth files and `cdf_project_foundation`'s `producer.Group.yaml` — required before Chunk D can delete `cdf_ingestion`'s auth files once the module is wired into the Demo pack.

## Changes

- **`producer.Group.yaml`**: adds `groupsAcl`, `functionsAcl`, `entitymatchingAcl`; extends `rawAcl` (+`LIST`) and `dataModelInstancesAcl` (+`WRITE_PROPERTIES`); adds read-only access to `additionalSchemaSpaces` and the base `cdf_cdm` space (needed for `CogniteAsset.parent`). `admin.Group.yaml` already had full parity — no changes.
- **`additionalSchemaSpaces`** (new list variable): variant-aware via `additional_schema_spaces_for_variant()`. Base CDM/IDM spaces always included; each variant adds only its own search-solution space (`cfihos_oil_and_gas_extension` → `dm_sol_oil_and_gas_search`, `isa_manufacturing_extension` → `dm_sol_isa_manufacturing_search`, `cdm` → none). Demo DP (CFIHOS-only) gets the CFIHOS space through this same rule.
- **CI compatibility fix**: a new required config variable would break `cdf build` for already-deployed Foundation DP projects with no migration path (generated CI templates ran `cdf build`/`cdf deploy` with no drift check). Added a **"Verify project config is in sync"** step (`setup_project.py --check`) before `cdf build` in all three templates, via a new `setup_project_check_cmd(org_dir)` helper — turns a raw Toolkit error into an actionable message. The one-time migration (re-run the wizard) is still required.

## Test

- [x] Pinned test asserting exact computed `additionalSchemaSpaces` per variant.
- [x] Updated CI-generator tests confirming the new check step is present, org-dir-prefixed, and ordered before `cdf build`.