### PR TITLE
fix(dashboards/context_quality): resolve deployment failures reported

### DIFF
--- a/modules/dashboards/context_quality/README.md
+++ b/modules/dashboards/context_quality/README.md
@@ -707,6 +707,19 @@ client.functions.schedules.create(
 2. Re-run all batches from the beginning
 3. Ensure each batch shows "✅ Completed" before running aggregation
 
+### Browser console shows CORS errors (`NetworkError`, "blocked by CORS policy")
+
+**Symptom:** Running a batch fails immediately with errors like `Failed to execute 'send' on 'XMLHttpRequest'` or `Access to XMLHttpRequest at '.../functions/byids' ... has been blocked by CORS policy: ... No 'Access-Control-Allow-Origin' header is present`, referencing an origin such as `https://cognite-stlite-fusion-standalone-production.web.app`.
+
+**Cause:** This is **not a bug in this module** — some CDF clusters (staging clusters, and greenfield-type clusters) enforce strict CORS checks that require the browser's Origin header to be on an allow-list of registered "Applications" for the project. The Streamlit dashboard runs in-browser (via Pyodide/stlite) from that fixed Cognite-hosted origin, so it's blocked until that origin is allow-listed for your project.
+
+**Solution:**
+1. Ask a CDF **organization admin** for your project to open Fusion → **Admin** → **My Organization** → **Applications**.
+2. Register (or confirm) an application entry for the origin `https://cognite-stlite-fusion-standalone-production.web.app` — this is the same origin for every Cognite Streamlit custom app, so this is a one-time, per-project fix, not something to repeat per dashboard.
+3. Re-run the batch once the origin is allow-listed.
+
+This requires org-admin access to the CDF project and cannot be worked around from inside the module.
+
 ---
 
 ## Metrics Reference

--- a/modules/dashboards/context_quality/functions/context_quality.Function.yaml
+++ b/modules/dashboards/context_quality/functions/context_quality.Function.yaml
@@ -3,6 +3,7 @@ externalId: context_quality_handler
 owner: 'Anonymous'
 description: Handles contextualization quality metrics operations.
 functionPath: 'handler.py'
+runtime: 'py312'
 # Required when the project is in DATA_MODELING_ONLY mode: used as the space for the
 # CogniteFile that stores the function code. Omit or override if using dataset-only.
 space: context_quality

--- a/modules/dashboards/context_quality/functions/context_quality_handler/pyproject.toml
+++ b/modules/dashboards/context_quality/functions/context_quality_handler/pyproject.toml
@@ -3,6 +3,6 @@ name = "context-quality-handler"
 version = "0.0.0"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "cognite-sdk>=7,<8",
+    "cognite-sdk>=7.89.0,<8",
     "mixpanel>=4.10.0",
 ]

--- a/modules/dashboards/context_quality/functions/context_quality_handler/requirements.txt
+++ b/modules/dashboards/context_quality/functions/context_quality_handler/requirements.txt
@@ -1,2 +1,2 @@
-cognite-sdk>=7.0.0
+cognite-sdk>=7.89.0,<8
 mixpanel>=4.10.0

--- a/modules/dashboards/context_quality/streamlit/context_quality_dashboard/pyproject.toml
+++ b/modules/dashboards/context_quality/streamlit/context_quality_dashboard/pyproject.toml
@@ -5,7 +5,6 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "pyodide-http>=0.2.1",
     "cognite-sdk>=7.89.0,<8",
-    "cognite-pygen",
     "packaging",
     "plotly",
     "matplotlib",

--- a/modules/dashboards/context_quality/streamlit/context_quality_dashboard/requirements.txt
+++ b/modules/dashboards/context_quality/streamlit/context_quality_dashboard/requirements.txt
@@ -1,6 +1,5 @@
 pyodide-http>=0.2.1
 cognite-sdk>=7.89.0,<8
-cognite-pygen
 packaging
 plotly
 matplotlib

--- a/scripts/generate_uv_member_projects.py
+++ b/scripts/generate_uv_member_projects.py
@@ -195,11 +195,11 @@ PACKAGE_SPECS: list[dict[str, object]] = [
         "name": "context-quality-handler",
         "requires_python": ">=3.11,<3.14",
         "dependencies": [
-            "cognite-sdk>=7,<8",
+            "cognite-sdk>=7.89.0,<8",
             "mixpanel>=4.10.0",
         ],
         "deploy_dependencies": [
-            "cognite-sdk>=7.0.0",
+            "cognite-sdk>=7.89.0,<8",
             "mixpanel>=4.10.0",
         ],
     },
@@ -210,7 +210,6 @@ PACKAGE_SPECS: list[dict[str, object]] = [
         "dependencies": [
             "pyodide-http>=0.2.1",
             "cognite-sdk>=7.89.0,<8",
-            "cognite-pygen",
             "packaging",
             "plotly",
             "matplotlib",
@@ -219,7 +218,6 @@ PACKAGE_SPECS: list[dict[str, object]] = [
         "deploy_dependencies": [
             "pyodide-http>=0.2.1",
             "cognite-sdk>=7.89.0,<8",
-            "cognite-pygen",
             "packaging",
             "plotly",
             "matplotlib",

--- a/uv.lock
+++ b/uv.lock
@@ -311,22 +311,6 @@ dev = [
 ]
 
 [[package]]
-name = "cognite-pygen"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cognite-sdk" },
-    { name = "inflect" },
-    { name = "jinja2" },
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/0f/a5e0530d6ac8b0d263068ab8ffb5c3d5d6bd2ac35970e763569ffa130a22/cognite_pygen-1.3.0.tar.gz", hash = "sha256:c70326eebff66ad1e4694da18568db2821815bcf0134c60df7bf868099a3baf5", size = 127342, upload-time = "2026-03-28T13:46:18.689Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/76/5d449d8fc66904091787187aaa3d214f903cf9cced78f02fce70fb0aa221/cognite_pygen-1.3.0-py3-none-any.whl", hash = "sha256:bf258c1fb7afc8b47d0b2366302abe57236347425529836fd06cb109e26c576e", size = 165487, upload-time = "2026-03-28T13:46:17.251Z" },
-]
-
-[[package]]
 name = "cognite-sdk"
 version = "7.94.0"
 source = { registry = "https://pypi.org/simple" }
@@ -366,7 +350,6 @@ name = "context-quality-dashboard"
 version = "0.0.0"
 source = { virtual = "modules/dashboards/context_quality/streamlit/context_quality_dashboard" }
 dependencies = [
-    { name = "cognite-pygen" },
     { name = "cognite-sdk" },
     { name = "fpdf2" },
     { name = "matplotlib" },
@@ -377,7 +360,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognite-pygen" },
     { name = "cognite-sdk", specifier = ">=7.89.0,<8" },
     { name = "fpdf2", specifier = ">=2.7.0" },
     { name = "matplotlib" },
@@ -397,7 +379,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cognite-sdk", specifier = ">=7,<8" },
+    { name = "cognite-sdk", specifier = ">=7.89.0,<8" },
     { name = "mixpanel", specifier = ">=4.10.0" },
 ]
 
@@ -928,19 +910,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
-]
-
-[[package]]
-name = "inflect"
-version = "7.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-    { name = "typeguard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
 ]
 
 [[package]]
@@ -1923,18 +1892,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
-]
-
-[[package]]
-name = "typeguard"
-version = "4.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Remove cognite-pygen from the Streamlit app's deps: it has no pure-Python wheel, so micropip can't install it in the Pyodide runtime CDF Streamlit apps run in.
- Pin the context_quality_handler function to runtime: 'py312' (matching other functions in this repo), since the default runtime's Python 3.14 has no prebuilt pydantic-core wheel and fails to compile it from source (missing C toolchain in the function build sandbox).
- Align context_quality_handler's cognite-sdk pin with the Streamlit app's (>=7.89.0,<8) instead of the looser >=7.0.0.

The main.py/handler.py absolute-import fixes Jan Inge applied directly (modules.dashboards... -> local from dashboards import / from metrics import) were already present on main.