### PR TITLE
AT-99: Author templates/ado/ + variable-group/registration/branch-policy docs + validation

### DIFF
--- a/modules/common/cdf_project_foundation/README.md
+++ b/modules/common/cdf_project_foundation/README.md
@@ -216,17 +216,20 @@ cdf deploy
 
 ### Step 6 — Set up CI/CD (optional)
 
-Generate GitHub Actions workflows that automate build, dry-run, and deploy on PR / merge / release. This can also be triggered through the setup wizard (Step 3):
+Generate CI/CD that automates build, dry-run, and deploy on PR / merge / release, for either GitHub Actions (default) or Azure DevOps. This can also be triggered through the setup wizard (Step 3):
 
 ```bash
 python modules/common/cdf_project_foundation/scripts/generate_actions.py --force
+python modules/common/cdf_project_foundation/scripts/generate_actions.py --force --provider ado
 ```
 
 The script reads `org-dir` and toolkit version from `cdf.toml` automatically. It uses `environment.project` from each `config.<env>.yaml` as the CDF project name and validates that `environment.name` matches the expected environment.
 
-This writes `.github/workflows/` (`dry-run.yml`, `deploy-dev.yml`, `deploy-prod.yml`, and `deploy-test.yml` when `config.test.yaml` exists) and `docs/FOUNDATION_CICD.md` (GitHub Environments and secrets). Configure `ADMIN_SOURCE_ID`, `CONSUMER_SOURCE_ID`, and `PRODUCER_SOURCE_ID` as GitHub Environment variables alongside the CDF auth variables.
+**GitHub (default):** writes `.github/workflows/` (`dry-run.yml`, `deploy-dev.yml`, `deploy-prod.yml`, and `deploy-test.yml` when `config.test.yaml` exists) and `docs/FOUNDATION_CICD.md` (GitHub Environments and secrets). Configure `ADMIN_SOURCE_ID`, `CONSUMER_SOURCE_ID`, and `PRODUCER_SOURCE_ID` as GitHub Environment variables alongside the CDF auth variables.
 
-Branching model: PRs to `dev`; PRs to `main` and deploy **test** on merge to `main` only when `config.test.yaml` exists; deploy **dev** on merge to `dev`, and **prod** on GitHub Release from `main`.
+**Azure DevOps (`--provider ado`):** writes `.devops/` (`dry-run-pipeline.yml` and the reusable `deploy-pipeline.yml`) and `docs/FOUNDATION_CICD.md` (variable groups, the three `deploy-pipeline.yml` registrations, and the Build Validation branch policy). See `docs/FOUNDATION_CICD.md` for the exact setup steps — variable groups follow the same `<env>-toolkit-credentials` naming as GitHub Environments.
+
+Branching model: PRs to `dev`; PRs to `main` and deploy **test** on merge to `main` only when `config.test.yaml` exists; deploy **dev** on merge to `dev`, and **prod** on a GitHub Release (or, for Azure DevOps, a `vX.Y.Z` tag) from `main`.
 
 ---
 
@@ -245,10 +248,11 @@ cdf_project_foundation/
 │   ├── _env_io.py                 # .env file parse / upsert helpers
 │   ├── _yaml_patch.py             # line-preserving YAML scalar patcher
 │   ├── setup_project.py           # interactive wizard — creates / updates config.<env>.yaml
-│   ├── generate_actions.py        # generates GitHub Actions CI/CD workflows
+│   ├── generate_actions.py        # generates GitHub Actions or Azure DevOps CI/CD (--provider)
 │   └── generate_env_configs.py    # generates config.{dev,test,prod}.yaml skeletons
 ├── templates/
-│   └── github/                    # GitHub Actions workflow templates
+│   ├── github/                    # GitHub Actions workflow templates
+│   └── ado/                       # Azure DevOps pipeline templates
 ├── default.config.yaml
 └── module.toml
 ```

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -113,17 +113,18 @@ def remove_file(path: Path) -> None:
         print(f"Removed {path}")
 
 
-def build_lint_paths(org_dir: str | None) -> str:
+def build_lint_paths(org_dir: str | None, provider: str) -> str:
     """Return git pathspecs for generated workflow linting.
 
     Keep this scoped to committed project-level files. Deployment modules often
     ship README files, notebooks, and generated Python that are not intended to
     satisfy the destination repository's pre-commit hooks.
     """
+    ci_scripts_dir = ".github/scripts/" if provider == "github" else ".devops/scripts/"
     entries: list[str] = [
         "'cdf.toml'",
         "'.pre-commit-config.yaml'",
-        "'.github/scripts/'",
+        f"'{ci_scripts_dir}'",
     ]
     if org_dir:
         entries.insert(0, f"'{org_dir}/config*.yaml'")
@@ -215,7 +216,13 @@ def pr_branches(projects: dict[str, str]) -> str:
     return "\n".join(f"      - {branch}" for branch in branches)
 
 
-def dry_run_environment(projects: dict[str, str]) -> str:
+def github_dry_run_environment(projects: dict[str, str]) -> str:
+    """GitHub Actions ``environment:`` expression for the dry-run job.
+
+    GitHub Actions-specific: relies on the ``github.base_ref`` expression context,
+    which has no equivalent on other providers. See ``ado_dry_run_jobs`` for the
+    Azure DevOps approach (one conditioned job per target branch).
+    """
     branches = branch_envs(projects)
     if not branches:
         return ""
@@ -232,7 +239,12 @@ def dry_run_environment(projects: dict[str, str]) -> str:
     )
 
 
-def dry_run_build_script(toolkit_version: str, org_dir: str | None, projects: dict[str, str]) -> str:
+def github_dry_run_build_script(toolkit_version: str, org_dir: str | None, projects: dict[str, str]) -> str:
+    """Bash build script for the dry-run job, keyed on ``$GITHUB_BASE_REF``.
+
+    GitHub Actions-specific: ``GITHUB_BASE_REF`` is a GitHub Actions runner
+    environment variable. See ``ado_dry_run_jobs`` for the Azure DevOps approach.
+    """
     branches = branch_envs(projects)
     if not branches:
         return ""
@@ -260,7 +272,193 @@ def dry_run_build_script(toolkit_version: str, org_dir: str | None, projects: di
     return "\n".join(cases)
 
 
-def branching_rows(projects: dict[str, str]) -> str:
+def _ado_promotion_guard_lines() -> list[str]:
+    return [
+        "      - script: |",
+        "          set -euo pipefail",
+        '          HEAD="$(System.PullRequest.SourceBranch)"',
+        '          HEAD="${HEAD#refs/heads/}"',
+        '          if [ "${HEAD}" != "dev" ] && [[ "${HEAD}" != hotfix/* ]]; then',
+        "            echo \"##vso[task.logissue type=error]PRs to 'main' must come from 'dev' or 'hotfix/*' only (head: ${HEAD})\"",
+        "            exit 1",
+        "          fi",
+        '          echo "Promotion flow OK: ${HEAD} -> main"',
+        "        displayName: 'Enforce promotion flow (main <- dev or hotfix/* only)'",
+        "",
+    ]
+
+
+def ado_dry_run_jobs(toolkit_version: str, org_dir: str | None, setup_check_cmd: str, projects: dict[str, str]) -> str:
+    """Azure DevOps jobs for the dry-run pipeline: one job per deployable branch,
+    each scoped to its own ``<env>-toolkit-credentials`` variable group and gated
+    on ``System.PullRequest.TargetBranch`` when more than one branch is deployable.
+    Avoids ever loading two environments' variable groups into the same job.
+    """
+    branches = branch_envs(projects)
+    if not branches:
+        return ""
+    if len(branches) > 2:
+        raise ValueError(f"Unsupported number of deployable branches: {len(branches)}")
+    gate_on_branch = len(branches) > 1
+
+    jobs: list[str] = []
+    for branch, env in branches.items():
+        lines = [
+            f"  - job: dry_run_{env}",
+            f"    displayName: 'cdf build & deploy --dry-run ({env})'",
+            "    dependsOn: lint",
+        ]
+        if gate_on_branch:
+            lines.append(f"    condition: eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/{branch}')")
+        lines.extend(
+            [
+                "    variables:",
+                f"      - group: {env}-toolkit-credentials",
+                "    steps:",
+                "      - checkout: self",
+                "",
+            ]
+        )
+        if branch == "main":
+            lines.extend(_ado_promotion_guard_lines())
+        lines.extend(
+            [
+                "      - script: rm -f .env",
+                "        displayName: 'Remove local .env'",
+                "",
+                "      - task: UsePythonVersion@0",
+                "        inputs:",
+                "          versionSpec: '3.13'",
+                "",
+                f'      - script: pip install "cognite-toolkit=={toolkit_version}"',
+                "        displayName: 'Install Cognite Toolkit'",
+                "",
+                f"      - script: {setup_check_cmd}",
+                "        displayName: 'Verify project config is in sync'",
+                "",
+                f"      - script: cdf build {build_args(toolkit_version, org_dir, env)}",
+                "        displayName: 'cdf build'",
+                "",
+                "      - script: cdf deploy --dry-run",
+                "        displayName: 'cdf deploy --dry-run'",
+            ]
+        )
+        jobs.append("\n".join(lines))
+    return "\n\n".join(jobs)
+
+
+ADO_DEPLOY_PIPELINE_NAMES = {"dev": "toolkit-deploy-dev", "test": "toolkit-deploy-test", "prod": "toolkit-deploy-prod"}
+ADO_DEPLOY_PIPELINE_TRIGGERS = {
+    "dev": "Push to `dev`",
+    "test": "Push to `main`",
+    "prod": "Git tag `vX.Y.Z` from `main`",
+}
+
+
+def ado_deploy_pipeline_rows(projects: dict[str, str]) -> str:
+    rows = [
+        f"| `{ADO_DEPLOY_PIPELINE_NAMES[env]}` | `.devops/deploy-pipeline.yml` | {ADO_DEPLOY_PIPELINE_TRIGGERS[env]} |"
+        for env in ENVIRONMENTS
+        if env in projects
+    ]
+    return "\n".join(rows)
+
+
+def _ado_deploy_condition(env: str) -> str:
+    if env == "dev":
+        return "eq(variables['Build.SourceBranch'], 'refs/heads/dev')"
+    if env == "test":
+        return "eq(variables['Build.SourceBranch'], 'refs/heads/main')"
+    return "startsWith(variables['Build.SourceBranch'], 'refs/tags/v')"
+
+
+def ado_deploy_jobs(toolkit_version: str, org_dir: str | None, setup_check_cmd: str, projects: dict[str, str]) -> str:
+    """Azure DevOps jobs for the single, reusable deploy-pipeline.yml: one job per
+    environment present in config.<env>.yaml, each gated on the branch or tag that
+    should trigger it and scoped to its own ``<env>-toolkit-credentials`` group.
+    Register the generated file three times in Azure DevOps (toolkit-deploy-dev,
+    toolkit-deploy-test, toolkit-deploy-prod) so history and permissions stay
+    per-environment; the job conditions make each registration a no-op outside its
+    own trigger.
+    """
+    envs = [env for env in ENVIRONMENTS if env in projects]
+    jobs: list[str] = []
+    for env in envs:
+        lines = [
+            f"  - job: deploy_{env}",
+            f"    displayName: 'Deploy to {projects[env]}'",
+            f"    condition: {_ado_deploy_condition(env)}",
+            "    variables:",
+            f"      - group: {env}-toolkit-credentials",
+            "    steps:",
+        ]
+        if env == "prod":
+            lines.extend(
+                [
+                    "      - checkout: self",
+                    "        fetchDepth: 0",
+                    "",
+                    "      - script: |",
+                    "          set -euo pipefail",
+                    '          TAG="$(Build.SourceBranchName)"',
+                    '          if [[ ! "$TAG" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]; then',
+                    '            echo "##vso[task.logissue type=error]Release tag must match vX.Y.Z (got: $TAG)"',
+                    "            exit 1",
+                    "          fi",
+                    "        displayName: 'Enforce release tag pattern'",
+                    "",
+                    "      - script: |",
+                    "          set -euo pipefail",
+                    "          git fetch origin main",
+                    "          if ! git merge-base --is-ancestor HEAD origin/main; then",
+                    '            echo "##vso[task.logissue type=error]Production releases must be published from a commit reachable from main"',
+                    "            exit 1",
+                    "          fi",
+                    "        displayName: 'Reject releases not reachable from main'",
+                    "",
+                ]
+            )
+        else:
+            lines.extend(["      - checkout: self", ""])
+        lines.extend(
+            [
+                "      - script: rm -f .env",
+                "        displayName: 'Remove local .env'",
+                "",
+                "      - task: UsePythonVersion@0",
+                "        inputs:",
+                "          versionSpec: '3.13'",
+                "",
+                f'      - script: pip install "cognite-toolkit=={toolkit_version}"',
+                "        displayName: 'Install Cognite Toolkit'",
+                "",
+                f"      - script: {setup_check_cmd}",
+                "        displayName: 'Verify project config is in sync'",
+                "",
+                f"      - script: cdf build {build_args(toolkit_version, org_dir, env)}",
+                "        displayName: 'cdf build'",
+            ]
+        )
+        if env == "prod":
+            lines.extend(
+                [
+                    "",
+                    "      - script: cdf deploy --dry-run",
+                    "        displayName: 'cdf deploy --dry-run'",
+                ]
+            )
+        lines.extend(
+            [
+                "",
+                "      - script: cdf deploy",
+                "        displayName: 'cdf deploy'",
+            ]
+        )
+        jobs.append("\n".join(lines))
+    return "\n\n".join(jobs)
+
+
+def branching_rows(projects: dict[str, str], provider: str) -> str:
     rows: list[str] = []
     for env in deployable_envs(projects):
         branch = DEPLOY_BRANCHES[env]
@@ -271,10 +469,9 @@ def branching_rows(projects: dict[str, str]) -> str:
             ]
         )
     if "prod" in projects:
-        rows.append(f"| GitHub Release (tag `vX.Y.Z` from `main`) | `{projects['prod']}` | Deploy |")
-    return "\n".join(
-        rows or ["| *(none)* | *(none)* | No CI/CD workflows generated |"]
-    )
+        prod_trigger = "GitHub Release (tag `vX.Y.Z` from `main`)" if provider == "github" else "Git tag `vX.Y.Z` pushed to `main`"
+        rows.append(f"| {prod_trigger} | `{projects['prod']}` | Deploy |")
+    return "\n".join(rows or ["| *(none)* | *(none)* | No CI/CD workflows generated |"])
 
 
 def branch_protection_rows(projects: dict[str, str]) -> str:
@@ -311,13 +508,14 @@ def indent(text: str, spaces: int) -> str:
     return "\n".join(f"{prefix}{line}" if line else line for line in text.splitlines())
 
 
-def environment_rows(projects: dict[str, str]) -> str:
+def environment_rows(projects: dict[str, str], provider: str) -> str:
     rows: list[str] = []
     for env in deployable_envs(projects):
         branch = DEPLOY_BRANCHES[env]
         rows.append(f"| `{env}-toolkit-credentials` | PR → {branch}, push `{branch}` | `{projects[env]}` |")
     if "prod" in projects:
-        rows.append(f"| `prod-toolkit-credentials` | Release published | `{projects['prod']}` |")
+        prod_trigger = "Release published" if provider == "github" else "Tag pushed"
+        rows.append(f"| `prod-toolkit-credentials` | {prod_trigger} | `{projects['prod']}` |")
     return "\n".join(rows)
 
 
@@ -362,70 +560,103 @@ def main() -> None:
     toolkit_version = cdf.get("modules", {}).get("version", "0.7.220")
     resolve_modules_root(repo_root, org_dir)
 
+    setup_check_cmd = setup_project_check_cmd(repo_root, org_dir)
     base_values: dict[str, str] = {
         "PR_BRANCHES": pr_branches(projects),
-        "DRY_RUN_ENVIRONMENT": dry_run_environment(projects),
-        "DRY_RUN_BUILD_SCRIPT": indent(dry_run_build_script(str(toolkit_version), org_dir, projects), 10),
-        "BRANCHING_ROWS": branching_rows(projects),
-        "ENVIRONMENT_ROWS": environment_rows(projects),
+        "BRANCHING_ROWS": branching_rows(projects, args.provider),
+        "ENVIRONMENT_ROWS": environment_rows(projects, args.provider),
         "EXAMPLE_BUILD_ARGS": example_build_args(str(toolkit_version), org_dir, projects),
         "ENV_CONFIG_LIST": env_config_list(projects),
         "BRANCH_PROTECTION_ROWS": branch_protection_rows(projects),
         "BRANCH_PROTECTION_NOTE": branch_protection_note(projects),
         "TOOLKIT_VERSION": str(toolkit_version),
-        "LINT_PATHS": build_lint_paths(org_dir),
-        "SETUP_PROJECT_CHECK_CMD": setup_project_check_cmd(repo_root, org_dir),
+        "LINT_PATHS": build_lint_paths(org_dir, args.provider),
+        "SETUP_PROJECT_CHECK_CMD": setup_check_cmd,
     }
 
-    if deployable_envs(projects):
-        template = templates / "dry-run.yml"
-        if not template.is_file():
-            print(f"Missing template: {template}", file=sys.stderr)
+    if args.provider == "github":
+        base_values["DRY_RUN_ENVIRONMENT"] = github_dry_run_environment(projects)
+        base_values["DRY_RUN_BUILD_SCRIPT"] = indent(
+            github_dry_run_build_script(str(toolkit_version), org_dir, projects), 10
+        )
+
+        if deployable_envs(projects):
+            template = templates / "dry-run.yml"
+            if not template.is_file():
+                print(f"Missing template: {template}", file=sys.stderr)
+                sys.exit(1)
+            write_file(
+                workflows_dir / "dry-run.yml",
+                render_template(template, base_values),
+                args.force,
+            )
+        else:
+            remove_file(workflows_dir / "dry-run.yml")
+
+        if "prod" in projects:
+            deploy_prod_template = templates / "deploy-prod.yml"
+            if not deploy_prod_template.is_file():
+                print(f"Missing template: {deploy_prod_template}", file=sys.stderr)
+                sys.exit(1)
+            prod_values = {
+                **base_values,
+                "PROD_PROJECT": projects["prod"],
+                "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
+            }
+            write_file(
+                workflows_dir / "deploy-prod.yml",
+                render_template(deploy_prod_template, prod_values),
+                args.force,
+            )
+        else:
+            remove_file(workflows_dir / "deploy-prod.yml")
+
+        deploy_template = templates / "deploy.yml"
+        if not deploy_template.is_file():
+            print(f"Missing template: {deploy_template}", file=sys.stderr)
+            sys.exit(1)
+        for env in ("dev", "test"):
+            if env not in projects:
+                remove_file(workflows_dir / f"deploy-{env}.yml")
+                continue
+            merged = {
+                **base_values,
+                "ENV": env,
+                "BRANCH": DEPLOY_BRANCHES[env],
+                "ENV_LABEL": ENV_LABELS[env],
+                "PROJECT": projects[env],
+                "BUILD_ARGS": build_args(str(toolkit_version), org_dir, env),
+            }
+            out = workflows_dir / f"deploy-{env}.yml"
+            write_file(out, render_template(deploy_template, merged), args.force)
+
+    elif args.provider == "ado":
+        base_values["DRY_RUN_JOBS"] = ado_dry_run_jobs(str(toolkit_version), org_dir, setup_check_cmd, projects)
+        base_values["DEPLOY_JOBS"] = ado_deploy_jobs(str(toolkit_version), org_dir, setup_check_cmd, projects)
+        base_values["DEPLOY_PIPELINE_ROWS"] = ado_deploy_pipeline_rows(projects)
+
+        if deployable_envs(projects):
+            dry_run_template = templates / "dry-run-pipeline.yml"
+            if not dry_run_template.is_file():
+                print(f"Missing template: {dry_run_template}", file=sys.stderr)
+                sys.exit(1)
+            write_file(
+                workflows_dir / "dry-run-pipeline.yml",
+                render_template(dry_run_template, base_values),
+                args.force,
+            )
+        else:
+            remove_file(workflows_dir / "dry-run-pipeline.yml")
+
+        deploy_pipeline_template = templates / "deploy-pipeline.yml"
+        if not deploy_pipeline_template.is_file():
+            print(f"Missing template: {deploy_pipeline_template}", file=sys.stderr)
             sys.exit(1)
         write_file(
-            workflows_dir / "dry-run.yml",
-            render_template(template, base_values),
+            workflows_dir / "deploy-pipeline.yml",
+            render_template(deploy_pipeline_template, base_values),
             args.force,
         )
-    else:
-        remove_file(workflows_dir / "dry-run.yml")
-
-    if "prod" in projects:
-        deploy_prod_template = templates / "deploy-prod.yml"
-        if not deploy_prod_template.is_file():
-            print(f"Missing template: {deploy_prod_template}", file=sys.stderr)
-            sys.exit(1)
-        prod_values = {
-            **base_values,
-            "PROD_PROJECT": projects["prod"],
-            "PROD_BUILD_ARGS": build_args(str(toolkit_version), org_dir, "prod"),
-        }
-        write_file(
-            workflows_dir / "deploy-prod.yml",
-            render_template(deploy_prod_template, prod_values),
-            args.force,
-        )
-    else:
-        remove_file(workflows_dir / "deploy-prod.yml")
-
-    deploy_template = templates / "deploy.yml"
-    if not deploy_template.is_file():
-        print(f"Missing template: {deploy_template}", file=sys.stderr)
-        sys.exit(1)
-    for env in ("dev", "test"):
-        if env not in projects:
-            remove_file(workflows_dir / f"deploy-{env}.yml")
-            continue
-        merged = {
-            **base_values,
-            "ENV": env,
-            "BRANCH": DEPLOY_BRANCHES[env],
-            "ENV_LABEL": ENV_LABELS[env],
-            "PROJECT": projects[env],
-            "BUILD_ARGS": build_args(str(toolkit_version), org_dir, env),
-        }
-        out = workflows_dir / f"deploy-{env}.yml"
-        write_file(out, render_template(deploy_template, merged), args.force)
 
     readme_template = templates / "FOUNDATION_CICD.md"
     if not readme_template.is_file():
@@ -441,12 +672,21 @@ def main() -> None:
     print()
     environments = [f"{env}-toolkit-credentials" for env in ENVIRONMENTS if env in projects]
     print("Next steps:")
-    print(f"  1. Create GitHub Environments: {', '.join(environments)}")
-    print("     (see docs/FOUNDATION_CICD.md)")
-    print("  2. Create and protect the branches used by the generated workflows")
-    if deployable_envs(projects):
-        branches = ", ".join(branch_envs(projects))
-        print(f"  3. Open a PR to {branches} to validate dry-run.yml")
+    if args.provider == "github":
+        print(f"  1. Create GitHub Environments: {', '.join(environments)}")
+        print("     (see docs/FOUNDATION_CICD.md)")
+        print("  2. Create and protect the branches used by the generated workflows")
+        if deployable_envs(projects):
+            branches = ", ".join(branch_envs(projects))
+            print(f"  3. Open a PR to {branches} to validate dry-run.yml")
+    else:
+        pipeline_names = [ADO_DEPLOY_PIPELINE_NAMES[env] for env in ENVIRONMENTS if env in projects]
+        print(f"  1. Create Azure DevOps variable groups: {', '.join(environments)}")
+        print("     (see docs/FOUNDATION_CICD.md)")
+        print(f"  2. Register deploy-pipeline.yml as: {', '.join(pipeline_names)}")
+        if deployable_envs(projects):
+            branches = ", ".join(branch_envs(projects))
+            print(f"  3. Add dry-run-pipeline.yml as a Build Validation policy on {branches}")
 
 
 if __name__ == "__main__":

--- a/modules/common/cdf_project_foundation/templates/ado/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/ado/FOUNDATION_CICD.md
@@ -1,0 +1,93 @@
+# Foundation Deployment Pack — CI/CD setup
+
+Generated from committed Toolkit environment configs.
+
+This follows the [CDF Foundation Setup guide](https://cogdocs.mintlify.io/gvd) *(password-protected — request access via [#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX) or contact [Valeriya Naumova](https://cognitedata.slack.com/team/U051XA95S0G))* — Step 5, Option B (Azure DevOps).
+
+## Branching model
+
+| Git branch / event | CDF project | Trigger |
+|--------------------|-------------|---------|
+{{BRANCHING_ROWS}}
+
+If a pre-production environment is present, PRs to `main` must come from `dev` or `hotfix/*` only.
+
+## Branch policies
+
+Protect the branches used above under **Repos → Branches → Branch policies**. This is required, not optional:
+
+| Branch | Required reviewers | Required status checks |
+|--------|---------------------|--------------------------|
+{{BRANCH_PROTECTION_ROWS}}
+
+{{BRANCH_PROTECTION_NOTE}}
+
+Register `dry-run-pipeline.yml` (the `toolkit-pr-validate` pipeline, see below) as a **Build Validation** policy on every branch listed above, so it runs automatically as a required check on each PR.
+
+## Variable groups
+
+Create one variable group per environment under **Pipelines → Library**:
+
+| Variable group | Used by | `CDF_PROJECT` example |
+|----------------|---------|-------------------------|
+{{ENVIRONMENT_ROWS}}
+
+Scope each group via **Pipeline permissions** to only the pipeline(s) that need it — the `dev-toolkit-credentials` group should grant access to `toolkit-pr-validate` and `toolkit-deploy-dev` only, and so on per environment.
+
+Each group needs these **variables**:
+
+- `CDF_CLUSTER`
+- `CDF_PROJECT` (must match `config.<env>.yaml`)
+- `LOGIN_FLOW` (typically `client_credentials`)
+- `IDP_TENANT_ID`
+- `IDP_CLIENT_ID`
+- `ADMIN_SOURCE_ID`
+- `CONSUMER_SOURCE_ID`
+- `PRODUCER_SOURCE_ID`
+
+And this **secret** (mark it secret in the Library UI):
+
+- `IDP_CLIENT_SECRET`
+
+## Pipelines to register
+
+Import the generated YAML as Azure DevOps pipelines under **Pipelines → New pipeline → Azure Repos Git**, selecting **Existing Azure Pipelines YAML file**:
+
+| Pipeline name | YAML file | Trigger |
+|---------------|-----------|---------|
+| `toolkit-pr-validate` | `.devops/dry-run-pipeline.yml` | PR to `dev` or `main` (via Build Validation policy above) |
+{{DEPLOY_PIPELINE_ROWS}}
+
+`deploy-pipeline.yml` is the same file for all three deploy registrations — each job inside it is gated on its own branch or tag, so only the matching registration actually deploys. Both `dry-run-pipeline.yml` and `deploy-pipeline.yml` set `trigger: none`; for each of the three deploy registrations, open **Edit → Triggers → Continuous integration** and override it to the one branch or tag pattern from the table above, so each registration's run history stays scoped to its own environment.
+
+## Toolkit configs
+
+This generator only writes Azure DevOps pipeline YAML and this guide. It does not
+create or refresh {{ENV_CONFIG_LIST}}.
+
+Before opening a PR, run the project setup wizard and commit the resulting config
+files together with the pipelines:
+
+```bash
+python modules/common/cdf_project_foundation/scripts/setup_project.py
+cdf build {{EXAMPLE_BUILD_ARGS}}
+```
+
+CI validates the committed configs as-is; it does not regenerate them.
+If the repository does not have a root `.pre-commit-config.yaml`, the generated
+PR pipeline skips the pre-commit config lint step.
+
+If any CDF Function under a `functions/` folder has Python source, the PR pipeline
+also runs `ruff check` and `pyright` against it, installing each function's
+`requirements.txt` first so imports resolve. Projects with no `functions/` Python
+code skip this step.
+
+## Regenerate pipelines
+
+```bash
+python modules/common/cdf_project_foundation/scripts/generate_actions.py --provider ado --force
+```
+
+## Toolkit version
+
+Pipelines install `cognite-toolkit=={{TOOLKIT_VERSION}}`. Keep in sync with `[modules].version` in `cdf.toml`.

--- a/modules/common/cdf_project_foundation/templates/ado/deploy-pipeline.yml
+++ b/modules/common/cdf_project_foundation/templates/ado/deploy-pipeline.yml
@@ -1,0 +1,7 @@
+trigger: none
+
+pool:
+  vmImage: ubuntu-latest
+
+jobs:
+{{DEPLOY_JOBS}}

--- a/modules/common/cdf_project_foundation/templates/ado/dry-run-pipeline.yml
+++ b/modules/common/cdf_project_foundation/templates/ado/dry-run-pipeline.yml
@@ -1,0 +1,74 @@
+trigger: none
+
+pr:
+  branches:
+    include:
+{{PR_BRANCHES}}
+
+pool:
+  vmImage: ubuntu-latest
+
+jobs:
+  - job: lint
+    displayName: 'Lint (pipeline YAML, config, functions)'
+    steps:
+      - checkout: self
+
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.13'
+
+      - script: pip install pyyaml
+        displayName: 'Install pyyaml'
+
+      - script: |
+          python - <<'PY'
+          from pathlib import Path
+          import yaml
+
+          for path in sorted(Path(".devops").glob("*.yml")):
+              yaml.safe_load(path.read_text())
+              print(f"valid yaml: {path}")
+          PY
+        displayName: 'Validate pipeline YAML'
+
+      - script: |
+          set -euo pipefail
+          if [ -f .pre-commit-config.yaml ]; then
+            pip install pre-commit
+            mapfile -t FILES < <(git ls-files \
+            {{LINT_PATHS}})
+            if [ "${#FILES[@]}" -gt 0 ]; then
+              SKIP=check-yaml,end-of-file-fixer,trailing-whitespace pre-commit run --files "${FILES[@]}"
+            fi
+          else
+            echo "No .pre-commit-config.yaml found; skipping pre-commit config lint."
+          fi
+        displayName: 'Config lint (Toolkit templates; skip strict YAML on modules)'
+
+      - script: |
+          set -euo pipefail
+          mapfile -t PY_FILES < <(git ls-files | grep -E '/functions/.*\.py$' || true)
+          if [ "${#PY_FILES[@]}" -eq 0 ]; then
+            echo "No Python found under functions/; skipping ruff and pyright."
+            exit 0
+          fi
+          pip install ruff pyright
+          mapfile -t REQS < <(git ls-files | grep -E '/functions/.*requirements\.txt$' || true)
+          for req in "${REQS[@]}"; do
+            pip install -r "$req"
+          done
+          status=0
+          ruff check "${PY_FILES[@]}" || status=$?
+          mapfile -t FUNC_DIRS < <(
+            for f in "${PY_FILES[@]}"; do
+              dirname "$f" | sed -E 's|^(.*functions/[^/]+).*|\1|'
+            done | sort -u
+          )
+          for dir in "${FUNC_DIRS[@]}"; do
+            (cd "$dir" && pyright --pythonversion 3.13 .) || status=$?
+          done
+          exit "$status"
+        displayName: 'Lint functions (ruff, pyright)'
+
+{{DRY_RUN_JOBS}}

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MODULE_ROOT = REPO_ROOT / "modules" / "common" / "cdf_project_foundation"
@@ -18,7 +19,7 @@ def test_generator_scripts_exist() -> None:
     assert (TEMPLATES / "dry-run.yml").is_file()
 
 
-def test_dry_run_environment_rejects_more_than_two_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_github_dry_run_environment_rejects_more_than_two_branches(monkeypatch: pytest.MonkeyPatch) -> None:
     sys.path.insert(0, str(MODULE_ROOT / "scripts"))
     import generate_actions  # pyright: ignore[reportMissingImports]
 
@@ -26,7 +27,23 @@ def test_dry_run_environment_rejects_more_than_two_branches(monkeypatch: pytest.
     monkeypatch.setitem(generate_actions.DEPLOY_BRANCHES, "qa", "qa")
 
     with pytest.raises(ValueError, match="Unsupported number of deployable branches: 3"):
-        generate_actions.dry_run_environment({"dev": "acme-dev", "test": "acme-test", "qa": "acme-qa"})
+        generate_actions.github_dry_run_environment({"dev": "acme-dev", "test": "acme-test", "qa": "acme-qa"})
+
+
+def test_ado_dry_run_jobs_rejects_more_than_two_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    monkeypatch.setattr(generate_actions, "deployable_envs", lambda projects: ["dev", "test", "qa"])
+    monkeypatch.setitem(generate_actions.DEPLOY_BRANCHES, "qa", "qa")
+
+    with pytest.raises(ValueError, match="Unsupported number of deployable branches: 3"):
+        generate_actions.ado_dry_run_jobs(
+            "0.8.0",
+            None,
+            "python scripts/setup_project.py --check",
+            {"dev": "acme-dev", "test": "acme-test", "qa": "acme-qa"},
+        )
 
 
 def test_workflows_output_dir_rejects_unsupported_provider(tmp_path: Path) -> None:
@@ -493,6 +510,97 @@ def test_generate_actions_explicit_provider_github_is_byte_identical_to_default(
     assert not (explicit_dir / ".devops").exists()
 
 
+def _scaffold_project_with_envs(project_dir: Path, envs: tuple[str, ...], org_dir: str | None = None) -> None:
+    (project_dir / "cdf.toml").write_text(
+        """
+[modules]
+version = "0.8.0"
+""".strip(),
+        encoding="utf-8",
+    )
+    base = (project_dir / org_dir) if org_dir else project_dir
+    modules = base / "modules" / "common" / "cdf_project_foundation"
+    modules.mkdir(parents=True)
+    (modules / "module.toml").write_text(
+        'id = "cdf_project_foundation"\npackage_id = "dp:foundation"\n',
+        encoding="utf-8",
+    )
+    for env in envs:
+        (base / f"config.{env}.yaml").write_text(
+            f"""
+environment:
+  name: {env}
+  project: acme-{env}
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+
+def test_generate_actions_ado_writes_pipelines_and_docs(tmp_path: Path) -> None:
+    _scaffold_project_with_envs(tmp_path, ("dev", "test", "prod"))
+
+    subprocess.run(
+        [sys.executable, str(GENERATE_ACTIONS), "--force", "--provider", "ado"],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    dry_run_path = tmp_path / ".devops" / "dry-run-pipeline.yml"
+    deploy_path = tmp_path / ".devops" / "deploy-pipeline.yml"
+    assert dry_run_path.is_file()
+    assert deploy_path.is_file()
+    assert (tmp_path / "docs" / "FOUNDATION_CICD.md").is_file()
+    # Nothing GitHub-specific should leak into ado's own output tree.
+    assert not (tmp_path / ".github").exists()
+
+    dry_run_yaml = yaml.safe_load(dry_run_path.read_text(encoding="utf-8"))
+    deploy_yaml = yaml.safe_load(deploy_path.read_text(encoding="utf-8"))
+    job_names = {job["job"] for job in dry_run_yaml["jobs"]}
+    assert job_names == {"lint", "dry_run_dev", "dry_run_test"}
+    deploy_job_names = {job["job"] for job in deploy_yaml["jobs"]}
+    assert deploy_job_names == {"deploy_dev", "deploy_test", "deploy_prod"}
+
+    dry_run_text = dry_run_path.read_text(encoding="utf-8")
+    assert "GITHUB_BASE_REF" not in dry_run_text
+    assert "github." not in dry_run_text
+    assert "System.PullRequest.TargetBranch" in dry_run_text
+    assert "dev-toolkit-credentials" in dry_run_text
+    assert "test-toolkit-credentials" in dry_run_text
+
+    deploy_text = deploy_path.read_text(encoding="utf-8")
+    assert "startsWith(variables['Build.SourceBranch'], 'refs/tags/v')" in deploy_text
+    assert "prod-toolkit-credentials" in deploy_text
+    assert "Enforce release tag pattern" in deploy_text
+
+    docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    assert "toolkit-deploy-dev" in docs
+    assert "toolkit-deploy-test" in docs
+    assert "toolkit-deploy-prod" in docs
+    assert "Build Validation" in docs
+    assert "GitHub Release" not in docs
+
+
+def test_generate_actions_ado_dev_only_has_no_branch_condition(tmp_path: Path) -> None:
+    _scaffold_project_with_envs(tmp_path, ("dev",))
+
+    subprocess.run(
+        [sys.executable, str(GENERATE_ACTIONS), "--force", "--provider", "ado"],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    dry_run_path = tmp_path / ".devops" / "dry-run-pipeline.yml"
+    deploy_path = tmp_path / ".devops" / "deploy-pipeline.yml"
+    dry_run_yaml = yaml.safe_load(dry_run_path.read_text(encoding="utf-8"))
+    deploy_yaml = yaml.safe_load(deploy_path.read_text(encoding="utf-8"))
+
+    dry_run_dev_job = next(job for job in dry_run_yaml["jobs"] if job["job"] == "dry_run_dev")
+    assert "condition" not in dry_run_dev_job
+    assert {job["job"] for job in deploy_yaml["jobs"]} == {"deploy_dev"}
+    # The promotion-flow guard only applies to the main/test job.
+    assert "Enforce promotion flow" not in dry_run_path.read_text(encoding="utf-8")
+
+
 def test_generate_actions_rejects_invalid_provider(tmp_path: Path) -> None:
     _scaffold_dev_only_project(tmp_path)
 
@@ -510,24 +618,36 @@ def test_generate_actions_rejects_invalid_provider(tmp_path: Path) -> None:
     assert not (tmp_path / ".devops").exists()
 
 
-def test_generate_actions_provider_ado_fails_with_missing_template_error(tmp_path: Path) -> None:
-    _scaffold_dev_only_project(tmp_path)
+def test_generate_actions_ado_missing_dry_run_template_fails_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
 
-    result = subprocess.run(
-        [sys.executable, str(GENERATE_ACTIONS), "--force", "--provider", "ado"],
-        cwd=tmp_path,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _scaffold_dev_only_project(project_dir)
 
-    assert result.returncode != 0
-    assert "Missing template" in result.stderr
-    assert "templates/ado" in result.stderr
-    # No-op: nothing should be written for a provider whose templates don't exist yet.
-    assert not (tmp_path / ".devops").exists()
-    assert not (tmp_path / ".github").exists()
-    assert not (tmp_path / "docs" / "FOUNDATION_CICD.md").exists()
+    # An ado template set missing dry-run-pipeline.yml — simulates an incomplete install.
+    ado_templates = MODULE_ROOT / "templates" / "ado"
+    fake_templates_root = tmp_path / "templates"
+    fake_ado_dir = fake_templates_root / "ado"
+    fake_ado_dir.mkdir(parents=True)
+    for name in ("deploy-pipeline.yml", "FOUNDATION_CICD.md"):
+        (fake_ado_dir / name).write_text((ado_templates / name).read_text(encoding="utf-8"), encoding="utf-8")
+
+    monkeypatch.setattr(generate_actions, "TEMPLATES_ROOT", fake_templates_root)
+    monkeypatch.setattr(sys, "argv", ["generate_actions.py", "--force", "--provider", "ado"])
+    monkeypatch.chdir(project_dir)
+
+    with pytest.raises(SystemExit) as exc_info:
+        generate_actions.main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Missing template" in captured.err
+    assert "dry-run-pipeline.yml" in captured.err
+    assert not (project_dir / ".devops").exists()
 
 
 def test_generate_actions_missing_readme_template_fails_gracefully(
@@ -540,16 +660,15 @@ def test_generate_actions_missing_readme_template_fails_gracefully(
     project_dir.mkdir()
     _scaffold_dev_only_project(project_dir)
 
-    # A provider whose template set is missing FOUNDATION_CICD.md — everything else is present.
-    fake_provider_dir = tmp_path / "templates" / "fake"
-    fake_provider_dir.mkdir(parents=True)
+    # A github template set missing FOUNDATION_CICD.md — everything else is present.
+    fake_templates_root = tmp_path / "templates"
+    fake_github_dir = fake_templates_root / "github"
+    fake_github_dir.mkdir(parents=True)
     for name in ("dry-run.yml", "deploy.yml"):
-        (fake_provider_dir / name).write_text((TEMPLATES / name).read_text(encoding="utf-8"), encoding="utf-8")
+        (fake_github_dir / name).write_text((TEMPLATES / name).read_text(encoding="utf-8"), encoding="utf-8")
 
-    monkeypatch.setattr(generate_actions, "TEMPLATES_ROOT", tmp_path / "templates")
-    monkeypatch.setattr(generate_actions, "PROVIDERS", (*generate_actions.PROVIDERS, "fake"))
-    monkeypatch.setitem(generate_actions.PROVIDER_WORKFLOWS_DIR, "fake", Path(".github") / "workflows")
-    monkeypatch.setattr(sys, "argv", ["generate_actions.py", "--force", "--provider", "fake"])
+    monkeypatch.setattr(generate_actions, "TEMPLATES_ROOT", fake_templates_root)
+    monkeypatch.setattr(sys, "argv", ["generate_actions.py", "--force", "--provider", "github"])
     monkeypatch.chdir(project_dir)
 
     with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
## Summary

- Adds `templates/ado/dry-run-pipeline.yml`, `deploy-pipeline.yml`, and `FOUNDATION_CICD.md` so `--provider ado` (added in #387) actually renders pipelines instead of failing with "Missing template".
- `dry-run-pipeline.yml`: shared `lint` job (YAML/config lint, ruff, pyright — same checks as GitHub) plus one `dry_run_<env>` job per deployable branch, each scoped to only its own `<env>-toolkit-credentials` variable group and gated on `System.PullRequest.TargetBranch` when both dev and test are deployable, so no job ever loads two environments' secrets at once. The `main`-targeting job also runs the promotion-flow guard (PRs to `main` must come from `dev` or `hotfix/*`), mirroring GitHub's `source-branch-guard`.
- `deploy-pipeline.yml`: one file reused for all three registrations (`toolkit-deploy-dev`, `toolkit-deploy-test`, `toolkit-deploy-prod`), each job gated on its own branch/tag (`refs/heads/dev`, `refs/heads/main`, `refs/tags/v*`) and scoped to its own variable group. The prod job adds the same release-tag-pattern and reachable-from-main checks as GitHub's `deploy-prod.yml`.
- `FOUNDATION_CICD.md` (ado): documents the `<env>-toolkit-credentials` variable groups, the three deploy-pipeline registrations (same file, override the CI trigger per registration since both templates set `trigger: none`), and registering `dry-run-pipeline.yml` as a Build Validation branch policy.
- Addresses Valeriya's follow-up comment on #387: `dry_run_environment`/`dry_run_build_script` are renamed to `github_dry_run_environment`/`github_dry_run_build_script` to make explicit they're GitHub Actions-only (`${{ github.base_ref }}`, `$GITHUB_BASE_REF` have no ADO equivalent — ADO's dry-run jobs use `System.PullRequest.TargetBranch` per-job conditions instead). `branching_rows`, `environment_rows`, and `build_lint_paths` now take an explicit `provider` so "GitHub Release" wording and the `.github/scripts/` lint path don't leak into ADO's generated docs.
- `--provider github` output is unaffected — full suite (222 tests) green, including the existing GitHub byte-identical check.

## Design notes / open questions for review

- Kept the same Toolkit env var contract as GitHub (`CDF_CLUSTER`, `IDP_TENANT_ID`, `ADMIN_SOURCE_ID`, etc.) rather than the slightly different set mentioned in an older `ado_setup` doc I could find — these are `cdf` CLI env vars, not provider-specific, so they should match GitHub's exactly. Flagging in case that doc reflects a newer/different convention.
- `deploy-pipeline.yml` sets `trigger: none`; the plan is to override the CI trigger per registration in the ADO UI (documented in the README) rather than declaring the full branch/tag trigger in YAML, which would otherwise cause all three registrations to fire on every push (job conditions would still no-op the wrong ones, just wastes pipeline minutes). Worth a sanity check from whoever sets this up on a real ADO org.
- PR-comment-with-dry-run-output (GitHub's `actions/github-script` step) has no ADO equivalent implemented here — out of scope for this PR, flagging as a possible gap vs. GitHub parity.

## Out of scope / not done here (from the parent ticket's Definition of Done)

- Dry-run on Ferdiglobe — needs an actual ADO project to validate against; can't do this from a local sandbox.
- Publishing to the packs library — release process, not part of this PR.

## Test plan

- [x] `uv run pytest` — 222 passed
- [x] `ruff check` / `ruff format --diff` clean on all changed files
- [x] `python validate_packages.py` — all packages valid
- [x] Manually generated `--provider ado` output for dev-only, dev+test, and dev+test+prod scaffolds; verified `yaml.safe_load` parses every generated file with no unfilled `{{PLACEHOLDER}}`
- [ ] pyright — not runnable in this sandbox (binary unavailable); relying on CI