### PR TITLE
Fix: foundation cicd lint hardening

### DIFF
--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -262,6 +262,35 @@ def branching_rows(projects: dict[str, str]) -> str:
     )
 
 
+def branch_protection_rows(projects: dict[str, str]) -> str:
+    rows: list[str] = []
+    for env in deployable_envs(projects):
+        branch = DEPLOY_BRANCHES[env]
+        if branch == "main":
+            rows.append("| `main` | 1 | `Source branch guardrail`, `cdf build & deploy --dry-run` |")
+        else:
+            rows.append(f"| `{branch}` | none | `cdf build & deploy --dry-run` |")
+    return "\n".join(rows or ["| *(none)* | *(none)* | No PR workflow generated |"])
+
+
+def branch_protection_note(projects: dict[str, str]) -> str:
+    branches = {DEPLOY_BRANCHES[env] for env in deployable_envs(projects)}
+    if not branches:
+        return "No PR workflow is generated without a dev or test environment configured."
+    if branches == {"dev"}:
+        return "PRs to `dev` only run dry-run CI (0 reviewers)."
+    if branches == {"main"}:
+        return (
+            "PRs to `main` require a reviewer and the `Source branch guardrail` check, which"
+            " enforces that changes are promoted from `dev` or `hotfix/*`, in addition to dry-run CI."
+        )
+    return (
+        "PRs to `dev` only run dry-run CI (0 reviewers). The `Source branch guardrail` check does"
+        " not run on `dev` — it only applies to PRs targeting `main`, where it enforces that changes"
+        " are promoted from `dev` or `hotfix/*`."
+    )
+
+
 def indent(text: str, spaces: int) -> str:
     prefix = " " * spaces
     return "\n".join(f"{prefix}{line}" if line else line for line in text.splitlines())
@@ -318,6 +347,8 @@ def main() -> None:
         "ENVIRONMENT_ROWS": environment_rows(projects),
         "EXAMPLE_BUILD_ARGS": example_build_args(str(toolkit_version), org_dir, projects),
         "ENV_CONFIG_LIST": env_config_list(projects),
+        "BRANCH_PROTECTION_ROWS": branch_protection_rows(projects),
+        "BRANCH_PROTECTION_NOTE": branch_protection_note(projects),
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir),
     }

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -183,16 +183,6 @@ def deployable_envs(projects: dict[str, str]) -> list[str]:
     return [env for env in ("dev", "test") if env in projects]
 
 
-def workflow_file_list(projects: dict[str, str]) -> str:
-    files: list[str] = []
-    if deployable_envs(projects):
-        files.append('".github/workflows/dry-run.yml"')
-    files.extend(f'".github/workflows/deploy-{env}.yml"' for env in deployable_envs(projects))
-    if "prod" in projects:
-        files.append('".github/workflows/deploy-prod.yml"')
-    return "\n".join(f"              {path}," for path in files)
-
-
 def branch_envs(projects: dict[str, str]) -> dict[str, str]:
     envs_by_branch: dict[str, str] = {}
     for env in deployable_envs(projects):
@@ -321,7 +311,6 @@ def main() -> None:
     resolve_modules_root(repo_root, org_dir)
 
     base_values: dict[str, str] = {
-        "WORKFLOW_FILES": workflow_file_list(projects),
         "PR_BRANCHES": pr_branches(projects),
         "DRY_RUN_ENVIRONMENT": dry_run_environment(projects),
         "DRY_RUN_BUILD_SCRIPT": indent(dry_run_build_script(str(toolkit_version), org_dir, projects), 10),

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -12,6 +12,16 @@ This follows the [CDF Foundation Setup guide](https://cogdocs.mintlify.io/gvd) *
 
 If a pre-production environment is present, PRs to `main` must come from `dev` or `hotfix/*` only.
 
+## Branch protection
+
+Protect the branches used above under **Settings → Branches**. This is required, not optional:
+
+| Branch | Required reviewers | Required status checks |
+|--------|---------------------|--------------------------|
+{{BRANCH_PROTECTION_ROWS}}
+
+{{BRANCH_PROTECTION_NOTE}}
+
 ## GitHub Environments
 
 Create the generated environments under **Settings → Environments**:

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install Cognite Toolkit
-        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
+        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
       - name: cdf build
         run: cdf build {{PROD_BUILD_ARGS}}

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -5,6 +5,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: toolkit-deploy-prod
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -24,16 +28,26 @@ jobs:
       PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}
       IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
     steps:
-      - name: Reject releases not created from main
+      - name: Enforce release tag pattern
         run: |
-          if [ "${{ github.event.release.target_commitish }}" != "main" ]; then
-            echo "::error::Production releases must be published from branch main"
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vX.Y.Z (got: $TAG)"
             exit 1
           fi
 
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Reject releases not reachable from main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Production releases must be published from a commit reachable from main"
+            exit 1
+          fi
 
       - name: Remove local .env
         run: rm -f .env
@@ -47,6 +61,9 @@ jobs:
 
       - name: cdf build
         run: cdf build {{PROD_BUILD_ARGS}}
+
+      - name: cdf deploy --dry-run
+        run: cdf deploy --dry-run
 
       - name: cdf deploy
         run: cdf deploy

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install Cognite Toolkit
-        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
+        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
       - name: cdf build
         run: cdf build {{BUILD_ARGS}}

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -31,7 +31,7 @@ jobs:
           echo "Promotion flow OK: ${HEAD} -> main"
 
   lint:
-    name: Lint (ruff, pyright, config)
+    name: Lint (workflow YAML)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +40,8 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install lint dependencies
-        run: pip install pre-commit pyyaml
+      - name: Install pyyaml
+        run: pip install pyyaml
 
       - name: Validate workflow YAML
         run: |
@@ -49,27 +49,29 @@ jobs:
           from pathlib import Path
           import yaml
 
-          for path in (
-{{WORKFLOW_FILES}}
-          ):
-              yaml.safe_load(Path(path).read_text())
+          for path in sorted(Path(".github/workflows").glob("*.yml")):
+              yaml.safe_load(path.read_text())
               print(f"valid yaml: {path}")
           PY
 
+      - name: Install pre-commit
+        if: hashFiles('.pre-commit-config.yaml') != ''
+        run: pip install pre-commit
+
       - name: Config lint (Toolkit templates; skip strict YAML on modules)
+        if: hashFiles('.pre-commit-config.yaml') != ''
         env:
           SKIP: check-yaml,end-of-file-fixer,trailing-whitespace
         run: |
-          if [ ! -f .pre-commit-config.yaml ]; then
-            echo "No .pre-commit-config.yaml found; skipping pre-commit config lint."
-            exit 0
-          fi
-
           mapfile -t FILES < <(git ls-files \
             {{LINT_PATHS}})
           if [ "${#FILES[@]}" -gt 0 ]; then
             pre-commit run --files "${FILES[@]}"
           fi
+
+      - name: No pre-commit config
+        if: hashFiles('.pre-commit-config.yaml') == ''
+        run: echo "No .pre-commit-config.yaml found; skipping pre-commit config lint."
 
   cdf-dry-run:
     name: cdf build & deploy --dry-run

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -105,7 +105,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install Cognite Toolkit
-        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}" pyyaml
+        run: pip install "cognite-toolkit=={{TOOLKIT_VERSION}}"
 
       - name: cdf build
         id: build


### PR DESCRIPTION
**Summary:**

- Rename the misleading Lint (ruff, pyright, config) job to Lint (workflow YAML) — it only ever validated workflow YAML and optionally ran pre-commit config checks; it never ran ruff or pyright. The pre-commit install step now only runs when .pre-commit-config.yaml exists (previously it installed pre-commit only to skip). Workflow YAML validation now globs .github/workflows/*.yml instead of a hardcoded file list, so generate_actions.py no longer needs to track every generated filename (workflow_file_list() removed).

- Drop unused pyyaml installs from deploy.yml, deploy-prod.yml, and the cdf-dry-run job in dry-run.yml — none of them import yaml; only the lint job's YAML-validation step does, and it installs its own copy.

**Harden deploy-prod.yml:**

- Add a concurrency group (toolkit-deploy-prod) so overlapping release publishes can't race, matching dev/test.

- Replace the target_commitish == main check with a real ancestry check (git merge-base --is-ancestor) — target_commitish only reflects the branch picked in the release UI, not that the tagged commit is reachable fro

- Require the release tag to match vX.Y.Z.

- Run cdf deploy --dry-run befor final safety net.

Document branch protection in the generated FOUNDATION_CICD.md as required, not optional: PRs
to dev only run dry-run CI with 0 h guardrail check there); mainrequires a PR, 1 reviewer, the guardrail check, and dry-run.

Test plan:

 [ x]  uv run pytest 
 [ x]  ruff check 
[ x] python validate_packages.py
 [ ]  Confirm rendered workflows on a real Toolkit project (generate_actions.py --force) look correct in both with-test and with
