### PR TITLE
fix(sourcesystem): drop rawAcl from files extractor producer group

### DIFF
--- a/modules/sourcesystem/cdf_files_extractor/README.md
+++ b/modules/sourcesystem/cdf_files_extractor/README.md
@@ -96,7 +96,9 @@ SharePoint Online example with a single extraction path. Before production use:
 5. **Pick a state-store path** in `Config.yaml` that the extractor service
    account can write to (default: `/path/to/state-store.json` is a placeholder
    — change before running). Optionally switch to RAW-backed state-store for
-   cluster deployments.
+   cluster deployments — that also requires adding a `raw/` folder with the
+   database and table, and a matching `rawAcl` in
+   `auth/producer.ep.files.Group.yaml`.
 6. **Confirm `data_model.space`** matches your `instanceSpace` — `CogniteFile`
    instances are written there. The CDM destination requires that the space
    already exists (this module deploys it automatically).

--- a/modules/sourcesystem/cdf_files_extractor/auth/producer.ep.files.Group.yaml
+++ b/modules/sourcesystem/cdf_files_extractor/auth/producer.ep.files.Group.yaml
@@ -15,12 +15,6 @@ capabilities:
       scope:
         datasetScope:
           ids: ["{{dataset}}"]
-  - rawAcl:
-      actions: [READ, WRITE, LIST]
-      scope:
-        tableScope:
-          dbsToTables:
-            db_{{location}}_files: [] 
   - dataModelInstancesAcl:
       actions: [READ, WRITE, WRITE_PROPERTIES]
       scope:


### PR DESCRIPTION
## Summary

`modules/sourcesystem/cdf_files_extractor/auth/producer.ep.files.Group.yaml` granted a `rawAcl` scoped to `db_{{location}}_files`, a RAW database that no module creates. CDF rejects the group as an invalid capability reference.

The Files Extractor runs in `destination-mode: cdm` — file bytes go to CDF Files and metadata to `CogniteFile` instances in `{{instanceSpace}}`. It does not stage to RAW, the module ships no `raw/` folder, and `ep_files_sharepoint.ExtractionPipeline.yaml` declares no `rawTables`. The `rawAcl` block is a copy-paste leftover from the OPC UA / SAP / DB extractor groups, which do ship a matching `raw/*.Database.yaml`.

## Changes

- Remove the `rawAcl` capability from the producer group.
- README: note that switching to the (optional, commented-out) RAW-backed state store also requires adding a `raw/` folder and a matching `rawAcl`.

## Verification

- `python validate_packages.py` passes.
- Every remaining `rawAcl` reference under `modules/` resolves to a `*.Database.yaml` in the same module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)