### PR TITLE
fix(sourcesystem): scope extractor data sets by location

### DIFF
--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -1150,6 +1150,16 @@ def _read_existing_values(
             ingestion_dataset = ingestion_vars.get("dataset", "ingestion")
             if ingestion_dataset and isinstance(ingestion_dataset, str) and ingestion_dataset not in ss_datasets:
                 ss_datasets.append(ingestion_dataset)
+        # Persona-group scope lives on cdf_project_foundation.dataset. Extractor
+        # ids are recomputed from the installed modules; anything else on this
+        # list (a data set the user added, or one folded in by an earlier run)
+        # must be carried forward or the overlay silently revokes that access.
+        foundation_datasets = foundation.get("dataset") or []
+        if not isinstance(foundation_datasets, list):
+            foundation_datasets = []
+        for ds in foundation_datasets:
+            if ds and isinstance(ds, str) and ds not in ss_datasets:
+                ss_datasets.append(ds)
         if ss_datasets:
             existing["dataset"] = ss_datasets
         app_owner = (

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -317,6 +317,39 @@ def _module_instance_space(module: str, location: str) -> str:
     return f"sp_{location}_{suffix}"
 
 
+# Unscoped data set externalId per extractor module — the ``default.config.yaml``
+# value, combined with location to form ds_{data_type}_{location}.
+_MODULE_DATASET_BASE: dict[str, str] = {
+    "cdf_pi_extractor":    "ds_pi",
+    "cdf_sap_extractor":   "ds_sap",
+    "cdf_opcua_extractor": "ds_opcua",
+    "cdf_db_extractor":    "ds_db_postgres",
+    "cdf_files_extractor": "ds_files",
+}
+
+
+def _module_dataset(module: str, location: str) -> str:
+    """Return a per-extractor data set externalId: ``ds_{data_type}_{location}``.
+
+    Falls back to the unscoped base when no location is set, matching the module's
+    ``default.config.yaml`` so a project configured without the wizard still resolves.
+    """
+    base = _MODULE_DATASET_BASE.get(module, module)
+    return f"{base}_{location}" if location else base
+
+
+def _is_extractor_dataset(dataset: str) -> bool:
+    """True when *dataset* is owned by an extractor module (scoped or not).
+
+    Values read from an existing config are stale once the location changes, so the
+    wizard drops them in favour of freshly resolved ones.
+    """
+    return any(
+        dataset == base or dataset.startswith(f"{base}_")
+        for base in _MODULE_DATASET_BASE.values()
+    )
+
+
 def _module_label(module: str) -> str:
     return _MODULE_LABELS.get(module, module)
 
@@ -333,6 +366,7 @@ def resolve_sourcesystem_variables(
     for module in installed_modules:
         vars_: dict[str, str] = {
             "instanceSpace": _module_instance_space(module, location),
+            "dataset": _module_dataset(module, location),
             "environment": env,
             "location": location,
         }
@@ -398,7 +432,8 @@ def build_overlay(
 
     ``datasets`` should be read from the existing ``config.<env>.yaml`` (populated
     by Toolkit at module-init time).  The ``default.config.yaml`` files are not
-    reliable as Toolkit may delete them after consuming them.
+    reliable as Toolkit may delete them after consuming them.  Extractor-owned
+    datasets in that list are ignored — they are recomputed from ``site`` instead.
     """
     instance_space = INGESTION_FOUNDATION_VARIABLES[variant]["instanceSpace"]
     if variant == "cdm":
@@ -413,9 +448,17 @@ def build_overlay(
         ctx_vars["cdf_entity_matching"]["location_name"] = site
         ctx_vars["cdf_entity_matching"]["source_name"] = site
 
+    # Extractor data sets are derived from the installed modules and the site, not
+    # taken from the config — the value on disk is stale whenever the site changes.
+    # Anything else read from the config (e.g. cdf_ingestion's own dataset) is kept.
+    ss_datasets = [_module_dataset(m, site) for m in installed_ss]
+    foundation_datasets = ss_datasets + [
+        d for d in (datasets or []) if not _is_extractor_dataset(d)
+    ]
+
     # Always write dataset (even as empty list) so the key is always present.
     modules_vars: dict[str, dict[str, object]] = {
-        "cdf_project_foundation": build_foundation_vars(variant, env, site, datasets),
+        "cdf_project_foundation": build_foundation_vars(variant, env, site, foundation_datasets),
     }
     modules_vars.update(ctx_vars)
     if installed_ss:

--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -338,16 +338,22 @@ def _module_dataset(module: str, location: str) -> str:
     return f"{base}_{location}" if location else base
 
 
-def _is_extractor_dataset(dataset: str) -> bool:
-    """True when *dataset* is owned by an extractor module (scoped or not).
+def _wizard_generated_datasets(sites: tuple[str, ...]) -> set[str]:
+    """Every extractor data set id this wizard can generate for *sites*.
 
-    Values read from an existing config are stale once the location changes, so the
-    wizard drops them in favour of freshly resolved ones.
+    Used to drop ids an earlier wizard run wrote, so they are replaced rather than
+    accumulated.  Matching is exact — a data set that merely shares a prefix with an
+    extractor base (``ds_files_archive``) is not a wizard-generated id and is kept.
+
+    The unscoped base is always included: it is the ``default.config.yaml`` value
+    Toolkit seeds a new project with, and no such data set is deployed once a
+    location is set.
     """
-    return any(
-        dataset == base or dataset.startswith(f"{base}_")
-        for base in _MODULE_DATASET_BASE.values()
-    )
+    return {
+        _module_dataset(module, site)
+        for module in _MODULE_DATASET_BASE
+        for site in ("", *sites)
+    }
 
 
 def _module_label(module: str) -> str:
@@ -423,6 +429,7 @@ def build_overlay(
     cfihos_integration_owner_email: str = "",
     extractor_group_source_ids: dict[str, str] | None = None,
     repo_root: Path | None = None,
+    previous_site: str = "",
 ) -> dict:
     """Full ``variables.modules`` overlay dict to merge into a config file.
 
@@ -432,8 +439,10 @@ def build_overlay(
 
     ``datasets`` should be read from the existing ``config.<env>.yaml`` (populated
     by Toolkit at module-init time).  The ``default.config.yaml`` files are not
-    reliable as Toolkit may delete them after consuming them.  Extractor-owned
-    datasets in that list are ignored — they are recomputed from ``site`` instead.
+    reliable as Toolkit may delete them after consuming them.  Extractor datasets in
+    that list are recomputed from ``site`` instead; ``previous_site`` is the site
+    recorded in that config, so ids the last run wrote are replaced rather than
+    accumulated.
     """
     instance_space = INGESTION_FOUNDATION_VARIABLES[variant]["instanceSpace"]
     if variant == "cdm":
@@ -450,10 +459,12 @@ def build_overlay(
 
     # Extractor data sets are derived from the installed modules and the site, not
     # taken from the config — the value on disk is stale whenever the site changes.
-    # Anything else read from the config (e.g. cdf_ingestion's own dataset) is kept.
+    # Only ids this wizard itself could have written are dropped; everything else
+    # read from the config (cdf_ingestion's dataset, or one the user added) is kept.
+    generated = _wizard_generated_datasets((site, previous_site))
     ss_datasets = [_module_dataset(m, site) for m in installed_ss]
     foundation_datasets = ss_datasets + [
-        d for d in (datasets or []) if not _is_extractor_dataset(d)
+        d for d in (datasets or []) if d not in generated
     ]
 
     # Always write dataset (even as empty list) so the key is always present.
@@ -1640,6 +1651,7 @@ def _write_wizard_configs(
                 if m in _MODULE_EXTRACTOR_ENV_VAR
             },
             repo_root=repo_root,
+            previous_site=existing["site"],
         )
         if write_config(path, env, project_names[env], overlay):
             changed_count += 1

--- a/modules/sourcesystem/cdf_db_extractor/README.md
+++ b/modules/sourcesystem/cdf_db_extractor/README.md
@@ -48,7 +48,7 @@ variables:
     cdf_db_extractor:
       location: "oslo"                                        # Site code, used in externalIds (ep_<location>_db_postgres, db_<location>_db_postgres)
       instanceSpace: "sp_oslo_db"                            # Per-extractor DM instance space — computed by setup_project.py
-      dataset: "ds_db_postgres"                               # dataSetExternalId for the pipeline and RAW database
+      dataset: "ds_db_postgres_oslo"                          # ds_<data_type>_<location> — computed by setup_project.py
 
       integration_owner_name: "Integration Owner"             # Technical contact for the pipeline
       integration_owner_email: "integration.owner@example.com"
@@ -93,7 +93,7 @@ example with a single query against `mytable`. Before production use:
    `db_{{location}}_db_postgres` so rows land in the database declared by this
    module.
 5. **If targeting a different DB engine**, rename this pipeline (and `dataset`)
-   accordingly, e.g. `ep_db_mssql` / `ds_db_mssql`.
+   accordingly, e.g. `ep_{{location}}_db_mssql` / `ds_db_mssql_{{location}}`.
 
 See `.cursor/rules/cdf-transformations.mdc` for AI-assisted guidance when
 authoring the downstream transformation from RAW into a data model.
@@ -104,7 +104,7 @@ authoring the downstream transformation from RAW into a data model.
 
 - Source database reachable from the extractor host with appropriate ODBC driver installed
 - DB Extractor service account with read access to the source database
-- Cognite service account with read/write to the `db_{{location}}_db_postgres` RAW database and read access to the `{{dataset}}` data set (default: `ds_db_postgres`)
+- Cognite service account with read/write to the `db_{{location}}_db_postgres` RAW database and read access to the `{{dataset}}` data set (`ds_db_postgres_{{location}}`)
 
 ### Deploy
 

--- a/modules/sourcesystem/cdf_db_extractor/data_sets/ds_db_postgres.DataSet.yaml
+++ b/modules/sourcesystem/cdf_db_extractor/data_sets/ds_db_postgres.DataSet.yaml
@@ -1,4 +1,4 @@
-- externalId: ds_db_postgres
+- externalId: "{{dataset}}"
   name: Database Foundation
   description: Data set for database foundation extraction pipelines
   writeProtected: false

--- a/modules/sourcesystem/cdf_db_extractor/default.config.yaml
+++ b/modules/sourcesystem/cdf_db_extractor/default.config.yaml
@@ -7,7 +7,8 @@ location: ""
 # DM space where DB extractor instances are written — one space per extractor.
 # Computed by setup_project.py as sp_{location}_db.
 instanceSpace: "sp_db_instance_space"
-# dataSetExternalId for the extraction pipeline and RAW database
+# dataSetExternalId for the extraction pipeline, RAW database, and the data set this
+# module deploys. Computed by setup_project.py as ds_db_postgres_{location}.
 dataset: "ds_db_postgres"
 
 # Integration owner (technical contact for the pipeline)

--- a/modules/sourcesystem/cdf_files_extractor/README.md
+++ b/modules/sourcesystem/cdf_files_extractor/README.md
@@ -50,7 +50,7 @@ variables:
   modules:
     cdf_files_extractor:
       location: "oslo"                                       # Site code, used in externalIds (ep_<location>_files_sharepoint)
-      dataset: "ds_files"                                    # dataSetExternalId for the pipeline (Files land in this data set)
+      dataset: "ds_files_oslo"                               # ds_<data_type>_<location> — computed by setup_project.py
       instanceSpace: "sp_oslo_files"                        # Per-extractor DM instance space — computed by setup_project.py
 
       integration_owner_name: "Integration Owner"            # Technical contact for the pipeline

--- a/modules/sourcesystem/cdf_files_extractor/data_sets/ds_files.DataSet.yaml
+++ b/modules/sourcesystem/cdf_files_extractor/data_sets/ds_files.DataSet.yaml
@@ -1,4 +1,4 @@
-- externalId: ds_files
+- externalId: "{{dataset}}"
   name: Files Foundation
   description: Data set for CDF Files foundation extraction pipelines
   writeProtected: false

--- a/modules/sourcesystem/cdf_files_extractor/default.config.yaml
+++ b/modules/sourcesystem/cdf_files_extractor/default.config.yaml
@@ -5,7 +5,9 @@
 # Populated automatically from the site / location name entered in setup_project.py.
 location: ""
 
-# dataSetExternalId for the extraction pipeline (Files written by the extractor land here)
+# dataSetExternalId for the extraction pipeline and the data set this module deploys
+# (Files written by the extractor land here).
+# Computed by setup_project.py as ds_files_{location}.
 dataset: "ds_files"
 
 # DM space where CogniteFile instances are written — one space per extractor.

--- a/modules/sourcesystem/cdf_opcua_extractor/README.md
+++ b/modules/sourcesystem/cdf_opcua_extractor/README.md
@@ -61,7 +61,7 @@ variables:
     cdf_opcua_extractor:
       location: "oslo"                                        # Site code, used in externalIds (ep_<location>_opcua, db_<location>_opcua)
       instanceSpace: "sp_oslo_opcua"                         # Per-extractor DM instance space — computed by setup_project.py
-      dataset: "ds_opcua"                                    # dataSetExternalId for the pipeline and RAW database
+      dataset: "ds_opcua_oslo"                               # ds_<data_type>_<location> — computed by setup_project.py
 
       integration_owner_name: "Integration Owner"             # Technical contact for the pipeline
       integration_owner_email: "integration.owner@example.com"

--- a/modules/sourcesystem/cdf_opcua_extractor/data_sets/ds_opcua.DataSet.yaml
+++ b/modules/sourcesystem/cdf_opcua_extractor/data_sets/ds_opcua.DataSet.yaml
@@ -1,4 +1,4 @@
-- externalId: ds_opcua
+- externalId: "{{dataset}}"
   name: OPC UA Foundation
   description: Data set for OPC UA foundation extraction pipelines
   writeProtected: false

--- a/modules/sourcesystem/cdf_opcua_extractor/default.config.yaml
+++ b/modules/sourcesystem/cdf_opcua_extractor/default.config.yaml
@@ -9,7 +9,8 @@ prometheusJobName: opcua-extractor
 # Computed by setup_project.py as sp_{location}_opcua.
 instanceSpace: "sp_opcua_instance_space"
 
-# dataSetExternalId for the extraction pipeline and RAW database
+# dataSetExternalId for the extraction pipeline, RAW database, and the data set this
+# module deploys. Computed by setup_project.py as ds_opcua_{location}.
 dataset: "ds_opcua"
 
 # Integration owner (technical contact for the pipeline)

--- a/modules/sourcesystem/cdf_pi_extractor/README.md
+++ b/modules/sourcesystem/cdf_pi_extractor/README.md
@@ -46,7 +46,7 @@ variables:
     cdf_pi_extractor:
       location: "oslo"                                       # Site code, used in externalIds (ep_<location>_pi)
       instanceSpace: "sp_oslo_pi"                           # Per-extractor DM instance space — computed by setup_project.py
-      dataset: "ds_pi"                                      # dataSetExternalId for the pipeline
+      dataset: "ds_pi_oslo"                                 # ds_<data_type>_<location> — computed by setup_project.py
       piIdPrefix: "pi:"                                     # External ID prefix for all PI tag timeseries
 
       integration_owner_name: "Integration Owner"            # Technical contact for the pipeline

--- a/modules/sourcesystem/cdf_pi_extractor/data_sets/ds_pi.DataSet.yaml
+++ b/modules/sourcesystem/cdf_pi_extractor/data_sets/ds_pi.DataSet.yaml
@@ -1,4 +1,4 @@
-- externalId: ds_pi
+- externalId: "{{dataset}}"
   name: PI Foundation
   description: Data set for PI foundation extraction pipelines
   writeProtected: false

--- a/modules/sourcesystem/cdf_pi_extractor/default.config.yaml
+++ b/modules/sourcesystem/cdf_pi_extractor/default.config.yaml
@@ -8,7 +8,8 @@ location: ""
 # Computed by setup_project.py as sp_{location}_pi.
 instanceSpace: "sp_pi_instance_space"
 
-# dataSetExternalId for the extraction pipeline
+# dataSetExternalId for the extraction pipeline and the data set this module deploys.
+# Computed by setup_project.py as ds_pi_{location}.
 dataset: "ds_pi"
 
 # External ID prefix for PI tag timeseries instances (used by the extractor)

--- a/modules/sourcesystem/cdf_sap_extractor/README.md
+++ b/modules/sourcesystem/cdf_sap_extractor/README.md
@@ -63,7 +63,7 @@ variables:
     cdf_sap_extractor:
       location: "oslo"                                        # Site code, used in externalIds (ep_<location>_sap, db_<location>_sap)
       instanceSpace: "sp_oslo_sap"                           # Per-extractor DM instance space — computed by setup_project.py
-      dataset: "ds_sap"                                       # dataSetExternalId for the pipeline and RAW database
+      dataset: "ds_sap_oslo"                                  # ds_<data_type>_<location> — computed by setup_project.py
       sapPlant: "1000"                                        # SAP plant code, used in OData filter expressions (MaintPlant eq '<sapPlant>')
       sapDisableSsl: false                                    # Set true only if SAP server uses an untrusted self-signed certificate
 

--- a/modules/sourcesystem/cdf_sap_extractor/data_sets/ds_sap.DataSet.yaml
+++ b/modules/sourcesystem/cdf_sap_extractor/data_sets/ds_sap.DataSet.yaml
@@ -1,4 +1,4 @@
-- externalId: ds_sap
+- externalId: "{{dataset}}"
   name: SAP Foundation
   description: Data set for SAP foundation extraction pipelines
   writeProtected: false

--- a/modules/sourcesystem/cdf_sap_extractor/default.config.yaml
+++ b/modules/sourcesystem/cdf_sap_extractor/default.config.yaml
@@ -8,7 +8,8 @@ location: ""
 # Computed by setup_project.py as sp_{location}_sap.
 instanceSpace: "sp_sap_instance_space"
 
-# dataSetExternalId for the extraction pipeline and RAW database
+# dataSetExternalId for the extraction pipeline, RAW database, and the data set this
+# module deploys. Computed by setup_project.py as ds_sap_{location}.
 dataset: "ds_sap"
 
 # SAP plant code — used in OData filter expressions (e.g. MaintPlant eq '{{sapPlant}}')

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -628,6 +628,56 @@ class TestModuleDataset:
         pf = overlay["variables"]["modules"]["cdf_project_foundation"]
         assert pf["dataset"] == ["ds_custom_ingestion", "ds_oil_and_gas_domain_model"]
 
+    def test_wizard_path_keeps_foundation_custom_dataset(self, tmp_path: Path) -> None:
+        """The wizard reads via _read_existing_values then writes via build_overlay.
+        Custom ids on cdf_project_foundation.dataset must survive that round-trip;
+        build_overlay-only tests miss the gap if the reader never surfaces them."""
+        from setup_project import _read_existing_values, build_overlay
+        ss_dir = tmp_path / "modules" / "sourcesystem"
+        (ss_dir / "cdf_pi_extractor").mkdir(parents=True)
+        (tmp_path / "config.dev.yaml").write_text(yaml.dump({
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_project_foundation": {
+                    "site": "oslo",
+                    "dataset": ["ds_pi", "ds_files_archive"],
+                },
+                "cdf_pi_extractor": {"dataset": "ds_pi"},
+            }},
+        }, sort_keys=False))
+        existing = _read_existing_values(tmp_path, ("dev",), ["cdf_pi_extractor"])
+        overlay = build_overlay(
+            "cdm", "dev", "oslo", [],
+            datasets=existing["dataset"],
+            previous_site=existing["site"],
+            repo_root=tmp_path,
+        )
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_pi_oslo", "ds_files_archive"]
+
+    def test_wizard_path_does_not_duplicate_variant_dataset(self, tmp_path: Path) -> None:
+        """ds_oil_and_gas_domain_model is already on the foundation list and is
+        also folded in by datasets_for_variant — the round-trip must not double it."""
+        from setup_project import _read_existing_values, build_overlay
+        (tmp_path / "config.dev.yaml").write_text(yaml.dump({
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_project_foundation": {
+                    "site": "oslo",
+                    "dataset": ["ds_custom_ingestion", "ds_oil_and_gas_domain_model"],
+                },
+            }},
+        }, sort_keys=False))
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        overlay = build_overlay(
+            "cfihos_oil_and_gas_extension", "dev", "oslo", [],
+            datasets=existing["dataset"],
+            previous_site=existing["site"],
+            repo_root=tmp_path,
+        )
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_custom_ingestion", "ds_oil_and_gas_domain_model"]
+
 
 class TestExtractorDataSetResources:
     """The DataSet resource must resolve from {{dataset}} — the same variable the
@@ -1660,6 +1710,53 @@ class TestReadExistingValues:
         )
         assert "ds_pi_oslo" in existing["dataset"]
         assert "ds_sap_oslo" in existing["dataset"]
+
+    def test_reads_custom_datasets_from_foundation(self, tmp_path: Path) -> None:
+        """Persona-group scope lives on cdf_project_foundation.dataset. A data set
+        the user added there is not on any extractor module, so it is lost unless
+        this reader surfaces it to build_overlay."""
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_project_foundation": {
+                    "site": "oslo",
+                    "dataset": ["ds_pi_oslo", "ds_files_archive"],
+                },
+                "cdf_pi_extractor": {"dataset": "ds_pi_oslo"},
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), ["cdf_pi_extractor"])
+        assert existing["dataset"] == ["ds_pi_oslo", "ds_files_archive"]
+
+    def test_reads_custom_datasets_from_nested_foundation(self, tmp_path: Path) -> None:
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "common": {
+                    "cdf_project_foundation": {
+                        "site": "oslo",
+                        "dataset": ["ds_custom"],
+                    },
+                },
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["dataset"] == ["ds_custom"]
+
+    def test_ignores_non_list_foundation_dataset(self, tmp_path: Path) -> None:
+        """A scalar dataset on an extractor module is a string; the foundation
+        key is a list. A stray string must not be iterated character by character."""
+        from setup_project import _read_existing_values
+        self._write_config(tmp_path / "config.dev.yaml", {
+            "environment": {"project": "acme-dev"},
+            "variables": {"modules": {
+                "cdf_project_foundation": {"site": "oslo", "dataset": "ds_pi"},
+            }},
+        })
+        existing = _read_existing_values(tmp_path, ("dev",), [])
+        assert existing["dataset"] == []
 
     def test_reads_cdf_ingestion_dataset_when_installed(self, tmp_path: Path) -> None:
         """cdf_ingestion's own dataset must be folded into the persona dataset list —

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -634,7 +634,7 @@ class TestExtractorDataSetResources:
     extraction pipeline and the producer group already scope themselves to. A
     hardcoded externalId silently drifts from them once location scoping applies."""
 
-    _EXTRACTOR_MODULES = (
+    _EXTRACTOR_MODULES: tuple[str, ...] = (
         "cdf_pi_extractor",
         "cdf_sap_extractor",
         "cdf_files_extractor",

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -574,6 +574,49 @@ class TestModuleDataset:
         pf = overlay["variables"]["modules"]["cdf_project_foundation"]
         assert pf["dataset"] == ["ds_pi_oslo"]
 
+    def test_build_overlay_keeps_custom_dataset_sharing_an_extractor_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        """ds_files_archive is not an id the wizard generates — dropping it would
+        silently revoke the persona groups' access to a data set the user added."""
+        from setup_project import build_overlay
+        ss_dir = tmp_path / "modules" / "sourcesystem"
+        (ss_dir / "cdf_files_extractor").mkdir(parents=True)
+        overlay = build_overlay(
+            "cdm", "dev", "oslo", [],
+            datasets=["ds_files_archive"], repo_root=tmp_path,
+        )
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_files_oslo", "ds_files_archive"]
+
+    def test_build_overlay_replaces_previous_sites_datasets(self, tmp_path: Path) -> None:
+        """On a site rename the ids the last run wrote are replaced, not accumulated."""
+        from setup_project import build_overlay
+        ss_dir = tmp_path / "modules" / "sourcesystem"
+        (ss_dir / "cdf_pi_extractor").mkdir(parents=True)
+        overlay = build_overlay(
+            "cdm", "dev", "bergen", [],
+            datasets=["ds_pi_oslo"], previous_site="oslo", repo_root=tmp_path,
+        )
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_pi_bergen"]
+
+    def test_build_overlay_keeps_unknown_site_dataset_when_no_previous_site(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a recorded previous site the old id cannot be told apart from a
+        custom one, so it is kept. That data set exists in CDF, so the result is a
+        stale grant the user can remove — never a scope referencing a data set that
+        was never deployed."""
+        from setup_project import build_overlay
+        ss_dir = tmp_path / "modules" / "sourcesystem"
+        (ss_dir / "cdf_pi_extractor").mkdir(parents=True)
+        overlay = build_overlay(
+            "cdm", "dev", "bergen", [], datasets=["ds_pi_oslo"], repo_root=tmp_path
+        )
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_pi_bergen", "ds_pi_oslo"]
+
     def test_build_overlay_keeps_non_extractor_datasets(self, tmp_path: Path) -> None:
         """cdf_ingestion's dataset (Demo pack) is not owned by any extractor module —
         it is read from the config and must survive."""

--- a/tests/test_foundation_setup_wizard.py
+++ b/tests/test_foundation_setup_wizard.py
@@ -523,6 +523,93 @@ class TestBuildOverlay:
         assert "cdm" not in mods
 
 
+class TestModuleDataset:
+    """Extractor data sets follow ds_<data_type>_<location>, the same location scoping
+    the extraction pipelines (ep_<location>_<type>) and instance spaces already use.
+    Without the location suffix two sites deploying the same extractor collide on a
+    single shared data set."""
+
+    def test_per_extractor_dataset_uses_location(self) -> None:
+        from setup_project import _module_dataset
+        assert _module_dataset("cdf_pi_extractor", "oslo") == "ds_pi_oslo"
+        assert _module_dataset("cdf_sap_extractor", "oslo") == "ds_sap_oslo"
+        assert _module_dataset("cdf_files_extractor", "oslo") == "ds_files_oslo"
+        assert _module_dataset("cdf_opcua_extractor", "oslo") == "ds_opcua_oslo"
+        assert _module_dataset("cdf_db_extractor", "oslo") == "ds_db_postgres_oslo"
+
+    def test_falls_back_to_base_when_location_blank(self) -> None:
+        """Matches the module default in default.config.yaml, so a project set up
+        without the wizard still resolves to a valid externalId."""
+        from setup_project import _module_dataset
+        assert _module_dataset("cdf_pi_extractor", "") == "ds_pi"
+
+    def test_resolve_sourcesystem_writes_dataset(self) -> None:
+        from setup_project import resolve_sourcesystem_variables
+        result = resolve_sourcesystem_variables(
+            ["cdf_sap_extractor", "cdf_pi_extractor"], "dev", "oslo"
+        )
+        assert result["cdf_sap_extractor"]["dataset"] == "ds_sap_oslo"
+        assert result["cdf_pi_extractor"]["dataset"] == "ds_pi_oslo"
+
+    def test_build_overlay_foundation_dataset_uses_resolved_ids(self, tmp_path: Path) -> None:
+        """The persona groups' dataset scope must list the same externalIds the
+        extractor modules deploy, or producer/consumer/admin lose access to them."""
+        from setup_project import build_overlay
+        ss_dir = tmp_path / "modules" / "sourcesystem"
+        (ss_dir / "cdf_sap_extractor").mkdir(parents=True)
+        (ss_dir / "cdf_pi_extractor").mkdir(parents=True)
+        overlay = build_overlay("cdm", "dev", "oslo", [], repo_root=tmp_path)
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_pi_oslo", "ds_sap_oslo"]
+
+    def test_build_overlay_drops_stale_unscoped_extractor_dataset(self, tmp_path: Path) -> None:
+        """Re-running the wizard on a project written before location scoping reads
+        the old ds_pi from disk — it must be replaced, not appended alongside."""
+        from setup_project import build_overlay
+        ss_dir = tmp_path / "modules" / "sourcesystem"
+        (ss_dir / "cdf_pi_extractor").mkdir(parents=True)
+        overlay = build_overlay(
+            "cdm", "dev", "oslo", [], datasets=["ds_pi"], repo_root=tmp_path
+        )
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_pi_oslo"]
+
+    def test_build_overlay_keeps_non_extractor_datasets(self, tmp_path: Path) -> None:
+        """cdf_ingestion's dataset (Demo pack) is not owned by any extractor module —
+        it is read from the config and must survive."""
+        from setup_project import build_overlay
+        overlay = build_overlay(
+            "cfihos_oil_and_gas_extension", "dev", "oslo",
+            [], datasets=["ds_custom_ingestion"], repo_root=tmp_path,
+        )
+        pf = overlay["variables"]["modules"]["cdf_project_foundation"]
+        assert pf["dataset"] == ["ds_custom_ingestion", "ds_oil_and_gas_domain_model"]
+
+
+class TestExtractorDataSetResources:
+    """The DataSet resource must resolve from {{dataset}} — the same variable the
+    extraction pipeline and the producer group already scope themselves to. A
+    hardcoded externalId silently drifts from them once location scoping applies."""
+
+    _EXTRACTOR_MODULES = (
+        "cdf_pi_extractor",
+        "cdf_sap_extractor",
+        "cdf_files_extractor",
+        "cdf_opcua_extractor",
+        "cdf_db_extractor",
+    )
+
+    @pytest.mark.parametrize("module", _EXTRACTOR_MODULES)
+    def test_dataset_external_id_is_templated(self, module: str) -> None:
+        data_sets = REPO_ROOT / "modules" / "sourcesystem" / module / "data_sets"
+        files = list(data_sets.glob("*.DataSet.yaml"))
+        assert files, f"{module} has no DataSet resource"
+        for path in files:
+            resources = yaml.safe_load(path.read_text(encoding="utf-8"))
+            for resource in resources:
+                assert resource["externalId"] == "{{dataset}}"
+
+
 class TestModuleInstanceSpace:
     def test_per_extractor_space_uses_location_and_suffix(self) -> None:
         from setup_project import _module_instance_space
@@ -1521,15 +1608,15 @@ class TestReadExistingValues:
             "environment": {"project": "acme-dev"},
             "variables": {"modules": {
                 "cdf_project_foundation": {"site": ""},
-                "cdf_pi_extractor": {"dataset": "ds_pi", "instanceSpace": "sp_oslo_pi"},
-                "cdf_sap_extractor": {"dataset": "ds_sap", "instanceSpace": "sp_oslo_sap"},
+                "cdf_pi_extractor": {"dataset": "ds_pi_oslo", "instanceSpace": "sp_oslo_pi"},
+                "cdf_sap_extractor": {"dataset": "ds_sap_oslo", "instanceSpace": "sp_oslo_sap"},
             }},
         })
         existing = _read_existing_values(
             tmp_path, ("dev",), ["cdf_pi_extractor", "cdf_sap_extractor"]
         )
-        assert "ds_pi" in existing["dataset"]
-        assert "ds_sap" in existing["dataset"]
+        assert "ds_pi_oslo" in existing["dataset"]
+        assert "ds_sap_oslo" in existing["dataset"]
 
     def test_reads_cdf_ingestion_dataset_when_installed(self, tmp_path: Path) -> None:
         """cdf_ingestion's own dataset must be folded into the persona dataset list —


### PR DESCRIPTION
Extraction pipelines, RAW databases and instance spaces are all location scoped (ep_{location}_pi, db_{location}_sap, sp_{location}_pi) but the DataSet resources hardcoded two-segment externalIds. Two sites deploying the same extractor into one project collided on a shared data set, and each site's producer group — scoped via idScope: ["{{dataset}}"] — got write access to the other site's data.

Data sets now follow ds_<data_type>_<location>. The DataSet resource resolves from {{dataset}}, the same indirection the extraction pipeline and producer group already use, so it cannot drift from them. setup_project.py resolves the value per module.

Toolkit does not expand variables nested inside config values, so the composition lives in setup_project.py rather than default.config.yaml; the unscoped base is kept there as the no-wizard fallback.

build_overlay derives cdf_project_foundation.dataset from the installed modules and site instead of trusting the on-disk value, dropping stale unscoped entries — otherwise re-running the wizard leaves ds_pi in the persona dataset scope alongside ds_pi_oslo.

Covers all five extractor modules: the wizard code is shared, so converting only some would make it write ds_opcua_oslo for a module still deploying ds_opcua.

BREAKING CHANGE: already-deployed projects get a new data set on the next deploy. The previous ds_<type> data set is orphaned (CDF data sets cannot be deleted) and existing time series, files and RAW rows stay tagged with the old id — these need re-tagging or an explicit decision to leave historical data on the legacy data set.