### PR TITLE
[AT-59] Part 4: wire cdf_project_foundation into Demo DP 🪡

### DIFF
--- a/modules/common/cdf_ingestion/README.md
+++ b/modules/common/cdf_ingestion/README.md
@@ -39,6 +39,8 @@ cdf_ingestion/
 ├── 📁 auth/                             # Authentication groups
 │   ├── 📄 user.Group.yaml                      # User permissions for manual runs
 │   └── 📄 workflow.Group.yaml                  # Service account permissions
+├── 📁 data_sets/                        # Dataset definitions
+│   └── 📄 ingestion.DataSet.yaml               # Dataset referenced by the workflow (dataSetExternalId)
 ├── 📁 workflows/                        # Workflow definitions
 │   ├── 📄 ingest.Workflow.yaml                 # Main workflow definition
 │   ├── 📄 v1.WorkflowVersion.yaml              # Workflow version with tasks

--- a/modules/common/cdf_ingestion/README.md
+++ b/modules/common/cdf_ingestion/README.md
@@ -51,6 +51,12 @@ cdf_ingestion/
 
 ### 1. Auth Groups
 
+> **Note:** When `common/cdf_project_foundation` is also installed (as it is on
+> `dp:quickstart`), these two files are automatically removed by
+> `setup_project.py` — the persona groups in `cdf_project_foundation` already cover
+> every capability listed below. See that module's
+> [README](../cdf_project_foundation/README.md#access-groups) for details.
+
 | Resource | Description |
 |----------|-------------|
 | `user.Group` | Permissions for users to run the workflow manually |

--- a/modules/common/cdf_ingestion/data_sets/ingestion.DataSet.yaml
+++ b/modules/common/cdf_ingestion/data_sets/ingestion.DataSet.yaml
@@ -1,0 +1,3 @@
+name: Ingestion
+externalId: {{ dataset }}
+description: This dataset contains Transformations, Functions, and Workflows for ingesting data into Cognite Data Fusion.

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -9,11 +9,22 @@ The **Foundation Deployment Pack** (`dp:foundation`) is the recommended starting
 - **Highly extensible** — simple to plug in your own data sources and processing logic
 - **Reliable** — everything included works out of the box
 
-This module provides the **project-level foundation** of the pack: three persona-based access groups and a project setup wizard, aligned with the [project-setup SOP](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G)).*
+This module provides the **project-level foundation** shared by two deployment packs: three persona-based access groups and a project setup wizard, aligned with the [project-setup SOP](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G)).*
+
+## Foundation vs. Demo
+
+| | `dp:foundation` (Foundation) | `dp:quickstart` (Foundation Deployment Pack Demo) |
+|---|---|---|
+| **Use for** | Real customer projects, no synthetic data | Exploring CDF / showcasing end-to-end ingestion + contextualization |
+| **Source systems** | `*_extractor` modules (`cdf_pi_extractor`, `cdf_sap_extractor`, …) | `*_data_dump` modules (`cdf_pi_data_dump`, `cdf_sap_data_dump`, `cdf_sharepoint_data_dump`) |
+| **Data model** | Choose CDM / ISA / CFIHOS | Always CFIHOS (`cfihos_oil_and_gas_extension`) |
+| **Ingestion orchestration** | Each extractor module owns its own extraction pipeline config | `common/cdf_ingestion` (shared workflow driving all the CFIHOS transformations) |
+
+Both packs include this module (`cdf_project_foundation`) for the persona access groups and the setup wizard. The wizard **auto-detects which pack you're running** from the sourcesystem modules you selected in Step 2 — you don't need to tell it which pack you're on. See [Which pack am I on?](#which-pack-am-i-on) below for how detection works.
 
 ---
 
-## Deploying the Foundation Deployment Pack
+## Deploying the Foundation Deployment Pack (or the Demo)
 
 ### Step 0 — Prerequisites
 
@@ -42,7 +53,7 @@ From a clean Toolkit project directory, run the interactive module selector:
 cdf modules init
 ```
 
-Select **Foundation Deployment Pack** from the list.
+Select **Foundation Deployment Pack** for a real customer project, or **Foundation Deployment Pack Demo** to explore CDF with synthetic data.
 
 > **Note:** The Toolkit selector shows display titles (e.g. "Foundation Deployment Pack"). The actual module IDs used in config files and referenced in the tables below are the directory names shown in each table (e.g. `cdf_project_foundation`, `isa_manufacturing_extension`).
 
@@ -52,7 +63,14 @@ Select **Foundation Deployment Pack** from the list.
 
 ### Step 2 — Select modules
 
-The module selector presents all available modules. Make selections carefully:
+> **Demo pack users can skip this step.** `dp:quickstart` ships a fixed module list
+> (`canCherryPick = false` in `packages.toml`) — `cdf modules init` installs everything
+> below automatically: `cdf_common`, `cdf_ingestion`, `cdf_project_foundation`,
+> `cdf_file_annotation`, `cdf_entity_matching`, the three `*_data_dump` source modules,
+> and the CFIHOS data model + search extension. Go straight to
+> [Step 3](#step-3--run-the-setup-wizard).
+
+The Foundation pack's module selector presents all available modules individually. Make selections carefully:
 
 **Data model** — optional, select **at most one** core variant:
 
@@ -101,7 +119,7 @@ The module selector presents all available modules. Make selections carefully:
 
 | Module | Description |
 |--------|-------------|
-| `cdf_project_foundation` | This module — persona access groups, per-extractor groups, and the interactive setup wizard. |
+| `cdf_project_foundation` | This module — persona access groups, per-extractor groups, and the interactive setup wizard. Also shipped by `dp:quickstart`, where it covers the same capabilities `cdf_common`/`cdf_ingestion` used to grant via their own auth files (now removed by the wizard as redundant — see [Access Groups](#access-groups)). |
 
 **Project observability** — recommended:
 
@@ -114,6 +132,28 @@ The module selector presents all available modules. Make selections carefully:
 ### Step 3 — Run the setup wizard
 
 From the Toolkit project root, run the interactive setup wizard. It prompts for CDF project names, site/location, Entra ID group source IDs, source system owner contacts, and ApplicationOwner (if file annotation is installed), then writes all `config.<env>.yaml` files and `.env` in one pass.
+
+#### Which pack am I on?
+
+The wizard header shows the resolved pack and data model variant on every run:
+
+```
+──────────────────────────────────────────────────────────
+  Foundation Deployment Pack Demo — Project Setup
+──────────────────────────────────────────────────────────
+  ✓  Deployment pack    : demo
+  ✓  Data model variant : cfihos_oil_and_gas_extension
+```
+
+Detection looks at which `modules/sourcesystem/` modules are installed:
+
+| Installed sourcesystem modules | Resolved pack |
+|---|---|
+| Only `*_extractor` modules (`cdf_pi_extractor`, …) | `foundation` |
+| Only `*_data_dump` modules (`cdf_pi_data_dump`, …) | `demo` |
+| Both kinds, or neither | **Ambiguous** — the wizard prompts you to choose |
+
+You never need to pass a flag for this — it's fully automatic for both packs shipped via `cdf modules init`. The ambiguous case only comes up if you hand-cherry-picked source system modules from both packs into the same project.
 
 > **Environment selection — first prompt:** Toolkit creates `dev`, `prod`, and `staging` (= test) config files during `cdf modules init`. The wizard detects these and asks:
 > *"You selected dev and prod while installing the DP. Continue with current selection (dev, prod)?"*
@@ -232,7 +272,7 @@ Three CDF groups are deployed, each bound to an Entra ID security group via its 
 | Group | Name (example) | Persona | Capability scope |
 |-------|---------------|---------|-----------------|
 | `consumer.Group.yaml` | `consumer_all_dev` / `consumer_oslo_all_prod` | Read-only | READ on data models / instances / timeseries / files / transformations, scoped to `{{ dataset }}` / `{{ instanceSpaces }}` / `{{ schemaSpace }}` — `instanceSpaces` includes the project-level DM space plus one per installed extractor |
-| `producer.Group.yaml` | `producer_all_dev` / `producer_oslo_all_prod` | Read/write | Consumer rights plus WRITE to instances / timeseries / files / RAW, run transformations, workflow orchestration, sessions CREATE |
+| `producer.Group.yaml` | `producer_all_dev` / `producer_oslo_all_prod` | Read/write | Consumer rights plus WRITE to instances / timeseries / files / RAW, run transformations, workflow orchestration, sessions CREATE, plus `functionsAcl` and `entitymatchingAcl` and read access to `{{ additionalSchemaSpaces }}` (base CDM/IDM + the installed variant's search-solution space) |
 | `admin.Group.yaml` | `admin_all_dev` / `admin_all_prod` | Admin | Full capabilities including `groups:write`, projects, datasets, data models, transformations, workflows, extraction pipelines |
 
 The wizard stores group source IDs in `.env` as `CONSUMER_SOURCE_ID`, `PRODUCER_SOURCE_ID`, `ADMIN_SOURCE_ID` and the config files reference them via `${…}`. These are Entra ID object IDs, **not secrets**.
@@ -254,17 +294,19 @@ The wizard (`scripts/setup_project.py`) is split across four helper modules:
 
 ### Wizard flow
 
-1. Prompts for which environments to set up (all three, dev only, dev+prod, or custom).
-2. Asks for the CDF project name for each selected environment (pre-filled on re-run).
-3. Asks for an required site / location name — used as access-group suffix, source system location, and entity-matching `location_name`.
-4. Prompts for source system integration owner and data owner contacts (shared or per-module).
+1. Resolves which pack (`foundation` or `demo`) this project is set up for — see [Which pack am I on?](#which-pack-am-i-on). Shown in the header; only prompts if genuinely ambiguous.
+2. Prompts for which environments to set up (all three, dev only, dev+prod, or custom).
+3. Asks for the CDF project name for each selected environment (pre-filled on re-run).
+4. Asks for an required site / location name — used as access-group suffix, source system location, and entity-matching `location_name`.
+5. Prompts for source system integration owner and data owner contacts (shared or per-module).
    - For the CFIHOS data model: prompts for **data model owner** name and email (renamed from "integration owner" to reflect its purpose).
-5. Prompts for group source IDs (Entra ID object IDs) and writes them to `.env`.
-6. Asks for the Streamlit ApplicationOwner email if `cdf_file_annotation` is installed.
-7. Shows a review summary then confirms before writing anything.
-8. Creates new config files or updates existing ones in-place (preserving comments).
-9. Removes redundant auth files from contextualization and tools modules covered by the foundation.
-10. Optionally generates GitHub Actions CI/CD workflows.
+6. Prompts for group source IDs (Entra ID object IDs) and writes them to `.env`.
+7. Asks for the Streamlit ApplicationOwner email if `cdf_file_annotation` is installed.
+8. Shows a review summary then confirms before writing anything.
+9. Creates new config files or updates existing ones in-place (preserving comments).
+10. Removes redundant auth files from contextualization, tools, and (Demo pack) `cdf_ingestion` modules covered by the foundation.
+11. Removes the synthetic diagram-annotation pipeline if both `cdf_sharepoint_data_dump` and `cdf_file_annotation` are installed — see [Demo pack: synthetic diagram-annotation cleanup](#demo-pack-synthetic-diagram-annotation-cleanup).
+12. Optionally generates GitHub Actions CI/CD workflows (this now includes a `setup_project.py --check` step before every `cdf build`, so a project with stale config fails with an actionable message instead of a raw Toolkit build error).
 
 | Env key | Maps to | Config file |
 |---------|---------|------------|
@@ -285,6 +327,13 @@ instanceSpace: "inst_isa_manufacturing"    # ISA default; CFIHOS uses inst_locat
 instanceSpaces: ["inst_isa_manufacturing"] # project-level space + per-extractor spaces (computed by wizard)
 dataModelVariant: isa_manufacturing_extension
 
+# Read-only producer.Group.yaml scope, in addition to schemaSpace. Base CDM/IDM spaces
+# are always included; the installed variant's own search-solution space is appended
+# (cfihos_oil_and_gas_extension -> dm_sol_oil_and_gas_search,
+#  isa_manufacturing_extension -> dm_sol_isa_manufacturing_search, cdm -> none extra).
+# Computed per env by setup_project.py; static default here is CDM-only.
+additionalSchemaSpaces: ["cdf_cdm", "cdf_idm", "cdf_cdm_units"]
+
 # Computed per env by setup_project.py:
 consumerGroupName: "consumer_all_dev"
 producerGroupName: "producer_all_dev"
@@ -300,9 +349,11 @@ adminSourceId: "${ADMIN_SOURCE_ID}"
 
 ## Dependencies
 
-**Package**: `dp:foundation`
+**Package**: `dp:foundation` (primary), also shipped by `dp:quickstart` (Demo).
 
-Self-contained. The group ACLs reference `{{ dataset }}`, `{{ instanceSpaces }}`, and `{{ schemaSpace }}`, which must match the values used by the deployed source-system and data-model modules. `instanceSpaces` is computed by the setup wizard as the project-level DM space plus one per installed extractor module.
+Self-contained. The group ACLs reference `{{ dataset }}`, `{{ instanceSpaces }}`, `{{ schemaSpace }}`, and `{{ additionalSchemaSpaces }}`, which must match the values used by the deployed source-system and data-model modules. `instanceSpaces` is computed by the setup wizard as the project-level DM space plus one per installed extractor module.
+
+On `dp:quickstart`, this module's persona groups replace `common/cdf_ingestion`'s own auth files (removed by the wizard as redundant) — `cdf_ingestion` itself (workflows, datasets) stays installed and required.
 
 See the [project-setup SOP](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G))* for the authoritative procedure covering environments, Entra ID integration, CI/CD, and sign-off.
 

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -65,10 +65,9 @@ Select **Foundation Deployment Pack** for a real customer project, or **Foundati
 
 > **Demo pack users can skip this step.** `dp:quickstart` ships a fixed module list
 > (`canCherryPick = false` in `packages.toml`) — `cdf modules init` installs everything
-> below automatically: `cdf_common`, `cdf_ingestion`, `cdf_project_foundation`,
-> `cdf_file_annotation`, `cdf_entity_matching`, the three `*_data_dump` source modules,
-> and the CFIHOS data model + search extension. Go straight to
-> [Step 3](#step-3--run-the-setup-wizard).
+> below automatically: `cdf_ingestion`, `cdf_project_foundation`, `cdf_file_annotation`,
+> `cdf_entity_matching`, the three `*_data_dump` source modules, and the CFIHOS data
+> model + search extension. Go straight to [Step 3](#step-3--run-the-setup-wizard).
 
 The Foundation pack's module selector presents all available modules individually. Make selections carefully:
 
@@ -119,7 +118,7 @@ The Foundation pack's module selector presents all available modules individuall
 
 | Module | Description |
 |--------|-------------|
-| `cdf_project_foundation` | This module — persona access groups, per-extractor groups, and the interactive setup wizard. Also shipped by `dp:quickstart`, where it covers the same capabilities `cdf_common`/`cdf_ingestion` used to grant via their own auth files (now removed by the wizard as redundant — see [Access Groups](#access-groups)). |
+| `cdf_project_foundation` | This module — persona access groups, per-extractor groups, and the interactive setup wizard. Also shipped by `dp:quickstart`, where it covers the same capabilities `cdf_ingestion` used to grant via its own auth files (now removed by the wizard as redundant — see [Access Groups](#access-groups)). |
 
 **Project observability** — recommended:
 

--- a/modules/common/cdf_project_foundation/scripts/_pack_config.py
+++ b/modules/common/cdf_project_foundation/scripts/_pack_config.py
@@ -68,8 +68,8 @@ CONTEXTUALIZATION_REDUNDANT_AUTH: dict[str, tuple[str, ...]] = {
     "cdf_file_annotation": ("auth/file_annotation.Group.yaml",),
 }
 
-# Tools/apps modules whose standalone auth groups become redundant when
-# cdf_foundation is present.
+# Other modules (outside contextualization/) whose standalone auth groups become
+# redundant when cdf_project_foundation is present.
 # Maps module path (relative to modules/) → auth file(s) relative to the module root.
 TOOLS_REDUNDANT_AUTH: dict[str, tuple[str, ...]] = {
     "tools/apps/qualitizer": ("auth/apps.qualitizer.Group.yaml",),
@@ -78,6 +78,11 @@ TOOLS_REDUNDANT_AUTH: dict[str, tuple[str, ...]] = {
     "datamodels/cfihos_oil_and_gas_extension": (
         "auth/gp_cdf_owner_cfihos_oil_gas_data_model.group.yaml",
         "auth/gp_cdf_read_cfihos_oil_gas_data_model.group.yaml",
+    ),
+    # cdf_ingestion's own auth (Demo pack only) is redundant
+    "common/cdf_ingestion": (
+        "auth/user.Group.yaml",
+        "auth/workflow.Group.yaml",
     ),
 }
 

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -1040,7 +1040,8 @@ def _read_existing_values(
         # Support both flat (new) and nested-category (old) structures.
         foundation = (
             modules.get("cdf_project_foundation")
-            or modules.get("common", {}).get("cdf_project_foundation", {})
+            or (modules.get("common") or {}).get("cdf_project_foundation")
+            or {}
         )
         if foundation.get("site"):
             existing["site"] = foundation["site"]
@@ -1060,7 +1061,7 @@ def _read_existing_values(
         if (pack_root / "modules" / "common" / "cdf_ingestion").is_dir():
             ingestion_vars = (
                 modules.get("cdf_ingestion")
-                or modules.get("common", {}).get("cdf_ingestion", {})
+                or (modules.get("common") or {}).get("cdf_ingestion")
                 or {}
             )
             ingestion_dataset = ingestion_vars.get("dataset", "ingestion")

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -220,6 +220,11 @@ _STALE_CTX_KEYS: tuple[str, ...] = (
     "variables.modules.cfihos_oil_and_gas_extension.read_source_id",
     "variables.modules.datamodels.cfihos_oil_and_gas_extension.owner_source_id",
     "variables.modules.datamodels.cfihos_oil_and_gas_extension.read_source_id",
+    # cdf_ingestion's own group source ID (Demo pack) — only ever referenced by its
+    # own auth/{user,workflow}.Group.yaml, which remove_redundant_auth_files() deletes
+    # once cdf_project_foundation's persona groups are present.
+    "variables.modules.cdf_ingestion.groupSourceId",
+    "variables.modules.common.cdf_ingestion.groupSourceId",
 )
 
 # ── Domain helpers ─────────────────────────────────────────────────────────────
@@ -1225,13 +1230,19 @@ def _detect_installed_envs(pack_root: Path) -> tuple[str, ...]:
     return tuple(detected)
 
 
+_PACK_KIND_TITLE: dict[str, str] = {
+    "foundation": "Foundation Deployment Pack",
+    "demo": "Foundation Deployment Pack Demo",
+}
+
+
 def _print_wizard_header(
     variant: str,
     pack_root: Path,
     installed_ctx: list[str],
     pack_kind: Literal["foundation", "demo"],
 ) -> None:
-    _banner("Foundation Deployment Pack — Project Setup")
+    _banner(f"{_PACK_KIND_TITLE[pack_kind]} — Project Setup")
     _ok(f"Deployment pack    : {pack_kind}")
     _ok(f"Data model variant : {variant}")
     _ok(f"Pack root          : {pack_root}")

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -1053,6 +1053,19 @@ def _read_existing_values(
             ds = mod_vars.get("dataset", "")
             if ds and isinstance(ds, str) and ds not in ss_datasets:
                 ss_datasets.append(ds)
+        # cdf_ingestion (Demo pack only) has its own dataset, scoped by the
+        # workflow.Group.yaml auth that remove_redundant_auth_files() deletes once
+        # cdf_project_foundation's persona groups take over — fold it into the persona
+        # dataset list too, or the producer group loses that access entirely.
+        if (pack_root / "modules" / "common" / "cdf_ingestion").is_dir():
+            ingestion_vars = (
+                modules.get("cdf_ingestion")
+                or modules.get("common", {}).get("cdf_ingestion", {})
+                or {}
+            )
+            ingestion_dataset = ingestion_vars.get("dataset", "ingestion")
+            if ingestion_dataset and isinstance(ingestion_dataset, str) and ingestion_dataset not in ss_datasets:
+                ss_datasets.append(ingestion_dataset)
         if ss_datasets:
             existing["dataset"] = ss_datasets
         app_owner = (

--- a/modules/packages.toml
+++ b/modules/packages.toml
@@ -34,6 +34,7 @@ canCherryPick = false
 modules = [
     "common/cdf_common",
     "common/cdf_ingestion",
+    "common/cdf_project_foundation",
     "contextualization/cdf_file_annotation",
     "contextualization/cdf_entity_matching",
     "sourcesystem/cdf_pi_data_dump",

--- a/modules/packages.toml
+++ b/modules/packages.toml
@@ -32,7 +32,6 @@ title = "Foundation Deployment Pack Demo"
 description = "Showcase end-to-end CDF: ingestion, contextualization, and dashboards. Use this to explore CDF; for production deployments use the Foundation Deployment Pack."
 canCherryPick = false
 modules = [
-    "common/cdf_common",
     "common/cdf_ingestion",
     "common/cdf_project_foundation",
     "contextualization/cdf_file_annotation",

--- a/modules/sourcesystem/cdf_sharepoint_data_dump/README.md
+++ b/modules/sourcesystem/cdf_sharepoint_data_dump/README.md
@@ -12,6 +12,17 @@ Use this module when deploying `dp:quickstart` against the `cfihos_oil_and_gas_e
 model. It is not a replacement for `cdf_sharepoint` in other deployment packs — `cdf_sharepoint`
 remains the correct choice for `dp:foundation`.
 
+> **Diagram-annotation cleanup:** the `diagram_annotation.*` RAW data, its 3 transformation
+> pairs, and the standalone `wf_diagram_annotation.*` workflow work on their own — this module
+> doesn't require `contextualization/cdf_file_annotation` to produce annotation edges. But
+> `dp:quickstart` installs both, and running both together would write competing
+> `CogniteDiagramAnnotation` edges. `common/cdf_project_foundation`'s setup wizard
+> (`setup_project.py`) detects this and automatically removes the diagram-annotation files
+> from your project (and the matching tasks from `common/cdf_ingestion`'s workflow) the first
+> time it runs — nothing is removed from the library module itself, and a project using only
+> this module keeps the synthetic pipeline unchanged. `tr_file_all_to_file` (populates `Files`)
+> is never removed by either path.
+
 ## Module Components
 
 - `raw/file.Table.yaml`, `diagram_annotation.Table.yaml` — RAW table definitions.

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -1499,6 +1499,41 @@ class TestReadExistingValues:
         assert "ds_pi" in existing["dataset"]
         assert "ds_sap" in existing["dataset"]
 
+    def test_reads_cdf_ingestion_dataset_when_installed(self, tmp_path: Path) -> None:
+        """cdf_ingestion's own dataset must be folded into the persona dataset list —
+        remove_redundant_auth_files() deletes the auth file that used to scope its
+        transformations/extraction-pipeline access to this dataset, so the persona
+        groups are the only thing left granting it."""
+        from setup_project import _read_existing_values
+        (tmp_path / "modules" / "common" / "cdf_ingestion").mkdir(parents=True)
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_ingestion": {"dataset": "ds_custom_ingestion"},
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert "ds_custom_ingestion" in existing["dataset"]
+
+    def test_reads_cdf_ingestion_dataset_default_when_no_override(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        (tmp_path / "modules" / "common" / "cdf_ingestion").mkdir(parents=True)
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {}},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert "ingestion" in existing["dataset"]
+
+    def test_skips_cdf_ingestion_dataset_when_not_installed(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {}},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["dataset"] == []
+
     def test_reads_app_owner(self, tmp_path: Path) -> None:
         from setup_project import _read_existing_values
         self._write_config(tmp_path / "config.dev.yaml", {

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -1515,6 +1515,16 @@ class TestReadExistingValues:
         existing = _read_existing_values(tmp_path, ("dev",), [])
         assert "ds_custom_ingestion" in existing["dataset"]
 
+    def test_reads_cdf_ingestion_dataset_when_common_key_is_null(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        (tmp_path / "modules" / "common" / "cdf_ingestion").mkdir(parents=True)
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {"common": None}},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert "ingestion" in existing["dataset"]
+
     def test_reads_cdf_ingestion_dataset_default_when_no_override(self, tmp_path: Path) -> None:
         from setup_project import _read_existing_values
         (tmp_path / "modules" / "common" / "cdf_ingestion").mkdir(parents=True)

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -365,6 +365,27 @@ class TestBuildFoundationVars:
         with pytest.raises(ValueError, match="Unknown data model variant"):
             additional_schema_spaces_for_variant("not_a_real_variant")
 
+    def test_no_demo_specific_keys_leak_into_foundation_config(self) -> None:
+        """cdf_project_foundation is now shared by both
+        packs, but build_foundation_vars() takes no pack-kind parameter at all — it
+        must keep producing the exact same fixed key set regardless of which pack
+        (Foundation or Demo) triggered the wizard, for every variant. If a
+        Demo-specific key were ever added here by mistake, it would silently reach
+        every Foundation deploy too."""
+        from setup_project import build_foundation_vars
+
+        expected_keys = {
+            "dataModelVariant", "schemaSpace", "instanceSpace", "site", "dataset",
+            "additionalSchemaSpaces",
+            "consumerGroupName", "producerGroupName", "adminGroupName",
+            "consumerSourceId", "producerSourceId", "adminSourceId",
+        }
+        for variant in ("cdm", "isa_manufacturing_extension", "cfihos_oil_and_gas_extension"):
+            vars_ = build_foundation_vars(variant, "dev", "oslo", ["ds_pi"])
+            assert set(vars_.keys()) == expected_keys, (
+                f"unexpected key set for variant={variant}: {set(vars_.keys())}"
+            )
+
 
 class TestCdmInstanceSpace:
     def test_uses_site_when_set(self) -> None:
@@ -812,6 +833,41 @@ class TestRemoveRedundantAuthFiles:
         self._make_auth_file(auth_dir / "other.group.yaml")  # unrelated file stays
         remove_redundant_auth_files(tmp_path)
         assert auth_dir.exists()
+
+    # ── cdf_ingestion (Chunk D: redundant once cdf_project_foundation covers Demo) ──
+
+    def test_removes_cdf_ingestion_auth(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        ingestion_auth = tmp_path / "modules" / "common" / "cdf_ingestion" / "auth"
+        self._make_auth_file(ingestion_auth / "user.Group.yaml")
+        self._make_auth_file(ingestion_auth / "workflow.Group.yaml")
+        removed = remove_redundant_auth_files(tmp_path)
+        assert len(removed) == 2
+        assert not (ingestion_auth / "user.Group.yaml").exists()
+        assert not (ingestion_auth / "workflow.Group.yaml").exists()
+
+    def test_removes_empty_cdf_ingestion_auth_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        ingestion_auth = tmp_path / "modules" / "common" / "cdf_ingestion" / "auth"
+        self._make_auth_file(ingestion_auth / "user.Group.yaml")
+        self._make_auth_file(ingestion_auth / "workflow.Group.yaml")
+        remove_redundant_auth_files(tmp_path)
+        assert not ingestion_auth.exists()
+
+    def test_leaves_non_empty_cdf_ingestion_auth_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        ingestion_auth = tmp_path / "modules" / "common" / "cdf_ingestion" / "auth"
+        self._make_auth_file(ingestion_auth / "user.Group.yaml")
+        self._make_auth_file(ingestion_auth / "workflow.Group.yaml")
+        self._make_auth_file(ingestion_auth / "other.Group.yaml")  # unrelated file stays
+        remove_redundant_auth_files(tmp_path)
+        assert ingestion_auth.exists()
+
+    def test_no_op_when_cdf_ingestion_not_installed(self, tmp_path: Path) -> None:
+        """Foundation-only projects never ship cdf_ingestion — must not error."""
+        from setup_project import remove_redundant_auth_files
+        removed = remove_redundant_auth_files(tmp_path)
+        assert removed == []
 
 
 class TestRestoreCdmSpaceFile:
@@ -1738,6 +1794,22 @@ class TestResolvePackKindForCheck:
             pass
 
 
+class TestWizardHeaderTitle:
+
+    def test_foundation_banner(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        from setup_project import _print_wizard_header
+        _print_wizard_header("cdm", tmp_path, [], "foundation")
+        out = capsys.readouterr().out
+        assert "Foundation Deployment Pack — Project Setup" in out
+        assert "Foundation Deployment Pack Demo" not in out
+
+    def test_demo_banner(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        from setup_project import _print_wizard_header
+        _print_wizard_header("cfihos_oil_and_gas_extension", tmp_path, [], "demo")
+        out = capsys.readouterr().out
+        assert "Foundation Deployment Pack Demo — Project Setup" in out
+
+
 class TestEnvPathResolution:
     """The .env file must always be written to repo root (where cdf.toml lives),
     not inside the org directory."""
@@ -1802,3 +1874,24 @@ class TestStaleKeyRemoval:
         content = p.read_text()
         assert "owner_source_id" not in content
         assert "read_source_id" not in content
+
+    def test_cdf_ingestion_group_source_id_in_stale_keys(self) -> None:
+        from setup_project import _STALE_CTX_KEYS
+        assert any(k.endswith("cdf_ingestion.groupSourceId") for k in _STALE_CTX_KEYS)
+
+    def test_stale_cdf_ingestion_group_source_id_removed_from_config(self, tmp_path: Path) -> None:
+        from setup_project import _write_config_update, build_overlay
+        p = tmp_path / "config.dev.yaml"
+        p.write_text(textwrap.dedent("""\
+            environment:
+              project: acme-dev
+            variables:
+              modules:
+                cdf_ingestion:
+                  groupSourceId: ${GROUP_SOURCE_ID}
+                  dataset: ingestion
+        """))
+        overlay = build_overlay("cfihos_oil_and_gas_extension", "dev", "", [])
+        _write_config_update(p, "acme-dev", overlay)
+        content = p.read_text()
+        assert "groupSourceId" not in content


### PR DESCRIPTION
Chunk D of the "Unified Foundation/Demo setup script" plan. Wires `cdf_project_foundation` into `dp:quickstart` (Demo DP) so both packs share the same persona groups and setup wizard, and extends the existing redundant-auth cleanup to cover `cdf_ingestion`.

## Changes

- **`packages.toml`**: adds `common/cdf_project_foundation` to the Demo pack. 
- **`_pack_config.py`**: extends the existing redundant-auth mapping to cover `cdf_ingestion`'s auth files, same mechanism already used for CFIHOS DM and qualitizer — no logic change needed in the removal function itself.
- - **Drops `common/cdf_common` from Demo DP entirely.** Traced its actual usage and found only one hard dependency (the `ingestion` dataset `cdf_ingestion`'s workflow references) — everything else it ships (spaces, RAW databases, an annotation-writer function) is unused by any module Demo DP actually installs. Duplicated the one needed dataset resource directly into `cdf_ingestion` and removed `cdf_common` from the pack's module list. `cdf_common` itself is untouched — still shipped standalone via `dp:common`.
- **README updates**: documented the shared setup script, pack auto-detection, and the diagram-annotation/auth cleanup behavior across `cdf_project_foundation`, `cdf_ingestion`, and `cdf_sharepoint_data_dump`.

## Test

- [x] New tests covering the `cdf_ingestion` redundant-auth case, the wizard banner per pack kind, and the stale-key cleanup.
- [x] Full suite green, ruff/pyright clean, `validate_packages.py` passing.