### PR TITLE
AT-90-Audit and fix all Deployment Packs for missing .Database.yaml files

### DIFF
--- a/ADDING_PACKAGES_AND_MODULES.md
+++ b/ADDING_PACKAGES_AND_MODULES.md
@@ -86,14 +86,16 @@ schemaSpace: cdf_cdm
 annotationSpace: springfield_instances
 ```
 
-5. **Reference shared assets with `[[extra_resources]]`** — only when files live **outside** the module folder. Each `location` is relative to `modules/`. Prefer keeping assets inside the module when possible; use `extra_resources` for shared YAML under `common/cdf_common` and similar. `validate_packages.py` fails if a path does not exist.
+5. **If the module has a `raw/` directory, give every RAW database its own `.Database.yaml`** — every `dbName` referenced by a `*.Table.yaml` file must have a matching `<name>.Database.yaml` file **in the same module's `raw/` directory**. The Cognite Toolkit only creates RAW databases from `*.Database.yaml` files, and RAW tables depend on their database, so a module that references a database declared only in a *different* module fails at `cdf deploy` with a "DB not found" error the moment someone deploys it on its own (deployment packs are independently selectable — don't assume a sibling module is always deployed alongside it). `validate_packages.py` enforces this automatically; run it after touching any `raw/` file.
+
+6. **Reference shared assets with `[[extra_resources]]`** — only when files live **outside** the module folder. Each `location` is relative to `modules/`. Prefer keeping assets inside the module when possible; use `extra_resources` for shared YAML under `common/cdf_common` and similar. `validate_packages.py` fails if a path does not exist.
 
 ```toml
 [[extra_resources]]
 location = "common/cdf_common/data_sets/demo.DataSet.yaml"
 ```
 
-6. **Wire the module into `packages.toml`** — add the module path (relative to `modules/`) to every pack that should include it.
+7. **Wire the module into `packages.toml`** — add the module path (relative to `modules/`) to every pack that should include it.
 
 ## Adding a new package
 

--- a/modules/contextualization/cdf_p_and_id_annotation/raw/ds_files.Database.yaml
+++ b/modules/contextualization/cdf_p_and_id_annotation/raw/ds_files.Database.yaml
@@ -1,0 +1,1 @@
+dbName: ds_files_{{location_name}}_{{source_name}}

--- a/modules/sourcesystem/cdf_pi_data_dump/raw/cfihos_oil_and_gas.Database.yaml
+++ b/modules/sourcesystem/cdf_pi_data_dump/raw/cfihos_oil_and_gas.Database.yaml
@@ -1,0 +1,1 @@
+dbName: cfihos_oil_and_gas

--- a/modules/sourcesystem/cdf_sharepoint_data_dump/raw/cfihos_oil_and_gas.Database.yaml
+++ b/modules/sourcesystem/cdf_sharepoint_data_dump/raw/cfihos_oil_and_gas.Database.yaml
@@ -1,0 +1,1 @@
+dbName: cfihos_oil_and_gas

--- a/tests/test_validate_packages.py
+++ b/tests/test_validate_packages.py
@@ -113,3 +113,14 @@ def test_find_raw_database_gaps_ignores_trailing_comments(tmp_path: Path) -> Non
     (raw_dir / "cfihos_oil_and_gas.Database.yaml").write_text('dbName: "cfihos_oil_and_gas"  # another comment\n')
 
     assert find_raw_database_gaps(str(tmp_path)) == []
+
+
+def test_find_raw_database_gaps_matches_table_yaml_case_insensitively(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "common" / "cdf_common" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "contextualization_state.table.yaml").write_text(
+        "dbName: contextualizationState\ntableName: diagramParsing\n"
+    )
+    (raw_dir / "contextualization_state.DataBase.yaml").write_text("dbName: contextualizationState\n")
+
+    assert find_raw_database_gaps(str(tmp_path)) == []

--- a/tests/test_validate_packages.py
+++ b/tests/test_validate_packages.py
@@ -102,3 +102,14 @@ def test_find_raw_database_gaps_handles_list_shaped_table_files(tmp_path: Path) 
     (raw_dir / "isa_all_manufacturing.Database.yaml").write_text("dbName: {{ rawDatabase }}\n")
 
     assert find_raw_database_gaps(str(tmp_path)) == []
+
+
+def test_find_raw_database_gaps_ignores_trailing_comments(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "sourcesystem" / "cdf_pi_data_dump" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "timeseries.Table.yaml").write_text(
+        "dbName: cfihos_oil_and_gas  # some comment\ntableName: timeseries\n"
+    )
+    (raw_dir / "cfihos_oil_and_gas.Database.yaml").write_text('dbName: "cfihos_oil_and_gas"  # another comment\n')
+
+    assert find_raw_database_gaps(str(tmp_path)) == []

--- a/tests/test_validate_packages.py
+++ b/tests/test_validate_packages.py
@@ -124,3 +124,12 @@ def test_find_raw_database_gaps_matches_table_yaml_case_insensitively(tmp_path: 
     (raw_dir / "contextualization_state.DataBase.yaml").write_text("dbName: contextualizationState\n")
 
     assert find_raw_database_gaps(str(tmp_path)) == []
+
+
+def test_find_raw_database_gaps_matches_uppercase_names_and_yml_extension(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "sourcesystem" / "cdf_db_extractor" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "db_postgres.TABLE.yml").write_text('dbName: "db_postgres"\ntableName: mytable\n')
+    (raw_dir / "db_postgres.DATABASE.YML").write_text('dbName: "db_postgres"\n')
+
+    assert find_raw_database_gaps(str(tmp_path)) == []

--- a/tests/test_validate_packages.py
+++ b/tests/test_validate_packages.py
@@ -1,6 +1,5 @@
 """Tests for validate_packages registry parsing."""
 
-
 import sys
 from pathlib import Path
 
@@ -8,7 +7,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from validate_packages import PackageSpec, PackagesRegistry, parse_packages_registry
+from validate_packages import (
+    PackageSpec,
+    PackagesRegistry,
+    RawDatabaseGap,
+    find_raw_database_gaps,
+    parse_packages_registry,
+)
 
 
 def test_parse_packages_registry_accepts_minimal_valid_shape() -> None:
@@ -57,3 +62,43 @@ def test_parse_packages_registry_rejects_empty_module_path() -> None:
     }
 
     assert parse_packages_registry(data) is None
+
+
+def test_find_raw_database_gaps_flags_table_with_no_local_database_yaml(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "sourcesystem" / "cdf_pi_data_dump" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "timeseries.Table.yaml").write_text("dbName: cfihos_oil_and_gas\ntableName: timeseries\n")
+
+    # A different, unrelated module declares the same database name -- this must
+    # NOT count, because each module has to be independently deployable.
+    other_raw_dir = tmp_path / "sourcesystem" / "cdf_sap_data_dump" / "raw"
+    other_raw_dir.mkdir(parents=True)
+    (other_raw_dir / "cfihos_oil_and_gas.Database.yaml").write_text("dbName: cfihos_oil_and_gas\n")
+
+    gaps = find_raw_database_gaps(str(tmp_path))
+
+    assert gaps == [
+        RawDatabaseGap(
+            module_path="sourcesystem/cdf_pi_data_dump",
+            db_name="cfihos_oil_and_gas",
+            table_files=("timeseries.Table.yaml",),
+        )
+    ]
+
+
+def test_find_raw_database_gaps_accepts_matching_database_yaml_in_same_module(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "sourcesystem" / "cdf_sap_extractor" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "equipment.Table.yaml").write_text('dbName: "db_{{location}}_sap"\ntableName: equipment\n')
+    (raw_dir / "db_sap.Database.yaml").write_text('dbName: "db_{{location}}_sap"\n')
+
+    assert find_raw_database_gaps(str(tmp_path)) == []
+
+
+def test_find_raw_database_gaps_handles_list_shaped_table_files(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "datamodels" / "isa_manufacturing_extension" / "raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "isa_asset.Table.yaml").write_text("- dbName: {{ rawDatabase }}\n  tableName: isa_asset\n")
+    (raw_dir / "isa_all_manufacturing.Database.yaml").write_text("dbName: {{ rawDatabase }}\n")
+
+    assert find_raw_database_gaps(str(tmp_path)) == []

--- a/validate_packages.py
+++ b/validate_packages.py
@@ -283,7 +283,7 @@ def _extract_db_names(path: Path) -> list[str]:
     templated Jinja expression (for example ``{{ location }}``), which PyYAML's
     safe loader cannot parse as a plain string.
     """
-    return [match.strip() for match in _DB_NAME_PATTERN.findall(path.read_text())]
+    return [match.strip() for match in _DB_NAME_PATTERN.findall(path.read_text(encoding="utf-8"))]
 
 
 def find_raw_database_gaps(base_path: str = "modules") -> list[RawDatabaseGap]:
@@ -307,7 +307,7 @@ def find_raw_database_gaps(base_path: str = "modules") -> list[RawDatabaseGap]:
             declared_db_names.update(_extract_db_names(database_file))
 
         referenced_by: defaultdict[str, list[str]] = defaultdict(list)
-        for table_file in raw_dir.glob("*.Table.yaml"):
+        for table_file in raw_dir.glob("*.[Tt]able.yaml"):
             for db_name in _extract_db_names(table_file):
                 referenced_by[db_name].append(table_file.name)
 

--- a/validate_packages.py
+++ b/validate_packages.py
@@ -6,6 +6,7 @@ Assumes "modules" as the base folder where packages.toml is located.
 """
 
 import os
+import re
 import sys
 import tomllib
 from collections import defaultdict
@@ -63,9 +64,7 @@ def parse_packages_registry(data: dict[str, object]) -> PackagesRegistry | None:
 
         package_id = _require_non_empty_str(package_data, "id", f"Package '{package_name}'")
         title = _require_non_empty_str(package_data, "title", f"Package '{package_name}'")
-        package_description = _require_non_empty_str(
-            package_data, "description", f"Package '{package_name}'"
-        )
+        package_description = _require_non_empty_str(package_data, "description", f"Package '{package_name}'")
         if package_id is None or title is None or package_description is None:
             return None
 
@@ -106,9 +105,7 @@ def validate_module_paths(
     for module_path in modules:
         full_path = base_path_obj / module_path
         if not full_path.exists():
-            print(
-                f"ERROR: Package '{package_name}' module path '{module_path}' does not exist at '{full_path}'"
-            )
+            print(f"ERROR: Package '{package_name}' module path '{module_path}' does not exist at '{full_path}'")
             return False
 
         module_toml = full_path / "module.toml"
@@ -123,9 +120,7 @@ def validate_module_paths(
 
         module_raw = module_data.get("module")
         if not isinstance(module_raw, dict):
-            print(
-                f"ERROR: Package '{package_name}' module path '{module_path}' is missing a [module] table"
-            )
+            print(f"ERROR: Package '{package_name}' module path '{module_path}' is missing a [module] table")
             return False
 
         required_fields = {"id", "package_id", "title"}
@@ -138,16 +133,12 @@ def validate_module_paths(
 
         extra_resources_raw = module_data.get("extra_resources", [])
         if not isinstance(extra_resources_raw, list):
-            print(
-                f"ERROR: Package '{package_name}' module '{module_path}' extra_resources must be a list"
-            )
+            print(f"ERROR: Package '{package_name}' module '{module_path}' extra_resources must be a list")
             return False
 
         for extra_resource in extra_resources_raw:
             if not isinstance(extra_resource, dict):
-                print(
-                    f"ERROR: Package '{package_name}' module '{module_path}' has an invalid extra_resource entry"
-                )
+                print(f"ERROR: Package '{package_name}' module '{module_path}' has an invalid extra_resource entry")
                 return False
             location = extra_resource.get("location")
             if not isinstance(location, str) or not location:
@@ -273,6 +264,83 @@ def validate_unique_module_ids(base_path: str = "modules") -> bool:
     return True
 
 
+@dataclass(frozen=True)
+class RawDatabaseGap:
+    """A RAW table dbName with no matching Database.yaml in the same module."""
+
+    module_path: str
+    db_name: str
+    table_files: tuple[str, ...]
+
+
+_DB_NAME_PATTERN = re.compile(r'^\s*-?\s*dbName:\s*["\']?(.+?)["\']?\s*$', re.MULTILINE)
+
+
+def _extract_db_names(path: Path) -> list[str]:
+    """Extract dbName values from a *.Table.yaml or *.Database.yaml file.
+
+    Uses a regex instead of a YAML parser because dbName is frequently a
+    templated Jinja expression (for example ``{{ location }}``), which PyYAML's
+    safe loader cannot parse as a plain string.
+    """
+    return [match.strip() for match in _DB_NAME_PATTERN.findall(path.read_text())]
+
+
+def find_raw_database_gaps(base_path: str = "modules") -> list[RawDatabaseGap]:
+    """Find RAW tables whose dbName has no matching Database.yaml in the same module.
+
+    Every module with a raw/ directory must be independently deployable: any
+    dbName referenced by a *.Table.yaml file must have a matching
+    *.Database.yaml file within the same module, not merely somewhere else in
+    the repo. The Cognite Toolkit only creates RAW databases from
+    *.Database.yaml files, and RAW tables depend on their RAW database, so a
+    module deployed on its own without that file fails at `cdf deploy` with a
+    "DB not found" error -- even if a different, unrelated module happens to
+    declare a database with the same name.
+    """
+    gaps: list[RawDatabaseGap] = []
+    for raw_dir in sorted(Path(base_path).glob("**/raw")):
+        module_path = raw_dir.parent.relative_to(Path(base_path)).as_posix()
+
+        declared_db_names: set[str] = set()
+        for database_file in raw_dir.glob("*.[Dd]ata[Bb]ase.yaml"):
+            declared_db_names.update(_extract_db_names(database_file))
+
+        referenced_by: defaultdict[str, list[str]] = defaultdict(list)
+        for table_file in raw_dir.glob("*.Table.yaml"):
+            for db_name in _extract_db_names(table_file):
+                referenced_by[db_name].append(table_file.name)
+
+        for db_name, table_files in sorted(referenced_by.items()):
+            if db_name not in declared_db_names:
+                gaps.append(
+                    RawDatabaseGap(
+                        module_path=module_path,
+                        db_name=db_name,
+                        table_files=tuple(sorted(table_files)),
+                    )
+                )
+
+    return gaps
+
+
+def validate_raw_databases(base_path: str = "modules") -> bool:
+    """Ensure every module with a raw/ directory can create its own RAW databases."""
+    gaps = find_raw_database_gaps(base_path)
+    if gaps:
+        print("\nERROR: RAW table(s) reference a database with no matching Database.yaml in the same module:")
+        for gap in gaps:
+            table_files = ", ".join(gap.table_files)
+            print(
+                f"  {gap.module_path}: dbName={gap.db_name!r} referenced by [{table_files}] "
+                "has no matching <name>.Database.yaml in this module's raw/ directory"
+            )
+        return False
+
+    print("\n✓ All RAW tables have a matching Database.yaml in their own module")
+    return True
+
+
 def main() -> None:
     """Main validation function."""
     packages_file = "modules/packages.toml"
@@ -307,9 +375,10 @@ def main() -> None:
         if not validate_unique_module_ids("modules"):
             sys.exit(1)
 
-        print(
-            f"\n🎉 All validation checks passed! {len(registry.packages)} packages validated successfully."
-        )
+        if not validate_raw_databases("modules"):
+            sys.exit(1)
+
+        print(f"\n🎉 All validation checks passed! {len(registry.packages)} packages validated successfully.")
 
     except tomllib.TOMLDecodeError as e:
         print(f"ERROR: Invalid TOML format: {e}")

--- a/validate_packages.py
+++ b/validate_packages.py
@@ -154,7 +154,7 @@ def validate_module_paths(
                 )
                 return False
 
-        print(f"✓ Module '{module_path}' validated successfully")
+        print(f"OK: Module '{module_path}' validated successfully")
 
     return True
 
@@ -221,7 +221,7 @@ def validate_module_id_prefixes(
                 print(f"  {rel_path}: id={module_id!r} (allowed prefixes: {allowed_str})")
         return False
 
-    print("\n✓ All module ids use an allowed dp:<pack>: prefix")
+    print("\nOK: All module ids use an allowed dp:<pack>: prefix")
     return True
 
 
@@ -260,7 +260,7 @@ def validate_unique_module_ids(base_path: str = "modules") -> bool:
                 print(f"    - {path}")
         return False
 
-    print(f"\n✓ All {len(ids_by_path)} module ids are unique")
+    print(f"\nOK: All {len(ids_by_path)} module ids are unique")
     return True
 
 
@@ -337,7 +337,7 @@ def validate_raw_databases(base_path: str = "modules") -> bool:
             )
         return False
 
-    print("\n✓ All RAW tables have a matching Database.yaml in their own module")
+    print("\nOK: All RAW tables have a matching Database.yaml in their own module")
     return True
 
 
@@ -353,18 +353,18 @@ def main() -> None:
         with open(packages_file, "rb") as f:
             data = tomllib.load(f)
 
-        print(f"✓ Successfully parsed {packages_file}")
+        print(f"OK: Successfully parsed {packages_file}")
 
         registry = parse_packages_registry(data)
         if registry is None:
             sys.exit(1)
 
-        print("✓ [library] header validation passed")
-        print(f"✓ Found {len(registry.packages)} packages")
+        print("OK: [library] header validation passed")
+        print(f"OK: Found {len(registry.packages)} packages")
 
         for package_name, package_spec in registry.packages.items():
             print(f"\nValidating package: {package_name}")
-            print(f"✓ Package '{package_name}' structure validation passed")
+            print(f"OK: Package '{package_name}' structure validation passed")
 
             if not validate_module_paths(package_name, package_spec.modules, "modules"):
                 sys.exit(1)
@@ -378,7 +378,7 @@ def main() -> None:
         if not validate_raw_databases("modules"):
             sys.exit(1)
 
-        print(f"\n🎉 All validation checks passed! {len(registry.packages)} packages validated successfully.")
+        print(f"\nAll validation checks passed! {len(registry.packages)} packages validated successfully.")
 
     except tomllib.TOMLDecodeError as e:
         print(f"ERROR: Invalid TOML format: {e}")

--- a/validate_packages.py
+++ b/validate_packages.py
@@ -273,7 +273,7 @@ class RawDatabaseGap:
     table_files: tuple[str, ...]
 
 
-_DB_NAME_PATTERN = re.compile(r'^\s*-?\s*dbName:\s*["\']?(.+?)["\']?\s*$', re.MULTILINE)
+_DB_NAME_PATTERN = re.compile(r'^\s*-?\s*dbName:\s*["\']?(.+?)["\']?\s*(?:#.*)?$', re.MULTILINE)
 
 
 def _extract_db_names(path: Path) -> list[str]:

--- a/validate_packages.py
+++ b/validate_packages.py
@@ -303,13 +303,17 @@ def find_raw_database_gaps(base_path: str = "modules") -> list[RawDatabaseGap]:
         module_path = raw_dir.parent.relative_to(Path(base_path)).as_posix()
 
         declared_db_names: set[str] = set()
-        for database_file in raw_dir.glob("*.[Dd]ata[Bb]ase.yaml"):
-            declared_db_names.update(_extract_db_names(database_file))
-
         referenced_by: defaultdict[str, list[str]] = defaultdict(list)
-        for table_file in raw_dir.glob("*.[Tt]able.yaml"):
-            for db_name in _extract_db_names(table_file):
-                referenced_by[db_name].append(table_file.name)
+        for file_path in sorted(raw_dir.iterdir()):
+            if not file_path.is_file():
+                continue
+            # Match the Cognite Toolkit's own file matching: any casing, .yaml or .yml.
+            name_lower = file_path.name.lower()
+            if name_lower.endswith((".database.yaml", ".database.yml")):
+                declared_db_names.update(_extract_db_names(file_path))
+            elif name_lower.endswith((".table.yaml", ".table.yml")):
+                for db_name in _extract_db_names(file_path):
+                    referenced_by[db_name].append(file_path.name)
 
         for db_name, table_files in sorted(referenced_by.items()):
             if db_name not in declared_db_names:


### PR DESCRIPTION
Adding corresponding .Database.yaml file to all RAW db defined across all DPs, so that cdf deploy doesn't fail with "DB not found" on Toolkit v0.8.x.
3 modules were missing it:
1. sourcesystem/cdf_pi_data_dump
2. sourcesystem/cdf_sharepoint_data_dump
3. contextualization/cdf_p_and_id_annotation

Also adds an automated check (validate_raw_databases in validate_packages.py,
wired into CI) so this gap is caught on any new module going forward, plus
a note in ADDING_PACKAGES_AND_MODULES.md documenting the requirement.

Verified live against the at-dev project: without the fix, cdf build blocks
deploy with "Missing dependency cdf: Broken reference to raw databases...";
with the fix, cdf deploy --dry-run --include raw reports "Able to deploy: Yes"
for all affected modules.