### PR TITLE
fix (ci): foundation cicd fixes

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -54,13 +54,20 @@ Select **Foundation Deployment Pack** from the list.
 
 The module selector presents all available modules. Make selections carefully:
 
-**Data model** — select **exactly one** core variant:
+**Data model** — optional, select **at most one** core variant:
 
 > ⚠️ **Select only one data model variant.** Selecting both will break auto-detection
-> and require the `--variant` flag on every script run.
+> and require the `--variant` flag on every script run. If you select **none**, the
+> pack automatically configures itself against the base Cognite Data Model
+> (CogniteCore, space `cdf_cdm`) — no extra module required, and the setup wizard
+> will not error. Since there's no extension module to create the instance space,
+> `cdf_project_foundation` creates it itself as `sp_{site}_instances` (the same
+> `sp_<site>_<suffix>` convention used for the extractor instance spaces), and
+> removes that resource automatically if you later add a data model extension.
 
 | Option | Description |
 |--------|-------------|
+| *(none selected)* | Falls back to the base Cognite Data Model (CogniteCore) — `CogniteAsset` / `CogniteTimeSeries` / `CogniteFile` in space `cdf_cdm`. |
 | [`isa_manufacturing_extension`](../../datamodels/isa_manufacturing_extension/README.md) | ISA-95 enterprise data model for manufacturing assets (assets, equipment, functional locations, time series). |
 | [`cfihos_oil_and_gas_extension`](../../datamodels/cfihos_oil_and_gas_extension/README.md) | CFIHOS enterprise data model for oil & gas assets. |
 
@@ -126,6 +133,8 @@ Other options:
 
 ```bash
 python modules/common/cdf_project_foundation/scripts/setup_project.py -y --variant isa_manufacturing_extension
+
+python modules/common/cdf_project_foundation/scripts/setup_project.py -y --variant cdm
 
 python modules/common/cdf_project_foundation/scripts/setup_project.py --check   # CI drift check
 ```

--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -61,9 +61,11 @@ The module selector presents all available modules. Make selections carefully:
 > pack automatically configures itself against the base Cognite Data Model
 > (CogniteCore, space `cdf_cdm`) — no extra module required, and the setup wizard
 > will not error. Since there's no extension module to create the instance space,
-> `cdf_project_foundation` creates it itself as `sp_{site}_instances` (the same
-> `sp_<site>_<suffix>` convention used for the extractor instance spaces), and
-> removes that resource automatically if you later add a data model extension.
+> the setup wizard writes a `data_modeling/cdm_instance_space.Space.yaml` resource
+> into `cdf_project_foundation` that creates `sp_{site}_instances` (the same
+> `sp_<site>_<suffix>` convention used for the extractor instance spaces). This
+> file is only ever written when no extension is selected — it isn't shipped by
+> the module itself.
 
 | Option | Description |
 |--------|-------------|

--- a/modules/common/cdf_project_foundation/data_modeling/cdm_instance_space.Space.yaml
+++ b/modules/common/cdf_project_foundation/data_modeling/cdm_instance_space.Space.yaml
@@ -1,3 +1,0 @@
-space: {{ instanceSpace }}
-name: Instance space
-description: Base Cognite Data Model (CogniteCore) instance space

--- a/modules/common/cdf_project_foundation/data_modeling/cdm_instance_space.Space.yaml
+++ b/modules/common/cdf_project_foundation/data_modeling/cdm_instance_space.Space.yaml
@@ -1,0 +1,3 @@
+space: {{ instanceSpace }}
+name: Instance space
+description: Base Cognite Data Model (CogniteCore) instance space

--- a/modules/common/cdf_project_foundation/default.config.yaml
+++ b/modules/common/cdf_project_foundation/default.config.yaml
@@ -20,13 +20,13 @@ producerSourceId: "${PRODUCER_SOURCE_ID}"    # read/write ingestion producers
 adminSourceId: "${ADMIN_SOURCE_ID}"          # foundation administrators
 
 # Schema space where the selected data model views are defined.
-schemaSpace: "dm_dom_isa_manufacturing"
+schemaSpace: "cdf_cdm"
 # Space where DM instances are written (project-level).
-instanceSpace: "inst_isa_manufacturing"
+instanceSpace: "sp_cdm_instances"
 # All DM spaces the consumer group needs read access to: project-level space +
 # one per installed extractor module. Computed by setup_project.py.
-instanceSpaces: ["inst_isa_manufacturing"]
+instanceSpaces: ["sp_cdm_instances"]
 
 # Data model variant — controls which schema/instance spaces are synced.
-# Supported: isa_manufacturing_extension | cfihos_oil_and_gas_extension
-dataModelVariant: isa_manufacturing_extension
+# Supported: cdm | isa_manufacturing_extension | cfihos_oil_and_gas_extension
+dataModelVariant: cdm

--- a/modules/common/cdf_project_foundation/scripts/_pack_config.py
+++ b/modules/common/cdf_project_foundation/scripts/_pack_config.py
@@ -32,6 +32,10 @@ KNOWN_DATA_MODEL_DIRS = (
     "cfihos_oil_and_gas_extension",
 )
 
+# Fallback variant used when no data model extension is installed — the base
+# Cognite Data Model (CogniteCore), always available without extra modules.
+DEFAULT_DATA_MODEL_VARIANT = "cdm"
+
 SOURCE_SYSTEM_MODULE_DIRS: tuple[str, ...] = (
     "cdf_pi_extractor",
     "cdf_sap_extractor",
@@ -156,13 +160,12 @@ def find_env_configs(repo_root: Path | None = None) -> list[Path]:
 def detect_data_model_variant(data_models_dir: Path) -> str:
     """
     Detect installed data model from subdirectory names under modules/datamodels/.
-    Raises SystemExit with a message when zero or multiple models are found.
+    Falls back to ``DEFAULT_DATA_MODEL_VARIANT`` (base CDM) when the directory is
+    missing or contains no supported extension. Raises SystemExit only when
+    multiple supported extensions are found (ambiguous).
     """
     if not data_models_dir.is_dir():
-        raise SystemExit(
-            f"ERROR: Data models directory not found: {data_models_dir}\n"
-            "  Expected modules/datamodels/ under the pack root."
-        )
+        return DEFAULT_DATA_MODEL_VARIANT
 
     present = [
         name
@@ -170,10 +173,7 @@ def detect_data_model_variant(data_models_dir: Path) -> str:
         if (data_models_dir / name).is_dir()
     ]
     if not present:
-        raise SystemExit(
-            f"ERROR: No supported data model found under {data_models_dir}\n"
-            f"  Expected one of: {', '.join(KNOWN_DATA_MODEL_DIRS)}"
-        )
+        return DEFAULT_DATA_MODEL_VARIANT
     if len(present) > 1:
         raise SystemExit(
             f"ERROR: Multiple data models found under {data_models_dir}: {present}\n"

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -178,17 +178,6 @@ def load_environment_projects(repo_root: Path, org_dir: str | None) -> dict[str,
     return projects
 
 
-def workflow_file_list(include_test: bool) -> str:
-    files = [
-        '".github/workflows/dry-run.yml"',
-        '".github/workflows/deploy-dev.yml"',
-    ]
-    if include_test:
-        files.append('".github/workflows/deploy-test.yml"')
-    files.append('".github/workflows/deploy-prod.yml"')
-    return "\n".join(f"              {path}," for path in files)
-
-
 def pr_branches(include_test: bool) -> str:
     branches = ["dev"]
     if include_test:
@@ -274,7 +263,6 @@ def main() -> None:
         "PROD_PROJECT": projects["prod"],
         "DEV_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "dev"),
         "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
-        "WORKFLOW_FILES": workflow_file_list(include_test),
         "PR_BRANCHES": pr_branches(include_test),
         "DRY_RUN_ENVIRONMENT": dry_run_environment(include_test),
         "DRY_RUN_BUILD_SCRIPT": indent(dry_run_build_script(str(toolkit_version), org_dir, include_test), 10),

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -236,6 +236,23 @@ def env_config_list(projects: dict[str, str]) -> str:
     return ", ".join(configs[:-1]) + f", or {configs[-1]}"
 
 
+def branch_protection_rows(projects: dict[str, str]) -> str:
+    rows = ["| `dev` | none | `cdf build & deploy --dry-run` |"]
+    if "test" in projects:
+        rows.append("| `main` | 1 | `Source branch guardrail`, `cdf build & deploy --dry-run` |")
+    return "\n".join(rows)
+
+
+def branch_protection_note(projects: dict[str, str]) -> str:
+    note = "PRs to `dev` only run dry-run CI (0 reviewers)."
+    if "test" in projects:
+        note += (
+            " The `Source branch guardrail` check does not run on `dev` — it only applies to PRs"
+            " targeting `main`, where it enforces that changes are promoted from `dev` or `hotfix/*`."
+        )
+    return note
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -269,6 +286,8 @@ def main() -> None:
         "TEST_BRANCHING_ROWS": test_branching_rows(projects),
         "TEST_ENVIRONMENT_ROW": test_environment_row(projects),
         "ENV_CONFIG_LIST": env_config_list(projects),
+        "BRANCH_PROTECTION_ROWS": branch_protection_rows(projects),
+        "BRANCH_PROTECTION_NOTE": branch_protection_note(projects),
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
     }

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -618,26 +618,33 @@ def remove_redundant_auth_files(repo_root: Path | None = None) -> list[Path]:
     return removed
 
 
-# Space resource that creates the base-CDM instance space — only needed when no
-# data model extension is installed (an installed extension ships its own).
+# Space resource that creates the base-CDM instance space. Not shipped as a
+# module asset — cdf_project_foundation has no fixed instance space of its own,
+# so this is written by the wizard only when no data model extension is
+# installed (an installed extension ships its own instance-space resource).
 _CDM_INSTANCE_SPACE_REL_PATH = "modules/common/cdf_project_foundation/data_modeling/cdm_instance_space.Space.yaml"
+_CDM_INSTANCE_SPACE_CONTENT = (
+    "space: {{ instanceSpace }}\n"
+    "name: Instance space\n"
+    "description: Base Cognite Data Model (CogniteCore) instance space\n"
+)
 
 
-def remove_redundant_cdm_space_file(variant: str, repo_root: Path | None = None) -> Path | None:
-    """Remove the CDM instance-space file once a data model extension is installed.
+def restore_cdm_space_file(variant: str, repo_root: Path | None = None) -> Path | None:
+    """Write the CDM instance-space file when no data model extension is installed.
 
-    The extension ships its own instance-space resource for the same
-    ``instanceSpace`` value, so keeping both would declare the same space twice.
-    Removes the ``data_modeling/`` directory too once it is left empty.
+    No-op unless ``variant == "cdm"``. Since the file is never shipped in the
+    module, this is the only place it gets created — including when a project
+    switches back to ``cdm`` after previously using an extension.
     """
-    if variant == "cdm":
+    if variant != "cdm":
         return None
     space_file = get_pack_root(repo_root) / _CDM_INSTANCE_SPACE_REL_PATH
-    if not space_file.exists():
+    if space_file.exists():
         return None
-    space_file.unlink()
-    _ok(f"Removed redundant CDM instance space file: {_CDM_INSTANCE_SPACE_REL_PATH}")
-    _rmdir_if_empty(space_file.parent)
+    space_file.parent.mkdir(parents=True, exist_ok=True)
+    space_file.write_text(_CDM_INSTANCE_SPACE_CONTENT)
+    _ok(f"Created CDM instance space file: {_CDM_INSTANCE_SPACE_REL_PATH}")
     return space_file
 
 
@@ -1323,7 +1330,7 @@ def _finalize_wizard(
 
     removed = remove_redundant_auth_files(repo_root)
     patched = patch_cfihos_auth_for_missing_search(repo_root)
-    removed_cdm_space = remove_redundant_cdm_space_file(variant, repo_root)
+    created_cdm_space = restore_cdm_space_file(variant, repo_root)
     _cleanup_file_annotation_module(repo_root)
 
     synthetic_removed = 0
@@ -1340,8 +1347,8 @@ def _finalize_wizard(
         _ok(f"{len(removed)} redundant auth file(s) removed.")
     if patched:
         _ok(f"{len(patched)} cfihos auth file(s) patched (search_space removed).")
-    if removed_cdm_space:
-        _ok("Redundant CDM instance space file removed (data model extension covers it).")
+    if created_cdm_space:
+        _ok("CDM instance space file created (no data model extension installed).")
     if env_dirty:
         _ok(".env updated with group source IDs.")
     if synthetic_removed:
@@ -1401,7 +1408,9 @@ def _run_wizard(
         site, installed_ss, repo_root
     )
     app_owner = _prompt_app_owner(installed_ctx, existing["app_owner"])
-    keep_synthetic = _prompt_synthetic_data()
+    # No data model extension installed under "cdm" — nothing for
+    # remove_synthetic_data to clean up, so don't ask.
+    keep_synthetic = True if variant == "cdm" else _prompt_synthetic_data()
 
     env_dirty = _env_values_dirty(env_vals, original_env_vals)
     _show_wizard_review(targets, project_names, env_dirty)
@@ -1557,9 +1566,9 @@ def _run_check(
             if (ctx_dir / module_dir / rel_path).exists():
                 stale_auth.append(ctx_dir / module_dir / rel_path)
 
-    stale_cdm_space = (
-        variant != "cdm" and (get_pack_root(repo_root) / _CDM_INSTANCE_SPACE_REL_PATH).exists()
-    )
+    missing_cdm_space = variant == "cdm" and not (
+        get_pack_root(repo_root) / _CDM_INSTANCE_SPACE_REL_PATH
+    ).exists()
 
     if all_errors:
         print(f"ERROR: Config file(s) out of sync with variant '{variant}':\n")
@@ -1575,9 +1584,9 @@ def _run_check(
             print(f"  {p.relative_to(ctx_dir.parent.parent)}")
         print("\n  Run: python scripts/setup_project.py -y")
         sys.exit(1)
-    if stale_cdm_space:
+    if missing_cdm_space:
         print(
-            f"ERROR: Redundant CDM instance space file still present for variant '{variant}':\n"
+            f"ERROR: CDM instance space file missing for variant '{variant}':\n"
             f"  {_CDM_INSTANCE_SPACE_REL_PATH}"
         )
         print("\n  Run: python scripts/setup_project.py -y")

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -29,7 +29,6 @@ import yaml
 from _env_io import parse_env_file
 from _pack_config import (
     CONTEXTUALIZATION_REDUNDANT_AUTH,
-    KNOWN_DATA_MODEL_DIRS,
     REPO_ROOT,
     TOOLS_REDUNDANT_AUTH,
     deep_merge,
@@ -64,6 +63,11 @@ PERSONAS: tuple[str, ...] = ("consumer", "producer", "admin")
 # ── Data-model-driven variable maps (per variant) ─────────────────────────────
 
 INGESTION_FOUNDATION_VARIABLES: dict[str, dict[str, str]] = {
+    "cdm": {
+        "dataModelVariant": "cdm",
+        "schemaSpace": "cdf_cdm",
+        "instanceSpace": "sp_cdm_instances",
+    },
     "isa_manufacturing_extension": {
         "dataModelVariant": "isa_manufacturing_extension",
         "schemaSpace": "dm_dom_isa_manufacturing",
@@ -81,6 +85,29 @@ INGESTION_FOUNDATION_VARIABLES: dict[str, dict[str, str]] = {
 # ``None`` values are sentinels resolved to the variant's ``instanceSpace``
 # at runtime by ``resolve_contextualization_variables``.
 CONTEXTUALIZATION_VARIABLES: dict[str, dict[str, dict]] = {
+    "cdm": {
+        "cdf_entity_matching": {
+            "schemaSpace": "cdf_cdm",
+            "assetInstanceSpace": None,
+            "timeseriesInstanceSpace": None,
+            "AssetViewExternalId": "CogniteAsset",
+            "TimeSeriesViewExternalId": "CogniteTimeSeries",
+            "targetViewExternalId": "CogniteAsset",
+            "entityViewExternalId": "CogniteTimeSeries",
+            "targetViewSearchProperty": "name",
+            "targetViewFilterValues": [],
+            "entityViewSearchProperty": "name",
+            "entityViewFilterValues": [],
+        },
+        "cdf_file_annotation": {
+            "fileSchemaSpace": "cdf_cdm",
+            "fileInstanceSpace": None,
+            "fileExternalId": "CogniteFile",
+            "targetEntitySchemaSpace": "cdf_cdm",
+            "targetEntityInstanceSpace": None,
+            "targetEntityExternalId": "CogniteAsset",
+        },
+    },
     "isa_manufacturing_extension": {
         "cdf_entity_matching": {
             "schemaSpace": "dm_dom_isa_manufacturing",
@@ -176,6 +203,15 @@ def group_name(persona: str, site: str, env: str) -> str:
     """SOP pattern: ``<persona>_[{site}_]all_<env>``; env is 'dev' (dev+test) or 'prod'."""
     segments = [persona] + ([site] if site else []) + ["all", GROUP_ENV[env]]
     return "_".join(segments)
+
+
+def _cdm_instance_space(site: str) -> str:
+    """Instance space for the base-CDM fallback: ``sp_{site}_instances``.
+
+    Falls back to ``sp_cdm_instances`` when no site has been set yet (matches
+    the "no-site" placeholder convention used for the other foundation defaults).
+    """
+    return f"sp_{site}_instances" if site else "sp_cdm_instances"
 
 
 def resolve_contextualization_variables(
@@ -277,6 +313,8 @@ def build_foundation_vars(
     """Variables block for ``variables.modules.cdf_project_foundation``."""
     ingestion = dict(INGESTION_FOUNDATION_VARIABLES[variant])
     ingestion["site"] = site
+    if variant == "cdm":
+        ingestion["instanceSpace"] = _cdm_instance_space(site)
     # Always write dataset so the key exists; empty list when no SS modules installed.
     ingestion["dataset"] = datasets if datasets is not None else []
     for persona in PERSONAS:
@@ -311,6 +349,8 @@ def build_overlay(
     reliable as Toolkit may delete them after consuming them.
     """
     instance_space = INGESTION_FOUNDATION_VARIABLES[variant]["instanceSpace"]
+    if variant == "cdm":
+        instance_space = _cdm_instance_space(site)
 
     installed_ss = list_installed_source_system_modules(repo_root)
     ctx_vars = resolve_contextualization_variables(variant, instance_space, installed_ctx)
@@ -385,7 +425,7 @@ def resolve_variant(args_variant: str | None, data_models_dir: Path) -> str:
         if args_variant not in INGESTION_FOUNDATION_VARIABLES:
             raise SystemExit(
                 f"ERROR: Unknown --variant '{args_variant}'.\n"
-                f"  Supported: {', '.join(KNOWN_DATA_MODEL_DIRS)}"
+                f"  Supported: {', '.join(INGESTION_FOUNDATION_VARIABLES)}"
             )
         return args_variant
     return detect_data_model_variant(data_models_dir)
@@ -532,12 +572,19 @@ def write_config(path: Path, env: str, project: str, overlay: dict) -> bool:
 
 # ── Redundant auth cleanup ─────────────────────────────────────────────────────
 
+def _rmdir_if_empty(directory: Path) -> None:
+    """Remove ``directory`` if it exists and is now empty."""
+    if directory.is_dir() and not any(directory.iterdir()):
+        directory.rmdir()
+
+
 def remove_redundant_auth_files(repo_root: Path | None = None) -> list[Path]:
     """Remove auth group files covered by cdf_project_foundation.
 
     Covers contextualization modules (entity matching, file annotation) and
     tools/apps modules (qualitizer) whose standalone auth becomes redundant
-    once the foundation persona groups are deployed.
+    once the foundation persona groups are deployed. Removes each module's
+    ``auth/`` directory too once it is left empty.
     """
     modules_root = get_pack_root(repo_root) / "modules"
     removed: list[Path] = []
@@ -545,26 +592,53 @@ def remove_redundant_auth_files(repo_root: Path | None = None) -> list[Path]:
     # Contextualization modules.
     ctx_dir = get_contextualization_dir(repo_root)
     for module_dir in list_installed_contextualization_modules(repo_root):
+        auth_dir = ctx_dir / module_dir / "auth"
         for rel_path in CONTEXTUALIZATION_REDUNDANT_AUTH[module_dir]:
             auth_file = ctx_dir / module_dir / rel_path
             if auth_file.exists():
                 auth_file.unlink()
                 removed.append(auth_file)
                 _ok(f"Removed redundant auth: {auth_file.relative_to(modules_root)}")
+        _rmdir_if_empty(auth_dir)
 
     # Tools / apps modules.
     for module_rel, auth_files in TOOLS_REDUNDANT_AUTH.items():
         module_dir = modules_root / module_rel
         if not module_dir.is_dir():
             continue
+        auth_dir = module_dir / "auth"
         for rel_path in auth_files:
             auth_file = module_dir / rel_path
             if auth_file.exists():
                 auth_file.unlink()
                 removed.append(auth_file)
                 _ok(f"Removed redundant auth: {auth_file.relative_to(modules_root)}")
+        _rmdir_if_empty(auth_dir)
 
     return removed
+
+
+# Space resource that creates the base-CDM instance space — only needed when no
+# data model extension is installed (an installed extension ships its own).
+_CDM_INSTANCE_SPACE_REL_PATH = "modules/common/cdf_project_foundation/data_modeling/cdm_instance_space.Space.yaml"
+
+
+def remove_redundant_cdm_space_file(variant: str, repo_root: Path | None = None) -> Path | None:
+    """Remove the CDM instance-space file once a data model extension is installed.
+
+    The extension ships its own instance-space resource for the same
+    ``instanceSpace`` value, so keeping both would declare the same space twice.
+    Removes the ``data_modeling/`` directory too once it is left empty.
+    """
+    if variant == "cdm":
+        return None
+    space_file = get_pack_root(repo_root) / _CDM_INSTANCE_SPACE_REL_PATH
+    if not space_file.exists():
+        return None
+    space_file.unlink()
+    _ok(f"Removed redundant CDM instance space file: {_CDM_INSTANCE_SPACE_REL_PATH}")
+    _rmdir_if_empty(space_file.parent)
+    return space_file
 
 
 # ── Staging → test migration ──────────────────────────────────────────────────
@@ -620,11 +694,15 @@ _ISA_SYNTHETIC_DIRS: tuple[str, ...] = (
 _DM_IMAGE_PATTERNS: tuple[str, ...] = ("*.png", "*.svg", "*.drawio", "*.ipynb")
 
 
-def remove_synthetic_data(repo_root: Path | None = None) -> int:
-    """Delete synthetic data directories and diagram files from data model modules.
+def remove_synthetic_data(variant: str, repo_root: Path | None = None) -> int:
+    """Delete synthetic data directories and diagram files from the *installed* data model.
 
     - CFIHOS: upload_data/, raw/, workflows/, transformations/ + image files
     - ISA: files/, raw/, transformations/, workflows/ + image files
+
+    Only touches the extension matching ``variant`` — with ``variant == "cdm"``
+    (no extension selected) this is a no-op, even if a stray ISA/CFIHOS directory
+    happens to be present. Idempotent: does nothing if already cleaned up.
 
     Returns the total number of files removed.
     """
@@ -648,20 +726,17 @@ def remove_synthetic_data(repo_root: Path | None = None) -> int:
                 count += 1
         return count
 
-    cfihos_dir = data_models_dir / "cfihos_oil_and_gas_extension"
-    if cfihos_dir.is_dir():
-        total += _remove_dirs(cfihos_dir, _CFIHOS_SYNTHETIC_DIRS)
-        total += _remove_images(cfihos_dir)
-        # Remove the auth/ directory if it is now empty (auth files were
-        # already deleted by remove_redundant_auth_files earlier in the wizard).
-        auth_dir = cfihos_dir / "auth"
-        if auth_dir.is_dir() and not any(auth_dir.iterdir()):
-            auth_dir.rmdir()
+    if variant == "cfihos_oil_and_gas_extension":
+        cfihos_dir = data_models_dir / "cfihos_oil_and_gas_extension"
+        if cfihos_dir.is_dir():
+            total += _remove_dirs(cfihos_dir, _CFIHOS_SYNTHETIC_DIRS)
+            total += _remove_images(cfihos_dir)
 
-    isa_dir = data_models_dir / "isa_manufacturing_extension"
-    if isa_dir.is_dir():
-        total += _remove_dirs(isa_dir, _ISA_SYNTHETIC_DIRS)
-        total += _remove_images(isa_dir)
+    if variant == "isa_manufacturing_extension":
+        isa_dir = data_models_dir / "isa_manufacturing_extension"
+        if isa_dir.is_dir():
+            total += _remove_dirs(isa_dir, _ISA_SYNTHETIC_DIRS)
+            total += _remove_images(isa_dir)
 
     return total
 
@@ -1225,6 +1300,7 @@ def _finalize_wizard(
     pack_root: Path,
     selected_envs: tuple[str, ...],
     *,
+    variant: str,
     keep_synthetic: bool,
     env_dirty: bool,
     changed_count: int,
@@ -1247,11 +1323,12 @@ def _finalize_wizard(
 
     removed = remove_redundant_auth_files(repo_root)
     patched = patch_cfihos_auth_for_missing_search(repo_root)
+    removed_cdm_space = remove_redundant_cdm_space_file(variant, repo_root)
     _cleanup_file_annotation_module(repo_root)
 
     synthetic_removed = 0
     if not keep_synthetic:
-        synthetic_removed = remove_synthetic_data(repo_root)
+        synthetic_removed = remove_synthetic_data(variant, repo_root)
         if synthetic_removed:
             _ok(f"Removed {synthetic_removed} synthetic data file(s) from upload_data/ directories.")
 
@@ -1263,6 +1340,8 @@ def _finalize_wizard(
         _ok(f"{len(removed)} redundant auth file(s) removed.")
     if patched:
         _ok(f"{len(patched)} cfihos auth file(s) patched (search_space removed).")
+    if removed_cdm_space:
+        _ok("Redundant CDM instance space file removed (data model extension covers it).")
     if env_dirty:
         _ok(".env updated with group source IDs.")
     if synthetic_removed:
@@ -1348,6 +1427,7 @@ def _run_wizard(
     _finalize_wizard(
         pack_root,
         selected_envs,
+        variant=variant,
         keep_synthetic=keep_synthetic,
         env_dirty=env_dirty,
         changed_count=changed_count,
@@ -1477,6 +1557,10 @@ def _run_check(
             if (ctx_dir / module_dir / rel_path).exists():
                 stale_auth.append(ctx_dir / module_dir / rel_path)
 
+    stale_cdm_space = (
+        variant != "cdm" and (get_pack_root(repo_root) / _CDM_INSTANCE_SPACE_REL_PATH).exists()
+    )
+
     if all_errors:
         print(f"ERROR: Config file(s) out of sync with variant '{variant}':\n")
         for filename, errs in all_errors.items():
@@ -1489,6 +1573,13 @@ def _run_check(
         print("ERROR: Redundant auth file(s) still present (covered by cdf_project_foundation):")
         for p in stale_auth:
             print(f"  {p.relative_to(ctx_dir.parent.parent)}")
+        print("\n  Run: python scripts/setup_project.py -y")
+        sys.exit(1)
+    if stale_cdm_space:
+        print(
+            f"ERROR: Redundant CDM instance space file still present for variant '{variant}':\n"
+            f"  {_CDM_INSTANCE_SPACE_REL_PATH}"
+        )
         print("\n  Run: python scripts/setup_project.py -y")
         sys.exit(1)
     print(f"OK: All config file(s) match variant '{variant}'. No stale auth files.")
@@ -1513,7 +1604,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--variant",
-        choices=list(KNOWN_DATA_MODEL_DIRS),
+        choices=list(INGESTION_FOUNDATION_VARIABLES),
         default=None,
         help="Force the data model variant instead of auto-detecting it",
     )

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -15,6 +15,16 @@ This follows the [CDF Foundation Setup guide](https://cogdocs.mintlify.io/gvd) *
 
 If the test environment is present, PRs to `main` must come from `dev` or `hotfix/*` only.
 
+## Branch protection
+
+Protect the branches used above under **Settings → Branches**. This is required, not optional:
+
+| Branch | Required reviewers | Required status checks |
+|--------|---------------------|--------------------------|
+{{BRANCH_PROTECTION_ROWS}}
+
+{{BRANCH_PROTECTION_NOTE}}
+
 ## GitHub Environments
 
 Create three environments under **Settings → Environments**:

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install Cognite Toolkit
-        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
+        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
       - name: cdf build
         run: cdf build {{PROD_BUILD_ARGS}}

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -5,6 +5,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: toolkit-deploy-prod
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -24,16 +28,26 @@ jobs:
       PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}
       IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
     steps:
-      - name: Reject releases not created from main
+      - name: Enforce release tag pattern
         run: |
-          if [ "${{ github.event.release.target_commitish }}" != "main" ]; then
-            echo "::error::Production releases must be published from branch main"
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vX.Y.Z (got: $TAG)"
             exit 1
           fi
 
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Reject releases not reachable from main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Production releases must be published from a commit reachable from main"
+            exit 1
+          fi
 
       - name: Remove local .env
         run: rm -f .env
@@ -47,6 +61,9 @@ jobs:
 
       - name: cdf build
         run: cdf build {{PROD_BUILD_ARGS}}
+
+      - name: cdf deploy --dry-run
+        run: cdf deploy --dry-run
 
       - name: cdf deploy
         run: cdf deploy

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install Cognite Toolkit
-        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
+        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
       - name: cdf build
         run: cdf build {{BUILD_ARGS}}

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -31,7 +31,7 @@ jobs:
           echo "Promotion flow OK: ${HEAD} -> main"
 
   lint:
-    name: Lint (ruff, pyright, config)
+    name: Lint (workflow YAML)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +40,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install lint dependencies
-        run: pip install pre-commit pyyaml
+      - name: Install pyyaml
+        run: pip install pyyaml
 
       - name: Validate workflow YAML
         run: |
@@ -49,27 +49,29 @@ jobs:
           from pathlib import Path
           import yaml
 
-          for path in (
-{{WORKFLOW_FILES}}
-          ):
-              yaml.safe_load(Path(path).read_text())
+          for path in sorted(Path(".github/workflows").glob("*.yml")):
+              yaml.safe_load(path.read_text())
               print(f"valid yaml: {path}")
           PY
 
+      - name: Install pre-commit
+        if: hashFiles('.pre-commit-config.yaml') != ''
+        run: pip install pre-commit
+
       - name: Config lint (Toolkit templates; skip strict YAML on modules)
+        if: hashFiles('.pre-commit-config.yaml') != ''
         env:
           SKIP: check-yaml,end-of-file-fixer,trailing-whitespace
         run: |
-          if [ ! -f .pre-commit-config.yaml ]; then
-            echo "No .pre-commit-config.yaml found; skipping pre-commit config lint."
-            exit 0
-          fi
-
           mapfile -t FILES < <(git ls-files \
             {{LINT_PATHS}})
           if [ "${#FILES[@]}" -gt 0 ]; then
             pre-commit run --files "${FILES[@]}"
           fi
+
+      - name: No pre-commit config
+        if: hashFiles('.pre-commit-config.yaml') == ''
+        run: echo "No .pre-commit-config.yaml found; skipping pre-commit config lint."
 
   cdf-dry-run:
     name: cdf build & deploy --dry-run

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -105,7 +105,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install Cognite Toolkit
-        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
+        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
       - name: cdf build
         id: build

--- a/modules/contextualization/cdf_entity_matching/default.config.yaml
+++ b/modules/contextualization/cdf_entity_matching/default.config.yaml
@@ -9,19 +9,19 @@ source_name: springfield
 dbName: db_asset_entity_matching
 contextualizationId: entity_matcher
 contextualizationName: Entity Matcher
-schemaSpace: dm_dom_oil_and_gas
+schemaSpace: cdf_cdm
 viewVersion: v1
-assetInstanceSpace: inst_location
-timeseriesInstanceSpace: inst_location
+assetInstanceSpace: sp_cdm_instances
+timeseriesInstanceSpace: sp_cdm_instances
 functionSpace: sp_entity_matching_fn # space where function code nodes are stored — created by this module
-AssetViewExternalId: Tag
-TimeSeriesViewExternalId: TimeSeriesData
-targetViewExternalId: Tag
-entityViewExternalId: TimeSeriesData
+AssetViewExternalId: CogniteAsset
+TimeSeriesViewExternalId: CogniteTimeSeries
+targetViewExternalId: CogniteAsset
+entityViewExternalId: CogniteTimeSeries
 targetViewSearchProperty: name
-targetViewFilterValues: ["root:WMT"]
+targetViewFilterValues: []
 entityViewSearchProperty: aliases
-entityViewFilterValues: ["site:VAL"]
+entityViewFilterValues: []
 
 workflow: EntityMatching
 ### UPDATE THE FOLLOWING VALUES FOR YOUR IDP CONFIGURATION ###

--- a/modules/contextualization/cdf_file_annotation/default.config.yaml
+++ b/modules/contextualization/cdf_file_annotation/default.config.yaml
@@ -7,9 +7,9 @@ annotationStateSchemaSpace: sp_hdm #NOTE: stands for space helper data model
 annotationStateVersion: v1.0.0
 patternModeInstanceSpace: sp_dat_pattern_mode_results
 patternDetectSink: pattern_detection_sink_node
-fileSchemaSpace: dm_dom_oil_and_gas
-fileInstanceSpace: inst_location
-fileExternalId: Files
+fileSchemaSpace: cdf_cdm
+fileInstanceSpace: sp_cdm_instances
+fileExternalId: CogniteFile
 fileVersion: v1
 
 # used in /raw and /extraction_pipelines
@@ -23,9 +23,9 @@ rawTablePromoteCache: annotation_tags_cache
 
 # used in /extraction_pipelines
 extractionPipelineExternalId: ep_file_annotation
-targetEntitySchemaSpace: dm_dom_oil_and_gas
-targetEntityInstanceSpace: inst_location
-targetEntityExternalId: Tag
+targetEntitySchemaSpace: cdf_cdm
+targetEntityInstanceSpace: sp_cdm_instances
+targetEntityExternalId: CogniteAsset
 targetEntityVersion: v1
 
 # used in /functions

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -783,47 +783,49 @@ class TestRemoveRedundantAuthFiles:
         assert auth_dir.exists()
 
 
-class TestRemoveRedundantCdmSpaceFile:
-    def _make_space_file(self, tmp_path: Path) -> Path:
-        space_file = (
+class TestRestoreCdmSpaceFile:
+    """The CDM instance-space file is never shipped as a module asset — the
+    wizard is the only thing that ever writes it, and only for variant == 'cdm'."""
+
+    def _space_file(self, tmp_path: Path) -> Path:
+        return (
             tmp_path / "modules" / "common" / "cdf_project_foundation"
             / "data_modeling" / "cdm_instance_space.Space.yaml"
         )
-        space_file.parent.mkdir(parents=True, exist_ok=True)
-        space_file.write_text("space: {{ instanceSpace }}\n")
-        return space_file
 
-    def test_kept_when_variant_is_cdm(self, tmp_path: Path) -> None:
-        from setup_project import remove_redundant_cdm_space_file
-        space_file = self._make_space_file(tmp_path)
-        removed = remove_redundant_cdm_space_file("cdm", tmp_path)
-        assert removed is None
+    def test_creates_file_when_missing_and_variant_is_cdm(self, tmp_path: Path) -> None:
+        from setup_project import restore_cdm_space_file
+        space_file = self._space_file(tmp_path)
+        created = restore_cdm_space_file("cdm", tmp_path)
+        assert created == space_file
         assert space_file.exists()
+        assert "{{ instanceSpace }}" in space_file.read_text()
 
-    def test_removed_when_extension_installed(self, tmp_path: Path) -> None:
-        from setup_project import remove_redundant_cdm_space_file
-        space_file = self._make_space_file(tmp_path)
-        removed = remove_redundant_cdm_space_file("isa_manufacturing_extension", tmp_path)
-        assert removed == space_file
+    def test_noop_when_file_already_present(self, tmp_path: Path) -> None:
+        from setup_project import restore_cdm_space_file
+        space_file = self._space_file(tmp_path)
+        space_file.parent.mkdir(parents=True)
+        space_file.write_text("space: {{ instanceSpace }}\ncustom: true\n")
+        created = restore_cdm_space_file("cdm", tmp_path)
+        assert created is None
+        assert "custom: true" in space_file.read_text()  # left untouched
+
+    def test_noop_when_variant_is_an_extension(self, tmp_path: Path) -> None:
+        from setup_project import restore_cdm_space_file
+        space_file = self._space_file(tmp_path)
+        created = restore_cdm_space_file("isa_manufacturing_extension", tmp_path)
+        assert created is None
         assert not space_file.exists()
 
-    def test_removes_now_empty_data_modeling_dir(self, tmp_path: Path) -> None:
-        from setup_project import remove_redundant_cdm_space_file
-        space_file = self._make_space_file(tmp_path)
-        remove_redundant_cdm_space_file("isa_manufacturing_extension", tmp_path)
-        assert not space_file.parent.exists()
-
-    def test_leaves_non_empty_data_modeling_dir(self, tmp_path: Path) -> None:
-        from setup_project import remove_redundant_cdm_space_file
-        space_file = self._make_space_file(tmp_path)
-        (space_file.parent / "other.DataModel.yaml").write_text("name: dummy\n")
-        remove_redundant_cdm_space_file("isa_manufacturing_extension", tmp_path)
-        assert space_file.parent.exists()
-
-    def test_idempotent_when_already_removed(self, tmp_path: Path) -> None:
-        from setup_project import remove_redundant_cdm_space_file
-        removed = remove_redundant_cdm_space_file("cfihos_oil_and_gas_extension", tmp_path)
-        assert removed is None
+    def test_leaves_existing_file_untouched_when_variant_is_extension(self, tmp_path: Path) -> None:
+        """A file created during a prior cdm run is intentionally left alone if the
+        project later switches to an extension — nothing deletes it."""
+        from setup_project import restore_cdm_space_file
+        space_file = self._space_file(tmp_path)
+        space_file.parent.mkdir(parents=True)
+        space_file.write_text("space: {{ instanceSpace }}\n")
+        restore_cdm_space_file("isa_manufacturing_extension", tmp_path)
+        assert space_file.exists()
 
 
 # ── setup_project — CFIHOS auth patching ──────────────────────────────────────

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -321,6 +321,29 @@ class TestBuildFoundationVars:
         assert vars_["schemaSpace"] == "dm_dom_oil_and_gas"
         assert vars_["instanceSpace"] == "inst_location"
 
+    def test_cdm_variant_contains_required_keys(self) -> None:
+        from setup_project import build_foundation_vars
+        vars_ = build_foundation_vars("cdm", "dev", "")
+        assert vars_["dataModelVariant"] == "cdm"
+        assert vars_["schemaSpace"] == "cdf_cdm"
+        # No site set — falls back to the static no-site placeholder.
+        assert vars_["instanceSpace"] == "sp_cdm_instances"
+
+    def test_cdm_variant_instance_space_derived_from_site(self) -> None:
+        from setup_project import build_foundation_vars
+        vars_ = build_foundation_vars("cdm", "dev", "oslo")
+        assert vars_["instanceSpace"] == "sp_oslo_instances"
+
+
+class TestCdmInstanceSpace:
+    def test_uses_site_when_set(self) -> None:
+        from setup_project import _cdm_instance_space
+        assert _cdm_instance_space("oslo") == "sp_oslo_instances"
+
+    def test_falls_back_to_static_placeholder_when_site_blank(self) -> None:
+        from setup_project import _cdm_instance_space
+        assert _cdm_instance_space("") == "sp_cdm_instances"
+
 
 class TestBuildOverlay:
     def test_isa_overlay_structure(self) -> None:
@@ -396,6 +419,24 @@ class TestBuildOverlay:
         assert dm["admin_user"] == "admin@firm.com"
         assert dm["integrationOwnerName"] == "Alice"
         assert dm["integrationOwnerEmail"] == "alice@firm.com"
+
+    def test_cdm_overlay_uses_base_cognite_core_views(self) -> None:
+        from setup_project import build_overlay
+        overlay = build_overlay(
+            "cdm", "dev", "oslo", ["cdf_entity_matching", "cdf_file_annotation"]
+        )
+        mods = overlay["variables"]["modules"]
+        em = mods["cdf_entity_matching"]
+        assert em["schemaSpace"] == "cdf_cdm"
+        assert em["AssetViewExternalId"] == "CogniteAsset"
+        assert em["TimeSeriesViewExternalId"] == "CogniteTimeSeries"
+        assert em["assetInstanceSpace"] == "sp_oslo_instances"
+        fa = mods["cdf_file_annotation"]
+        assert fa["fileSchemaSpace"] == "cdf_cdm"
+        assert fa["fileExternalId"] == "CogniteFile"
+        assert fa["targetEntityExternalId"] == "CogniteAsset"
+        # No CDM-specific module block — CDM has no extension module to configure.
+        assert "cdm" not in mods
 
 
 class TestModuleInstanceSpace:
@@ -698,6 +739,92 @@ class TestRemoveRedundantAuthFiles:
         removed = remove_redundant_auth_files(tmp_path)
         assert removed == []
 
+    def test_removes_empty_ctx_auth_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        auth_dir = (
+            tmp_path / "modules" / "contextualization" / "cdf_entity_matching" / "auth"
+        )
+        self._make_auth_file(auth_dir / "entity.matching.processing.groups.Group.yaml")
+        remove_redundant_auth_files(tmp_path)
+        assert not auth_dir.exists()
+
+    def test_leaves_non_empty_ctx_auth_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        auth_dir = (
+            tmp_path / "modules" / "contextualization" / "cdf_entity_matching" / "auth"
+        )
+        self._make_auth_file(auth_dir / "entity.matching.processing.groups.Group.yaml")
+        self._make_auth_file(auth_dir / "other.Group.yaml")  # unrelated file stays
+        remove_redundant_auth_files(tmp_path)
+        assert auth_dir.exists()
+
+    def test_removes_empty_cfihos_auth_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        auth_dir = (
+            tmp_path / "modules" / "datamodels" / "cfihos_oil_and_gas_extension" / "auth"
+        )
+        for name in (
+            "gp_cdf_owner_cfihos_oil_gas_data_model.group.yaml",
+            "gp_cdf_read_cfihos_oil_gas_data_model.group.yaml",
+        ):
+            self._make_auth_file(auth_dir / name)
+        remove_redundant_auth_files(tmp_path)
+        assert not auth_dir.exists()
+
+    def test_leaves_non_empty_cfihos_auth_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_auth_files
+        auth_dir = (
+            tmp_path / "modules" / "datamodels" / "cfihos_oil_and_gas_extension" / "auth"
+        )
+        self._make_auth_file(auth_dir / "gp_cdf_owner_cfihos_oil_gas_data_model.group.yaml")
+        self._make_auth_file(auth_dir / "gp_cdf_read_cfihos_oil_gas_data_model.group.yaml")
+        self._make_auth_file(auth_dir / "other.group.yaml")  # unrelated file stays
+        remove_redundant_auth_files(tmp_path)
+        assert auth_dir.exists()
+
+
+class TestRemoveRedundantCdmSpaceFile:
+    def _make_space_file(self, tmp_path: Path) -> Path:
+        space_file = (
+            tmp_path / "modules" / "common" / "cdf_project_foundation"
+            / "data_modeling" / "cdm_instance_space.Space.yaml"
+        )
+        space_file.parent.mkdir(parents=True, exist_ok=True)
+        space_file.write_text("space: {{ instanceSpace }}\n")
+        return space_file
+
+    def test_kept_when_variant_is_cdm(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_cdm_space_file
+        space_file = self._make_space_file(tmp_path)
+        removed = remove_redundant_cdm_space_file("cdm", tmp_path)
+        assert removed is None
+        assert space_file.exists()
+
+    def test_removed_when_extension_installed(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_cdm_space_file
+        space_file = self._make_space_file(tmp_path)
+        removed = remove_redundant_cdm_space_file("isa_manufacturing_extension", tmp_path)
+        assert removed == space_file
+        assert not space_file.exists()
+
+    def test_removes_now_empty_data_modeling_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_cdm_space_file
+        space_file = self._make_space_file(tmp_path)
+        remove_redundant_cdm_space_file("isa_manufacturing_extension", tmp_path)
+        assert not space_file.parent.exists()
+
+    def test_leaves_non_empty_data_modeling_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_cdm_space_file
+        space_file = self._make_space_file(tmp_path)
+        (space_file.parent / "other.DataModel.yaml").write_text("name: dummy\n")
+        remove_redundant_cdm_space_file("isa_manufacturing_extension", tmp_path)
+        assert space_file.parent.exists()
+
+    def test_idempotent_when_already_removed(self, tmp_path: Path) -> None:
+        from setup_project import remove_redundant_cdm_space_file
+        removed = remove_redundant_cdm_space_file("cfihos_oil_and_gas_extension", tmp_path)
+        assert removed is None
+
 
 # ── setup_project — CFIHOS auth patching ──────────────────────────────────────
 
@@ -764,11 +891,14 @@ class TestRemoveSyntheticData:
             files.append(f)
         return files
 
+    _CFIHOS = "cfihos_oil_and_gas_extension"
+    _ISA = "isa_manufacturing_extension"
+
     def test_removes_upload_data(self, tmp_path: Path) -> None:
         from setup_project import remove_synthetic_data
         cfihos = self._cfihos_dir(tmp_path)
         self._make_files(cfihos / "upload_data", "data.csv", "manifest.yaml")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._CFIHOS, tmp_path)
         assert count == 2
         assert not (cfihos / "upload_data").exists()
 
@@ -776,7 +906,7 @@ class TestRemoveSyntheticData:
         from setup_project import remove_synthetic_data
         cfihos = self._cfihos_dir(tmp_path)
         self._make_files(cfihos / "raw", "db.Database.yaml")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._CFIHOS, tmp_path)
         assert count == 1
         assert not (cfihos / "raw").exists()
 
@@ -784,7 +914,7 @@ class TestRemoveSyntheticData:
         from setup_project import remove_synthetic_data
         cfihos = self._cfihos_dir(tmp_path)
         self._make_files(cfihos / "workflows", "example.Workflow.yaml")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._CFIHOS, tmp_path)
         assert count == 1
         assert not (cfihos / "workflows").exists()
 
@@ -792,7 +922,7 @@ class TestRemoveSyntheticData:
         from setup_project import remove_synthetic_data
         cfihos = self._cfihos_dir(tmp_path)
         self._make_files(cfihos / "transformations", "populate.sql")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._CFIHOS, tmp_path)
         assert count == 1
         assert not (cfihos / "transformations").exists()
 
@@ -803,26 +933,26 @@ class TestRemoveSyntheticData:
         self._make_files(cfihos / "raw", "b.yaml")
         self._make_files(cfihos / "workflows", "c.yaml")
         self._make_files(cfihos / "transformations", "d.sql")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._CFIHOS, tmp_path)
         assert count == 4
         for d in ("upload_data", "raw", "workflows", "transformations"):
             assert not (cfihos / d).exists()
 
     def test_no_op_when_cfihos_not_installed(self, tmp_path: Path) -> None:
         from setup_project import remove_synthetic_data
-        assert remove_synthetic_data(tmp_path) == 0
+        assert remove_synthetic_data(self._CFIHOS, tmp_path) == 0
 
     def test_idempotent_when_dirs_already_removed(self, tmp_path: Path) -> None:
         from setup_project import remove_synthetic_data
         self._cfihos_dir(tmp_path)  # module dir exists but no synthetic dirs
-        assert remove_synthetic_data(tmp_path) == 0
+        assert remove_synthetic_data(self._CFIHOS, tmp_path) == 0
 
     def test_does_not_touch_other_cfihos_dirs(self, tmp_path: Path) -> None:
         from setup_project import remove_synthetic_data
         cfihos = self._cfihos_dir(tmp_path)
         self._make_files(cfihos / "data_modeling", "model.datamodel.yaml")
         self._make_files(cfihos / "auth", "group.yaml")
-        remove_synthetic_data(tmp_path)
+        remove_synthetic_data(self._CFIHOS, tmp_path)
         assert (cfihos / "data_modeling").exists()
         assert (cfihos / "auth").exists()
 
@@ -830,23 +960,22 @@ class TestRemoveSyntheticData:
         from setup_project import remove_synthetic_data
         cfihos = self._cfihos_dir(tmp_path)
         self._make_files(cfihos / "cfihos_model_config", "config.json", "schema.yaml")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._CFIHOS, tmp_path)
         assert count == 2
         assert not (cfihos / "cfihos_model_config").exists()
 
-    def test_removes_empty_auth_dir(self, tmp_path: Path) -> None:
+    def test_cdm_variant_does_not_touch_cfihos_or_isa(self, tmp_path: Path) -> None:
+        """No data model selected (variant == 'cdm') must not delete anything, even
+        if stray ISA/CFIHOS directories are still physically present."""
         from setup_project import remove_synthetic_data
         cfihos = self._cfihos_dir(tmp_path)
-        (cfihos / "auth").mkdir()  # empty auth dir (files already removed)
-        remove_synthetic_data(tmp_path)
-        assert not (cfihos / "auth").exists()
-
-    def test_leaves_non_empty_auth_dir(self, tmp_path: Path) -> None:
-        from setup_project import remove_synthetic_data
-        cfihos = self._cfihos_dir(tmp_path)
-        self._make_files(cfihos / "auth", "group.yaml")
-        remove_synthetic_data(tmp_path)
-        assert (cfihos / "auth").exists()  # still has files — must not be removed
+        isa = self._isa_dir(tmp_path)
+        self._make_files(cfihos / "upload_data", "a.csv")
+        self._make_files(isa / "files", "sample.pdf")
+        count = remove_synthetic_data("cdm", tmp_path)
+        assert count == 0
+        assert (cfihos / "upload_data").exists()
+        assert (isa / "files").exists()
 
     # ── ISA DM cleanup ────────────────────────────────────────────────────────
 
@@ -859,7 +988,7 @@ class TestRemoveSyntheticData:
         from setup_project import remove_synthetic_data
         isa = self._isa_dir(tmp_path)
         self._make_files(isa / "files", "sample.pdf")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._ISA, tmp_path)
         assert count == 1
         assert not (isa / "files").exists()
 
@@ -867,7 +996,7 @@ class TestRemoveSyntheticData:
         from setup_project import remove_synthetic_data
         isa = self._isa_dir(tmp_path)
         self._make_files(isa / "raw", "db.Database.yaml")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._ISA, tmp_path)
         assert count == 1
         assert not (isa / "raw").exists()
 
@@ -876,14 +1005,21 @@ class TestRemoveSyntheticData:
         isa = self._isa_dir(tmp_path)
         self._make_files(isa / "transformations", "tr.sql")
         self._make_files(isa / "workflows", "wf.yaml")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._ISA, tmp_path)
         assert count == 2
         assert not (isa / "transformations").exists()
         assert not (isa / "workflows").exists()
 
     def test_isa_no_op_when_not_installed(self, tmp_path: Path) -> None:
         from setup_project import remove_synthetic_data
-        assert remove_synthetic_data(tmp_path) == 0
+        assert remove_synthetic_data(self._ISA, tmp_path) == 0
+
+    def test_cfihos_variant_does_not_touch_isa_dir(self, tmp_path: Path) -> None:
+        from setup_project import remove_synthetic_data
+        isa = self._isa_dir(tmp_path)
+        self._make_files(isa / "files", "sample.pdf")
+        remove_synthetic_data(self._CFIHOS, tmp_path)
+        assert (isa / "files").exists()
 
     # ── Image / diagram file removal ──────────────────────────────────────────
 
@@ -892,7 +1028,7 @@ class TestRemoveSyntheticData:
         cfihos = self._cfihos_dir(tmp_path)
         (cfihos / "data_model_views.png").write_text("img")
         (cfihos / "dm-workflow.png").write_text("img")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._CFIHOS, tmp_path)
         assert count == 2
         assert not (cfihos / "data_model_views.png").exists()
         assert not (cfihos / "dm-workflow.png").exists()
@@ -901,24 +1037,15 @@ class TestRemoveSyntheticData:
         from setup_project import remove_synthetic_data
         isa = self._isa_dir(tmp_path)
         (isa / "diagram.svg").write_text("svg")
-        count = remove_synthetic_data(tmp_path)
+        count = remove_synthetic_data(self._ISA, tmp_path)
         assert count == 1
         assert not (isa / "diagram.svg").exists()
-
-    def test_removes_images_from_both_modules(self, tmp_path: Path) -> None:
-        from setup_project import remove_synthetic_data
-        cfihos = self._cfihos_dir(tmp_path)
-        isa = self._isa_dir(tmp_path)
-        (cfihos / "model.png").write_text("img")
-        (isa / "isa.png").write_text("img")
-        count = remove_synthetic_data(tmp_path)
-        assert count == 2
 
     def test_data_modeling_dir_not_touched(self, tmp_path: Path) -> None:
         from setup_project import remove_synthetic_data
         isa = self._isa_dir(tmp_path)
         self._make_files(isa / "data_modeling", "model.datamodel.yaml")
-        remove_synthetic_data(tmp_path)
+        remove_synthetic_data(self._ISA, tmp_path)
         assert (isa / "data_modeling").exists()
 
 
@@ -1167,6 +1294,41 @@ class TestGetOrgDirName:
         from _pack_config import get_org_dir_name
         (tmp_path / "cdf.toml").write_text('default_organization_dir = "wrong"\n')
         assert get_org_dir_name(tmp_path) is None
+
+
+class TestDetectDataModelVariant:
+    def test_missing_directory_falls_back_to_cdm(self, tmp_path: Path) -> None:
+        from _pack_config import detect_data_model_variant
+        assert detect_data_model_variant(tmp_path / "modules" / "datamodels") == "cdm"
+
+    def test_empty_directory_falls_back_to_cdm(self, tmp_path: Path) -> None:
+        from _pack_config import detect_data_model_variant
+        data_models_dir = tmp_path / "modules" / "datamodels"
+        data_models_dir.mkdir(parents=True)
+        assert detect_data_model_variant(data_models_dir) == "cdm"
+
+    def test_directory_with_unsupported_subdir_falls_back_to_cdm(self, tmp_path: Path) -> None:
+        from _pack_config import detect_data_model_variant
+        data_models_dir = tmp_path / "modules" / "datamodels"
+        (data_models_dir / "qs_enterprise_dm").mkdir(parents=True)
+        assert detect_data_model_variant(data_models_dir) == "cdm"
+
+    def test_single_known_extension_detected(self, tmp_path: Path) -> None:
+        from _pack_config import detect_data_model_variant
+        data_models_dir = tmp_path / "modules" / "datamodels"
+        (data_models_dir / "isa_manufacturing_extension").mkdir(parents=True)
+        assert detect_data_model_variant(data_models_dir) == "isa_manufacturing_extension"
+
+    def test_multiple_known_extensions_raise(self, tmp_path: Path) -> None:
+        from _pack_config import detect_data_model_variant
+        data_models_dir = tmp_path / "modules" / "datamodels"
+        (data_models_dir / "isa_manufacturing_extension").mkdir(parents=True)
+        (data_models_dir / "cfihos_oil_and_gas_extension").mkdir(parents=True)
+        try:
+            detect_data_model_variant(data_models_dir)
+            raise AssertionError("expected SystemExit")
+        except SystemExit:
+            pass
 
 
 class TestEnvPathResolution:


### PR DESCRIPTION
Summary:
- Rename the misleading Lint (ruff, pyright, config) job to Lint (workflow YAML) — it only ever validated workflow YAML and optionally ran pre-commit config checks; it never ran ruff or pyright. The pre-commit install step now only runs when .pre-commit-config.yaml exists (previously it installed pre-commit only to skip). Workflow YAML validation now globs .github/workflows/*.yml instead of a hardcoded file list, so generate_actions.py no longer needs to track every generated filename (workflow_file_list() removed).
- Drop unused pyyaml installs from deploy.yml, deploy-prod.yml, and the cdf-dry-run job in dry-run.yml — none of them import yaml; only the lint job's YAML-validation step does, and it installs its own copy.
- Harden deploy-prod.yml:
  - Add a concurrency group (toolkit-deploy-prod) so overlapping release publishes can't race, matching dev/test.
  - Replace the target_commitish == main check with a real ancestry check (git merge-base --is-ancestor) — target_commitish only reflects the branch picked in the release UI, not that the tagged commit is reachable fro
  - Require the release tag to match vX.Y.Z.
  - Run cdf deploy --dry-run befor final safety net.
- Document branch protection in the generated FOUNDATION_CICD.md as required, not optional: PRs
to dev only run dry-run CI with 0 h guardrail check there); mainrequires a PR, 1 reviewer, the guardrail check, and dry-run.

Test plan:
- [x] uv run pytest — 154 passed
- [x] ruff check — clean                                                                      
- [ x]  python validate_packages.py
- [ ] Confirm rendered workflows on a real Toolkit project (generate_actions.py --force) look correct in both with-test and with