### PR TITLE
AT 98: refactor(generate-actions): make CI/CD generation provider-aware

### DIFF
--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Generate GitHub Actions CI/CD for a Toolkit project using the Foundation Deployment Pack.
+Generate CI/CD for a Toolkit project using the Foundation Deployment Pack.
 
 Implements the branching model and workflows from sop-cdf-project-setup.md (Step 5):
   - PR to dev, and PR to main when config.test.yaml exists → dry-run
@@ -8,9 +8,14 @@ Implements the branching model and workflows from sop-cdf-project-setup.md (Step
   - Push to main → deploy to config.test.yaml's environment.project when present
   - Release published from main → deploy to config.prod.yaml's environment.project
 
+Supports multiple CI/CD providers via --provider (default: github). Provider-specific
+templates live under templates/<provider>/; output is written to a provider-specific
+directory (.github/workflows for GitHub, .devops for Azure DevOps).
+
 Run from the Toolkit project root after `cdf modules add -d dp:foundation`:
 
   python modules/common/cdf_project_foundation/scripts/generate_actions.py
+  python modules/common/cdf_project_foundation/scripts/generate_actions.py --provider ado
 """
 
 
@@ -28,11 +33,28 @@ except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 
 MODULE_DIR = Path(__file__).resolve().parents[1]
-TEMPLATES_DIR = MODULE_DIR / "templates" / "github"
+TEMPLATES_ROOT = MODULE_DIR / "templates"
 ENVIRONMENTS = ("dev", "test", "prod")
 DEPLOY_BRANCHES = {"dev": "dev", "test": "main"}
 ENV_LABELS = {"dev": "Dev", "test": "Test"}
 CONFIG_FLAG_MIN_VERSION = (0, 8, 0)
+
+PROVIDERS = ("github", "ado")
+DEFAULT_PROVIDER = "github"
+PROVIDER_WORKFLOWS_DIR = {
+    "github": Path(".github") / "workflows",
+    "ado": Path(".devops"),
+}
+
+
+def templates_dir(provider: str) -> Path:
+    """Provider-specific template directory (e.g. templates/github, templates/ado)."""
+    return TEMPLATES_ROOT / provider
+
+
+def workflows_output_dir(provider: str, repo_root: Path) -> Path:
+    """Where generated CI/CD files are written for this provider."""
+    return repo_root / PROVIDER_WORKFLOWS_DIR[provider]
 
 
 def resolve_modules_root(repo_root: Path, org_dir: str | None) -> Path:
@@ -320,12 +342,20 @@ def main() -> None:
         action="store_true",
         help="Overwrite generated files without prompting",
     )
+    parser.add_argument(
+        "--provider",
+        choices=PROVIDERS,
+        default=DEFAULT_PROVIDER,
+        help=f"CI/CD provider to generate for (default: {DEFAULT_PROVIDER})",
+    )
     args = parser.parse_args()
 
+    templates = templates_dir(args.provider)
     repo_root = find_repo_root(Path.cwd())
     cdf = load_cdf_toml(repo_root)
     org_dir: str | None = args.org_dir or cdf.get("cdf", {}).get("default_organization_dir") or None
     projects = load_environment_projects(repo_root, org_dir)
+    workflows_dir = workflows_output_dir(args.provider, repo_root)
 
     toolkit_version = cdf.get("modules", {}).get("version", "0.7.220")
     resolve_modules_root(repo_root, org_dir)
@@ -346,20 +376,20 @@ def main() -> None:
     }
 
     if deployable_envs(projects):
-        template = TEMPLATES_DIR / "dry-run.yml"
+        template = templates / "dry-run.yml"
         if not template.is_file():
             print(f"Missing template: {template}", file=sys.stderr)
             sys.exit(1)
         write_file(
-            repo_root / ".github" / "workflows" / "dry-run.yml",
+            workflows_dir / "dry-run.yml",
             render_template(template, base_values),
             args.force,
         )
     else:
-        remove_file(repo_root / ".github" / "workflows" / "dry-run.yml")
+        remove_file(workflows_dir / "dry-run.yml")
 
     if "prod" in projects:
-        deploy_prod_template = TEMPLATES_DIR / "deploy-prod.yml"
+        deploy_prod_template = templates / "deploy-prod.yml"
         if not deploy_prod_template.is_file():
             print(f"Missing template: {deploy_prod_template}", file=sys.stderr)
             sys.exit(1)
@@ -369,20 +399,20 @@ def main() -> None:
             "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
         }
         write_file(
-            repo_root / ".github" / "workflows" / "deploy-prod.yml",
+            workflows_dir / "deploy-prod.yml",
             render_template(deploy_prod_template, prod_values),
             args.force,
         )
     else:
-        remove_file(repo_root / ".github" / "workflows" / "deploy-prod.yml")
+        remove_file(workflows_dir / "deploy-prod.yml")
 
-    deploy_template = TEMPLATES_DIR / "deploy.yml"
+    deploy_template = templates / "deploy.yml"
     if not deploy_template.is_file():
         print(f"Missing template: {deploy_template}", file=sys.stderr)
         sys.exit(1)
     for env in ("dev", "test"):
         if env not in projects:
-            remove_file(repo_root / ".github" / "workflows" / f"deploy-{env}.yml")
+            remove_file(workflows_dir / f"deploy-{env}.yml")
             continue
         merged = {
             **base_values,
@@ -392,13 +422,13 @@ def main() -> None:
             "PROJECT": projects[env],
             "BUILD_ARGS": build_args(str(toolkit_version), org_dir, env),
         }
-        out = repo_root / ".github" / "workflows" / f"deploy-{env}.yml"
+        out = workflows_dir / f"deploy-{env}.yml"
         write_file(out, render_template(deploy_template, merged), args.force)
 
     cicd_readme = repo_root / "docs" / "FOUNDATION_CICD.md"
     write_file(
         cicd_readme,
-        render_template(TEMPLATES_DIR / "FOUNDATION_CICD.md", base_values),
+        render_template(templates / "FOUNDATION_CICD.md", base_values),
         args.force,
     )
 

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -427,10 +427,14 @@ def main() -> None:
         out = workflows_dir / f"deploy-{env}.yml"
         write_file(out, render_template(deploy_template, merged), args.force)
 
+    readme_template = templates / "FOUNDATION_CICD.md"
+    if not readme_template.is_file():
+        print(f"Missing template: {readme_template}", file=sys.stderr)
+        sys.exit(1)
     cicd_readme = repo_root / "docs" / "FOUNDATION_CICD.md"
     write_file(
         cicd_readme,
-        render_template(templates / "FOUNDATION_CICD.md", base_values),
+        render_template(readme_template, base_values),
         args.force,
     )
 

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -54,6 +54,8 @@ def templates_dir(provider: str) -> Path:
 
 def workflows_output_dir(provider: str, repo_root: Path) -> Path:
     """Where generated CI/CD files are written for this provider."""
+    if provider not in PROVIDER_WORKFLOWS_DIR:
+        raise ValueError(f"Unsupported provider: {provider}")
     return repo_root / PROVIDER_WORKFLOWS_DIR[provider]
 
 

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -431,6 +431,97 @@ environment:
             assert f"`config.{env}.yaml`" not in docs
 
 
+def _scaffold_dev_only_project(project_dir: Path) -> None:
+    (project_dir / "cdf.toml").write_text(
+        """
+[modules]
+version = "0.8.0"
+""".strip(),
+        encoding="utf-8",
+    )
+    modules = project_dir / "modules" / "common" / "cdf_project_foundation"
+    modules.mkdir(parents=True)
+    (modules / "module.toml").write_text(
+        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+        encoding="utf-8",
+    )
+    (project_dir / "config.dev.yaml").write_text(
+        """
+environment:
+  name: dev
+  project: acme-dev
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_generate_actions_explicit_provider_github_is_byte_identical_to_default(tmp_path: Path) -> None:
+    default_dir = tmp_path / "default"
+    explicit_dir = tmp_path / "explicit"
+    default_dir.mkdir()
+    explicit_dir.mkdir()
+    _scaffold_dev_only_project(default_dir)
+    _scaffold_dev_only_project(explicit_dir)
+
+    subprocess.run([sys.executable, str(GENERATE_ACTIONS), "--force"], check=True, cwd=default_dir)
+    subprocess.run(
+        [sys.executable, str(GENERATE_ACTIONS), "--force", "--provider", "github"],
+        check=True,
+        cwd=explicit_dir,
+    )
+
+    default_workflows = default_dir / ".github" / "workflows"
+    explicit_workflows = explicit_dir / ".github" / "workflows"
+    for name in ("dry-run.yml", "deploy-dev.yml"):
+        default_content = (default_workflows / name).read_text(encoding="utf-8")
+        explicit_content = (explicit_workflows / name).read_text(encoding="utf-8")
+        assert default_content == explicit_content
+
+    default_docs = (default_dir / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    explicit_docs = (explicit_dir / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    assert default_docs == explicit_docs
+
+    # Nothing provider-specific should leak into GitHub's own output tree.
+    assert not (explicit_dir / ".devops").exists()
+
+
+def test_generate_actions_rejects_invalid_provider(tmp_path: Path) -> None:
+    _scaffold_dev_only_project(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(GENERATE_ACTIONS), "--force", "--provider", "gitlab"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "invalid choice: 'gitlab'" in result.stderr
+    assert not (tmp_path / ".github").exists()
+    assert not (tmp_path / ".devops").exists()
+
+
+def test_generate_actions_provider_ado_fails_with_missing_template_error(tmp_path: Path) -> None:
+    _scaffold_dev_only_project(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(GENERATE_ACTIONS), "--force", "--provider", "ado"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "Missing template" in result.stderr
+    assert "templates/ado" in result.stderr
+    # No-op: nothing should be written for a provider whose templates don't exist yet.
+    assert not (tmp_path / ".devops").exists()
+    assert not (tmp_path / ".github").exists()
+    assert not (tmp_path / "docs" / "FOUNDATION_CICD.md").exists()
+
+
 def _make_foundation_module(modules_root: Path) -> None:
     module_dir = modules_root / "common" / "cdf_project_foundation" / "scripts"
     module_dir.mkdir(parents=True)

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -29,6 +29,14 @@ def test_dry_run_environment_rejects_more_than_two_branches(monkeypatch: pytest.
         generate_actions.dry_run_environment({"dev": "acme-dev", "test": "acme-test", "qa": "acme-qa"})
 
 
+def test_workflows_output_dir_rejects_unsupported_provider(tmp_path: Path) -> None:
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    with pytest.raises(ValueError, match="Unsupported provider: gitlab"):
+        generate_actions.workflows_output_dir("gitlab", tmp_path)
+
+
 def test_generate_actions_writes_workflows_and_docs(tmp_path: Path) -> None:
     org_dir = "industrial"
     (tmp_path / "cdf.toml").write_text(

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -530,6 +530,40 @@ def test_generate_actions_provider_ado_fails_with_missing_template_error(tmp_pat
     assert not (tmp_path / "docs" / "FOUNDATION_CICD.md").exists()
 
 
+def test_generate_actions_missing_readme_template_fails_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _scaffold_dev_only_project(project_dir)
+
+    # A provider whose template set is missing FOUNDATION_CICD.md — everything else is present.
+    fake_provider_dir = tmp_path / "templates" / "fake"
+    fake_provider_dir.mkdir(parents=True)
+    for name in ("dry-run.yml", "deploy.yml"):
+        (fake_provider_dir / name).write_text((TEMPLATES / name).read_text(encoding="utf-8"), encoding="utf-8")
+
+    monkeypatch.setattr(generate_actions, "TEMPLATES_ROOT", tmp_path / "templates")
+    monkeypatch.setattr(generate_actions, "PROVIDERS", (*generate_actions.PROVIDERS, "fake"))
+    monkeypatch.setitem(generate_actions.PROVIDER_WORKFLOWS_DIR, "fake", Path(".github") / "workflows")
+    monkeypatch.setattr(sys, "argv", ["generate_actions.py", "--force", "--provider", "fake"])
+    monkeypatch.chdir(project_dir)
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_actions.main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Missing template" in captured.err
+    assert "FOUNDATION_CICD.md" in captured.err
+    assert not (project_dir / "docs" / "FOUNDATION_CICD.md").exists()
+    # Workflow files ahead of the README step should still have been written.
+    assert (project_dir / ".github" / "workflows" / "dry-run.yml").is_file()
+
+
 def _make_foundation_module(modules_root: Path) -> None:
     module_dir = modules_root / "common" / "cdf_project_foundation" / "scripts"
     module_dir.mkdir(parents=True)


### PR DESCRIPTION
Add a --provider {github,ado} flag (default github) to generate_actions.py and resolve TEMPLATES_DIR/output paths through new templates_dir() and workflows_output_dir() helpers instead of hardcoding templates/github/ and .github/workflows/. This lets a second provider be added later without touching the GitHub generation path.

--provider github (or omitted) is verified byte-identical to current output. --provider ado currently fails fast with the existing "Missing template" error since templates/ado/ doesn't exist yet -- the actual ADO template rendering is separate follow-on work. Invalid --provider values exit non-zero via argparse's built-in validation.

AT-96/AT-98