### PR TITLE
feat(data_quality): add Data Quality Validation Toolkit pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ All deployable content lives under [`modules/`](modules/). The registry of packs
 
 | Folder | Purpose |
 |--------|---------|
-| [`common/`](modules/common/) | Shared CDF platform modules (`cdf_common`, `cdf_ingestion`, `cdf_search`) |
+| [`common/`](modules/common/) | Shared CDF platform modules (`cdf_common`, `cdf_dq_runtime`, `cdf_ingestion`, `cdf_search`) |
 | [`contextualization/`](modules/contextualization/) | File annotation, entity matching, P&ID, connection SQL |
 | [`datamodels/`](modules/datamodels/) | Industry and extension data models (`rmdm`, ISA, CFIHOS, …) |
 | [`solutions/`](modules/solutions/) | Product verticals (`cdm_maintain`, `cdf_infield`, `cdf_ai_extractor`) |
 | [`sourcesystem/`](modules/sourcesystem/) | Source connectors (PI, SAP, SharePoint, OID sync) |
 | [`dashboards/`](modules/dashboards/) | Streamlit dashboards and reporting |
+| [`common/cdf_dq_runtime/`](modules/common/cdf_dq_runtime/) | SHACL data-quality validation (`cdf_dq_runtime`) |
 | [`atlas_ai/`](modules/atlas_ai/) | Atlas AI agents |
 | [`tools/`](modules/tools/) | Qualitizer, performance notebooks |
 | [`custom/`](modules/custom/) | Empty module template |

--- a/modules/README.md
+++ b/modules/README.md
@@ -12,6 +12,7 @@ modules/
 │
 ├── common/                      # Shared CDF platform building blocks
 │   ├── cdf_common/
+│   ├── cdf_dq_runtime/          # SHACL data-quality validation (dp:data_quality)
 │   ├── cdf_ingestion/
 │   └── cdf_search/
 │
@@ -66,6 +67,7 @@ These are the packs exposed in the Toolkit menu (from `packages.toml`):
 | `dp:sourcesystem` | Source Systems | `sourcesystem/*_extractor` (real connector configs), `sourcesystem/*_data_dump` (synthetic sample data) |
 | `dp:models` | Data models | `datamodels/` |
 | `dp:dashboards` | Dashboards | `dashboards/` |
+| `dp:data_quality` | Data Quality Validation | `common/cdf_dq_runtime` |
 | `dp:atlas_ai` | Atlas AI | `atlas_ai/`, `solutions/cdf_ai_extractor` |
 | `dp:cdm_maintain` | CDM Maintain | `solutions/cdm_maintain/*` |
 | `dp:infield` | Infield | `solutions/cdf_infield/cdf_infield_location` |
@@ -90,6 +92,7 @@ Every `module.toml` **`id`** must be `dp:<package_short>:<slug>` where `<package
 | `contextualization/cdf_p_and_id_parser` | `dp:contextualization:cdf_p_and_id_parser` | `dp:contextualization` |
 | `custom/my_module` | `dp:emptymodule:my_module` | `dp:emptymodule` |
 | `dashboards/context_quality` | `dp:dashboards:context_quality` | `dp:dashboards` |
+| `common/cdf_dq_runtime` | `dp:data_quality:cdf_dq_runtime` | `dp:data_quality` |
 | `data_models/cfihos_oil_and_gas_extension` | `dp:models:cfihos_oil_and_gas_extension` | `dp:models` |
 | `data_models/cfihos_oil_and_gas_extension_search` | `dp:models:cfihos_oil_and_gas_extension_search` | `dp:models` |
 | `data_models/isa_manufacturing_extension` | `dp:models:isa_manufacturing_extension` | `dp:models` |

--- a/modules/common/cdf_dq_runtime/README.md
+++ b/modules/common/cdf_dq_runtime/README.md
@@ -1,0 +1,64 @@
+# Data Quality Validation
+
+## Overview
+
+Publishes SHACL **RuleSets** and **DataProducts** with Cognite Toolkit (`cdf deploy`), then runs the same Python deploy path as [data-quality-validation-deploy](https://github.com/cognitedata/data-quality-validation-deploy) (`scripts/deploy_infrastructure.py`).
+
+Bundled sample: cog-ai **YourOrg** (`config/environments/cog-ai`).
+
+| Layer | Toolkit (`cdf deploy`) | Module script (`deploy_infrastructure.py`) |
+| --- | --- | --- |
+| RuleSets / DataProducts | Yes | Consumes via `external_dataproducts` |
+| Function + containers | — | Yes |
+| Instance workflows | — | Yes (external DataProduct + `views/` overrides) |
+| Time-series workflows | — | Yes (`timeseries/` configs) |
+| `data_product_sync` + historic queue | — | Yes (`data_product_sync_cron`) |
+
+Only `dq_pypi_version` is in `default.config.yaml`.
+
+## Operator flow
+
+### Local
+
+```bash
+cdf modules add dp:data_quality
+cdf build && cdf deploy                    # RuleSets + DataProducts
+pip install cognite-data-quality==0.4.9
+python modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py \
+  --toolkit-config config.dev.yaml
+```
+
+Credentials come from environment variables (same as [data-quality-validation-deploy](https://github.com/cognitedata/data-quality-validation-deploy)): `COGNITE_PROJECT`, `COGNITE_CLIENT_ID`, `COGNITE_CLIENT_SECRET`, and `AZURE_TENANT_ID` or `COGNITE_TOKEN_URL`. In Toolkit projects, `CDF_*` / `IDP_*` work too. Optionally pass `--config-toml` for a local gitignored TOML file (notebooks).
+
+Optional historic enqueue (same as deploy repo `--enqueue-historic`):
+
+```bash
+python modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py \
+  --toolkit-config config.dev.yaml --enqueue-historic
+```
+
+Per-view historic pipeline:
+
+```bash
+python modules/common/cdf_dq_runtime/scripts/deploy_pipeline.py \
+  --view-external-id YourOrgAsset --historic-mode enqueue --toolkit-config config.dev.yaml
+```
+
+### CI/CD
+
+Run `deploy_infrastructure.py` in the same GitHub Actions job as `cdf deploy`, reusing the Toolkit environment block (`IDP_*`, `CDF_*`). Do not generate a credentials file. See [Toolkit pack CI/CD](https://github.com/cognitedata/data-quality-validation/blob/main/docs/usage/toolkit_pack.md#cicd).
+
+## Contents (cog-ai sample)
+
+**Views:** `YourOrgAsset`, `YourOrgEquipment`, `YourOrgMaintenanceOrder`, `YourOrgNotification`, `YourOrgOperation`, `YourOrgTimeSeries`
+
+**Time-series config:** `yourorg_timeseries_quality` only (no demo data generator / `demo_timeseries_quality`).
+
+**RuleSets:** matching `*_shacl_rules` / `timeseries_quality_rules` from deploy repo (inline in `rulesets/`)
+
+**Settings:** `settings.yaml` mirrors cog-ai workflow prefixes, records stream, `data_product_sync_cron`, and `timeseries.config_dir`.
+
+## Support
+
+- [data-quality-validation](https://github.com/cognitedata/data-quality-validation)
+- [data-quality-validation-deploy (cog-ai)](https://github.com/cognitedata/data-quality-validation-deploy/tree/main/config/environments/cog-ai)

--- a/modules/common/cdf_dq_runtime/README.md
+++ b/modules/common/cdf_dq_runtime/README.md
@@ -28,7 +28,10 @@ python modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py \
   --toolkit-config config.dev.yaml
 ```
 
-Credentials come from environment variables (same as [data-quality-validation-deploy](https://github.com/cognitedata/data-quality-validation-deploy)): `COGNITE_PROJECT`, `COGNITE_CLIENT_ID`, `COGNITE_CLIENT_SECRET`, and `AZURE_TENANT_ID` or `COGNITE_TOKEN_URL`. In Toolkit projects, `CDF_*` / `IDP_*` work too. Optionally pass `--config-toml` for a local gitignored TOML file (notebooks).
+Credentials come from the Toolkit project ``.env`` (next to ``cdf.toml``) when present,
+then environment variables (same as [data-quality-validation-deploy](https://github.com/cognitedata/data-quality-validation-deploy)):
+``COGNITE_PROJECT``, ``COGNITE_CLIENT_ID``, ``COGNITE_CLIENT_SECRET``, and ``AZURE_TENANT_ID`` or ``COGNITE_TOKEN_URL``.
+In Toolkit projects, ``CDF_*`` / ``IDP_*`` work too. Optionally pass ``--config-toml`` for a local gitignored TOML file (notebooks).
 
 Optional historic enqueue (same as deploy repo `--enqueue-historic`):
 

--- a/modules/common/cdf_dq_runtime/data_modeling/sp_enterprise_process_industry.Space.yaml
+++ b/modules/common/cdf_dq_runtime/data_modeling/sp_enterprise_process_industry.Space.yaml
@@ -1,0 +1,3 @@
+space: sp_enterprise_process_industry
+name: sp_enterprise_process_industry
+description: YourOrg operational schema space (cog-ai). Usually already exists; do not store instances here.

--- a/modules/common/cdf_dq_runtime/data_products/enterprise_process_industry.DataProduct.yaml
+++ b/modules/common/cdf_dq_runtime/data_products/enterprise_process_industry.DataProduct.yaml
@@ -1,0 +1,5 @@
+externalId: enterprise-process-industry
+name: Enterprise Process Industry
+description: YourOrg process industries DataProduct (cog-ai sample from data-quality-validation-deploy).
+schemaSpace: sp_enterprise_process_industry
+isGoverned: false

--- a/modules/common/cdf_dq_runtime/data_products/enterprise_process_industry.DataProductVersion.yaml
+++ b/modules/common/cdf_dq_runtime/data_products/enterprise_process_industry.DataProductVersion.yaml
@@ -1,0 +1,63 @@
+dataProductExternalId: enterprise-process-industry
+version: "1.1.10"
+status: published
+description: YourOrg views on enterprise-process-industry (cog-ai data-quality-validation-deploy sample).
+views:
+  - space: sp_enterprise_process_industry
+    externalId: YourOrgAsset
+    version: "v1"
+    instanceSpaces:
+      read:
+        - springfield_instances
+      write: []
+  - space: sp_enterprise_process_industry
+    externalId: YourOrgEquipment
+    version: "v1"
+    instanceSpaces:
+      read:
+        - springfield_instances
+      write: []
+  - space: sp_enterprise_process_industry
+    externalId: YourOrgMaintenanceOrder
+    version: "v1"
+    instanceSpaces:
+      read:
+        - test_data_pumps
+      write: []
+  - space: sp_enterprise_process_industry
+    externalId: YourOrgNotification
+    version: "v1"
+    instanceSpaces:
+      read:
+        - test_data_pumps
+      write: []
+  - space: sp_enterprise_process_industry
+    externalId: YourOrgOperation
+    version: "v1"
+    instanceSpaces:
+      read:
+        - test_data_pumps
+      write: []
+  - space: sp_enterprise_process_industry
+    externalId: YourOrgTimeSeries
+    version: "v1"
+    instanceSpaces:
+      read:
+        - springfield_instances
+      write: []
+quality:
+  rules:
+    - externalId: asset_shacl_rules
+      version: "1.0.0"
+    - externalId: equipment_shacl_rules
+      version: "1.0.0"
+    - externalId: maintenance_order_shacl_rules
+      version: "1.0.0"
+    - externalId: maintenance_order_rule_logic_test_shacl_rules
+      version: "1.0.0"
+    - externalId: notification_shacl_rules
+      version: "1.0.0"
+    - externalId: operation_shacl_rules
+      version: "1.0.0"
+    - externalId: timeseries_quality_rules
+      version: "1.0.0"

--- a/modules/common/cdf_dq_runtime/default.config.yaml
+++ b/modules/common/cdf_dq_runtime/default.config.yaml
@@ -1,0 +1,5 @@
+# Pin for deploy_infrastructure.py and the CDF Function (PyPI cognite-data-quality).
+# All other values in this module match the cog-ai YourOrg sample in
+# https://github.com/cognitedata/data-quality-validation-deploy (views/asset.yaml).
+
+dq_pypi_version: "0.4.9"

--- a/modules/common/cdf_dq_runtime/module.toml
+++ b/modules/common/cdf_dq_runtime/module.toml
@@ -1,0 +1,7 @@
+[module]
+title = "Data Quality Validation"
+id = "dp:data_quality:cdf_dq_runtime"
+package_id = "dp:data_quality"
+description = "Data quality validation for Data Products."
+is_selected_by_default = true
+tags = ["data-quality", "shacl", "rulesets", "dataproducts"]

--- a/modules/common/cdf_dq_runtime/rulesets/asset_shacl_rules.RuleSet.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/asset_shacl_rules.RuleSet.yaml
@@ -1,0 +1,2 @@
+externalId: asset_shacl_rules
+name: YourOrgAsset SHACL Rules

--- a/modules/common/cdf_dq_runtime/rulesets/asset_shacl_rules.RuleSetVersion.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/asset_shacl_rules.RuleSetVersion.yaml
@@ -1,0 +1,43 @@
+ruleSetExternalId: asset_shacl_rules
+version: "1.0.0"
+rules:
+  - |
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix dqs: <http://purl.org/cognite/dqs#> .
+    @prefix sp_asset: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgAsset/> .
+
+    # ==============================================================================
+    # YourOrgAsset — base shape
+    # ==============================================================================
+    sp_asset:AssetShape
+        a sh:NodeShape ;
+        sh:targetClass sp_asset:YourOrgAsset ;
+        sh:name "Asset Validation" ;
+        sh:description "Validates YourOrgAsset instances." ;
+        sh:severity sh:Info .
+
+    # ==============================================================================
+    # Edge existence: asset hierarchy (cdf_cdm has-parent)
+    #
+    # Validates typed parent edges in the asset hierarchy. Root assets may have zero
+    # incoming has-parent edges (minCount 0). Non-root assets should have at most
+    # one parent (maxCount 1).
+    #
+    # Production runtime: ADR-0008 edge_existence_event handler (instances.query).
+    # ==============================================================================
+    sp_asset:AssetParentEdgeExistenceShape
+        a sh:NodeShape ;
+        sh:targetClass sp_asset:YourOrgAsset ;
+        sh:name "Asset Parent Edge Existence" ;
+        sh:description "Validates hierarchy parent edges (cdf_cdm/has-parent) on assets." ;
+        sh:severity sh:Violation ;
+        dqs:edgeExistenceConstraint [
+            dqs:connectionProperty "parent" ;
+            dqs:edgeType "cdf_cdm/has-parent" ;
+            dqs:direction "inwards" ;
+            dqs:minCount 0 ;
+            dqs:maxCount 1
+        ] .

--- a/modules/common/cdf_dq_runtime/rulesets/equipment_shacl_rules.RuleSet.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/equipment_shacl_rules.RuleSet.yaml
@@ -1,0 +1,2 @@
+externalId: equipment_shacl_rules
+name: YourOrgEquipment SHACL Rules

--- a/modules/common/cdf_dq_runtime/rulesets/equipment_shacl_rules.RuleSetVersion.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/equipment_shacl_rules.RuleSetVersion.yaml
@@ -1,0 +1,198 @@
+ruleSetExternalId: equipment_shacl_rules
+version: "1.0.0"
+rules:
+  - |
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix dqs: <http://purl.org/cognite/dqs#> .
+    @prefix sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgEquipment/> .
+    @prefix sp_asset: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgAsset/> .
+    @prefix cdm_eqtype: <http://purl.org/cognite/cdf_cdm/CogniteEquipmentType/> .
+    @prefix cdm_assettype: <http://purl.org/cognite/cdf_cdm/CogniteAssetType/> .
+    @prefix dq: <http://example.org/dataquality/> .
+
+    # ==============================================================================
+    # Shape for CogniteEquipmentType (referenced by Equipment.equipmentType)
+    # This triggers auto-loading of EquipmentType instances
+    # ==============================================================================
+    sp:EquipmentTypeShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_eqtype:CogniteEquipmentType ;
+        sh:name "Equipment Type Shape" ;
+        sh:description "Shape for CogniteEquipmentType instances." ;
+        sh:severity sh:Info .
+
+    # ==============================================================================
+    # Shape for CogniteAssetType (referenced by Asset.type)
+    # This triggers auto-loading of AssetType instances
+    # ==============================================================================
+    sp:AssetTypeShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_assettype:CogniteAssetType ;
+        sh:name "Asset Type Shape" ;
+        sh:description "Shape for CogniteAssetType instances." ;
+        sh:severity sh:Info .
+
+    # ==============================================================================
+    # Shape for YourOrgAsset (referenced by YourOrgEquipment)
+    # This triggers auto-loading of Asset AND its related AssetType
+    # ==============================================================================
+    sp:AssetShape
+        a sh:NodeShape ;
+        sh:targetClass sp_asset:YourOrgAsset ;
+        sh:name "Asset Shape" ;
+        sh:description "Validates properties of YourOrgAsset instances referenced by Equipment." ;
+        sh:severity sh:Info ;
+
+        # Relation to AssetType (triggers auto-loading of AssetType)
+        sh:property [
+            sh:path sp_asset:type ;
+            sh:node sp:AssetTypeShape ;  # <-- This triggers auto-loading of AssetType!
+            sh:message "Asset type must conform to AssetTypeShape" ;
+        ] .
+
+    # ==============================================================================
+    # Main Shape for YourOrgEquipment
+    # ==============================================================================
+    sp:EquipmentShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgEquipment ;
+        sh:name "Equipment Validation" ;
+        sh:description "Validates YourOrgEquipment instances and their relations." ;
+        sh:severity sh:Violation ;
+
+        # Relation to Asset (triggers auto-loading of Asset)
+        sh:property [
+            sh:path sp:asset ;
+            dq:dimension "Conformity" ;
+            sh:node sp:AssetShape ;  # <-- This triggers auto-loading of Asset!
+            sh:message "Related asset must conform to AssetShape" ;
+        ] ;
+
+        # Relation to EquipmentType (triggers auto-loading of EquipmentType)
+        sh:property [
+            sh:path sp:equipmentType ;
+            sh:node sp:EquipmentTypeShape ;  # <-- This triggers auto-loading of EquipmentType!
+            sh:message "Equipment type must conform to EquipmentTypeShape" ;
+        ] .
+
+    # ==============================================================================
+    # Uniqueness Rule: Equipment name must be unique
+    # ==============================================================================
+    sp:EquipmentNameUniqueness
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgEquipment ;
+        sh:name "Equipment Name Uniqueness Validation" ;
+        sh:description "Ensures equipment names are unique across the target class." ;
+        sh:severity sh:Violation ;
+        dqs:uniquenessConstraint [
+            dqs:property "name" ;
+        ] .
+
+    # ==============================================================================
+    # Equipment-Asset Type Compatibility Validation
+    # ==============================================================================
+    # Logic (based on data model):
+    # 1. Start at an Equipment instance ($this)
+    # 2. Find its equipmentType -> CogniteEquipmentType -> equipmentClass (e.g., "PUMP")
+    # 3. Find the related Asset ($this -> asset -> YourOrgAsset)
+    # 4. Find that Asset's type -> CogniteAssetType -> code (e.g., "PUMP")
+    # 5. Fail if they do not match
+    #
+    # Auto-loading chain:
+    #   Equipment -> asset -> YourOrgAsset -> type -> CogniteAssetType
+    #   Equipment -> equipmentType -> CogniteEquipmentType
+    # ==============================================================================
+    sp:EquipmentAssetTypeCompatibilityShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgEquipment ;
+        sh:name "Equipment-Asset Type Compatibility" ;
+        sh:description "Validates that Equipment type matches its related Asset type." ;
+        sh:severity sh:Violation ;
+        dq:dimension "Consistency" ;
+
+        # =============================================================================
+        # Rule: EquipmentType.equipmentClass must match AssetType.code
+        # =============================================================================
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Equipment class '{?equipmentClass}' does not match Asset type code '{?assetTypeCode}'" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgEquipment/>
+                PREFIX sp_asset: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgAsset/>
+                PREFIX cdm_eqtype: <http://purl.org/cognite/cdf_cdm/CogniteEquipmentType/>
+                PREFIX cdm_assettype: <http://purl.org/cognite/cdf_cdm/CogniteAssetType/>
+
+                SELECT $this ?equipmentClass ?assetTypeCode
+                WHERE {
+                    # Equipment -> equipmentType -> equipmentClass
+                    $this sp:equipmentType ?equipmentType .
+                    ?equipmentType cdm_eqtype:equipmentClass ?equipmentClass .
+
+                    # Equipment -> asset -> type -> code
+                    $this sp:asset ?asset .
+                    ?asset sp_asset:type ?assetType .
+                    ?assetType cdm_assettype:code ?assetTypeCode .
+
+                    # Fail if they don't match
+                    FILTER(?equipmentClass != ?assetTypeCode)
+                }
+            """ ;
+        ] ;
+
+        # =============================================================================
+        # Warning: Equipment has equipmentType but Asset has no type
+        # =============================================================================
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Equipment has type '{?equipmentTypeCode}' but related Asset has no type" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgEquipment/>
+                PREFIX sp_asset: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgAsset/>
+                PREFIX cdm_eqtype: <http://purl.org/cognite/cdf_cdm/CogniteEquipmentType/>
+
+                SELECT $this ?equipmentTypeCode
+                WHERE {
+                    # Equipment has equipmentType with code
+                    $this sp:equipmentType ?equipmentType .
+                    ?equipmentType cdm_eqtype:code ?equipmentTypeCode .
+
+                    # Equipment has an asset
+                    $this sp:asset ?asset .
+
+                    # But asset has no type relation
+                    FILTER NOT EXISTS { ?asset sp_asset:type ?assetType }
+                }
+            """ ;
+        ] ;
+
+        # =============================================================================
+        # Warning: Asset has type but Equipment has no equipmentType
+        # =============================================================================
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Related Asset has type '{?assetTypeCode}' but Equipment has no equipmentType" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgEquipment/>
+                PREFIX sp_asset: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgAsset/>
+                PREFIX cdm_assettype: <http://purl.org/cognite/cdf_cdm/CogniteAssetType/>
+
+                SELECT $this ?assetTypeCode
+                WHERE {
+                    # Equipment has an asset
+                    $this sp:asset ?asset .
+
+                    # Asset has type with code
+                    ?asset sp_asset:type ?assetType .
+                    ?assetType cdm_assettype:code ?assetTypeCode .
+
+                    # But equipment has no equipmentType
+                    FILTER NOT EXISTS { $this sp:equipmentType ?equipmentType }
+                }
+            """ ;
+        ] .

--- a/modules/common/cdf_dq_runtime/rulesets/maintenance_order_rule_logic_test_shacl_rules.RuleSet.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/maintenance_order_rule_logic_test_shacl_rules.RuleSet.yaml
@@ -1,0 +1,2 @@
+externalId: maintenance_order_rule_logic_test_shacl_rules
+name: YourOrgMaintenanceOrder Rule Logic Test SHACL Rules

--- a/modules/common/cdf_dq_runtime/rulesets/maintenance_order_rule_logic_test_shacl_rules.RuleSetVersion.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/maintenance_order_rule_logic_test_shacl_rules.RuleSetVersion.yaml
@@ -1,0 +1,111 @@
+ruleSetExternalId: maintenance_order_rule_logic_test_shacl_rules
+version: "1.0.0"
+rules:
+  - |
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix dqs: <http://purl.org/cognite/dqs#> .
+    @prefix sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/> .
+
+    # ============================================================================
+    # Rule Logic Test Pack for YourOrgMaintenanceOrder
+    # ============================================================================
+    # This file intentionally exercises three behaviors against live cog-ai data:
+    # 1) Uniqueness: duplicate maintenance-order names
+    # 2) Conditional logic: status-driven check
+    # 3) Chained conditional logic: ordered SHACL-AF rules with dqs:dependsOn
+    # ============================================================================
+
+    sp:MaintenanceOrderNameUniquenessTest
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Maintenance Order Name Uniqueness Test" ;
+        sh:description "Ensures maintenance order names are unique across the target class." ;
+        sh:severity sh:Violation ;
+        dqs:uniquenessConstraint [
+            dqs:property "name" ;
+        ] .
+
+    # Conditional logic:
+    # If status is 900 (completed code in this dataset), endTime must exist.
+    sp:CompletedStatusMustHaveEndTime
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Completed Status Requires End Time" ;
+        sh:description "Rows with status=900 must have endTime." ;
+        sh:severity sh:Violation ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Status 900 requires endTime, but endTime is missing." ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+                SELECT $this
+                WHERE {
+                    $this sp:status ?status .
+                    FILTER(STR(?status) = "900")
+                    FILTER NOT EXISTS { $this sp:endTime ?endTime }
+                }
+            """ ;
+        ] .
+
+    # Chained conditional logic:
+    # Rule 1 tags completed rows. Rule 2 depends on Rule 1 and emits a follow-up
+    # inference for completed rows missing endTime.
+    sp:MaintenanceOrderRuleChain
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:rule [
+            a sh:SPARQLRule ;
+            sh:order 1 ;
+            dqs:ruleId "MO_Completed_Status_Tag" ;
+            sh:construct """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+                PREFIX dqs: <http://purl.org/cognite/dqs#>
+                CONSTRUCT {
+                    ?result a dqs:RuleEngineResult ;
+                            dqs:focusNode $this ;
+                            dqs:ruleId "MO_Completed_Status_Tag" ;
+                            dqs:resultType "Inference" ;
+                            dqs:resultValue "CompletedStatus900" ;
+                            dqs:resultPayload ?payload .
+                }
+                WHERE {
+                    $this sp:status ?status .
+                    FILTER(STR(?status) = "900")
+                    BIND(CONCAT('{"status":"', STR(?status), '"}') AS ?payload)
+                    BIND(IRI(CONCAT("urn:dqs:mo:completed:", STR($this))) AS ?result)
+                }
+            """ ;
+        ] ;
+        sh:rule [
+            a sh:SPARQLRule ;
+            sh:order 2 ;
+            dqs:ruleId "MO_Completed_Missing_EndTime" ;
+            dqs:dependsOn "MO_Completed_Status_Tag" ;
+            sh:construct """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+                PREFIX dqs: <http://purl.org/cognite/dqs#>
+                CONSTRUCT {
+                    ?result a dqs:RuleEngineResult ;
+                            dqs:focusNode $this ;
+                            dqs:ruleId "MO_Completed_Missing_EndTime" ;
+                            dqs:resultType "Inference" ;
+                            dqs:resultValue "MissingEndTimeForCompleted" ;
+                            dqs:resultPayload ?payload ;
+                            dqs:causedBy ?completedTag .
+                }
+                WHERE {
+                    $this sp:status ?status .
+                    FILTER(STR(?status) = "900")
+                    FILTER NOT EXISTS { $this sp:endTime ?endTime }
+                    OPTIONAL {
+                        ?completedTag a dqs:RuleEngineResult ;
+                                      dqs:focusNode $this ;
+                                      dqs:ruleId "MO_Completed_Status_Tag" .
+                    }
+                    BIND(CONCAT('{"status":"', STR(?status), '","missing":"endTime"}') AS ?payload)
+                    BIND(IRI(CONCAT("urn:dqs:mo:completed-missing-endtime:", STR($this))) AS ?result)
+                }
+            """ ;
+        ] .

--- a/modules/common/cdf_dq_runtime/rulesets/maintenance_order_shacl_rules.RuleSet.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/maintenance_order_shacl_rules.RuleSet.yaml
@@ -1,0 +1,2 @@
+externalId: maintenance_order_shacl_rules
+name: YourOrgMaintenanceOrder SHACL Rules

--- a/modules/common/cdf_dq_runtime/rulesets/maintenance_order_shacl_rules.RuleSetVersion.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/maintenance_order_shacl_rules.RuleSetVersion.yaml
@@ -1,0 +1,335 @@
+ruleSetExternalId: maintenance_order_shacl_rules
+version: "1.0.0"
+rules:
+  - |
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix dqs: <http://purl.org/cognite/dqs#> .
+    @prefix sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/> .
+    @prefix sp_asset: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgAsset/> .
+
+    # ==============================================================================
+    # Shape for YourOrgAsset (referenced by MaintenanceOrder.mainAsset)
+    # This triggers auto-loading of Asset instances
+    # ==============================================================================
+    sp:AssetShape
+        a sh:NodeShape ;
+        sh:targetClass sp_asset:YourOrgAsset ;
+        sh:name "Asset Shape" ;
+        sh:description "Shape for YourOrgAsset instances referenced by MaintenanceOrder." ;
+        sh:severity sh:Info .
+
+    # ==============================================================================
+    # Main Shape for YourOrgMaintenanceOrder
+    # ==============================================================================
+    sp:MaintenanceOrderShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Maintenance Order Validation" ;
+        sh:description "Validates YourOrgMaintenanceOrder instances." ;
+        sh:severity sh:Violation ;
+
+        # Relation to mainAsset (triggers auto-loading of Asset)
+        sh:property [
+            sh:path sp:mainAsset ;
+            sh:node sp:AssetShape ;
+            sh:message "Main asset must conform to AssetShape" ;
+        ] .
+
+    # ==============================================================================
+    # Priority Validation
+    # ==============================================================================
+    sp:MaintenanceOrderPriorityShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Priority Validation" ;
+        sh:description "Validates priority is within acceptable range (1-5)." ;
+        sh:severity sh:Violation ;
+
+        sh:property [
+            sh:path sp:priority ;
+            sh:minInclusive 1 ;
+            sh:maxInclusive 5 ;
+            sh:datatype xsd:integer ;
+            sh:message "Priority must be between 1 (highest) and 5 (lowest)" ;
+        ] .
+
+    # ==============================================================================
+    # Status Validation
+    # ==============================================================================
+    sp:MaintenanceOrderStatusShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Status Validation" ;
+        sh:description "Validates status is one of the allowed values." ;
+        sh:severity sh:Violation ;
+
+        # Status must be one of the allowed values
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Invalid status '{?status}'. Must be one of: CREATED, IN_PROGRESS, COMPLETED, CANCELLED, ON_HOLD" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+
+                SELECT $this ?status
+                WHERE {
+                    $this sp:status ?status .
+                    FILTER(! (?status IN ("CREATED", "IN_PROGRESS", "COMPLETED", "CANCELLED", "ON_HOLD")))
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Type/Order Type Validation
+    # ==============================================================================
+    sp:MaintenanceOrderTypeShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Order Type Validation" ;
+        sh:description "Validates order type follows expected patterns." ;
+        sh:severity sh:Warning ;
+
+        # Type should match pattern (e.g., CM01, PM01, etc.)
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Order type '{?orderType}' does not follow expected pattern (e.g., CM01, PM01, EM01)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+
+                SELECT $this ?orderType
+                WHERE {
+                    $this sp:type ?orderType .
+                    FILTER(!REGEX(?orderType, "^(CM|PM|EM|SM)[0-9]{2}$"))
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Schedule Validation - End time must be after Start time
+    # ==============================================================================
+    sp:MaintenanceOrderScheduleShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Schedule Validation" ;
+        sh:description "Validates scheduling constraints." ;
+        sh:severity sh:Violation ;
+
+        # Scheduled end time must be after scheduled start time
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Scheduled end time '{?endTime}' is before or equal to start time '{?startTime}'" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+                PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+                SELECT $this ?startTime ?endTime
+                WHERE {
+                    $this sp:scheduledStartTime ?startTime .
+                    $this sp:scheduledEndTime ?endTime .
+                    FILTER(xsd:dateTime(?endTime) <= xsd:dateTime(?startTime))
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Duration Validation - Work order should not exceed 24 hours
+    # ==============================================================================
+    sp:MaintenanceOrderDurationShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Duration Validation" ;
+        sh:description "Warns if scheduled duration exceeds 24 hours." ;
+        sh:severity sh:Warning ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Scheduled duration exceeds 24 hours (start: {?startTime}, end: {?endTime})" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+                PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+                SELECT $this ?startTime ?endTime
+                WHERE {
+                    $this sp:scheduledStartTime ?startTime .
+                    $this sp:scheduledEndTime ?endTime .
+                    # Duration > 24 hours (86400 seconds)
+                    BIND(xsd:dateTime(?endTime) - xsd:dateTime(?startTime) AS ?duration)
+                    FILTER(?duration > "PT24H"^^xsd:dayTimeDuration)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Business Rule: High Priority Orders should have mainAsset
+    # ==============================================================================
+    sp:HighPriorityMainAssetShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "High Priority Asset Validation" ;
+        sh:description "High priority orders (1-2) should have a main asset assigned." ;
+        sh:severity sh:Warning ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "High priority order (priority={?priority}) has no main asset assigned" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+
+                SELECT $this ?priority
+                WHERE {
+                    $this sp:priority ?priority .
+                    FILTER(?priority <= 2)
+                    FILTER NOT EXISTS { $this sp:mainAsset ?asset }
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Business Rule: Completed orders should have at least one related asset or equipment
+    # ==============================================================================
+    sp:CompletedOrderAssetsShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Completed Order Assets Validation" ;
+        sh:description "Completed orders should have related assets or equipment recorded." ;
+        sh:severity sh:Info ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Completed order has no assets or equipment recorded (status={?status})" ;
+            sh:severity sh:Info ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+
+                SELECT $this ?status
+                WHERE {
+                    $this sp:status ?status .
+                    FILTER(?status = "COMPLETED")
+                    FILTER NOT EXISTS { $this sp:assets ?asset }
+                    FILTER NOT EXISTS { $this sp:equipment ?equipment }
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Name Quality Validation
+    # ==============================================================================
+    sp:MaintenanceOrderNameShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Name Quality Validation" ;
+        sh:description "Validates name quality." ;
+        sh:severity sh:Warning ;
+
+        # Name should be descriptive (at least 10 characters)
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Order name '{?name}' is too short (less than 10 characters)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+
+                SELECT $this ?name
+                WHERE {
+                    $this sp:name ?name .
+                    FILTER(STRLEN(?name) < 10)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Uniqueness Rule: Maintenance order name must be unique
+    # ==============================================================================
+    sp:MaintenanceOrderNameUniqueness
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+        sh:name "Name Uniqueness Validation" ;
+        sh:description "Ensures maintenance order names are unique across the target class." ;
+        sh:severity sh:Violation ;
+        dqs:uniquenessConstraint [
+            dqs:property "name" ;
+        ] .
+
+    # ==============================================================================
+    # Inference Rules (SHACL-AF)
+    #
+    # These rules use sh:SPARQLRule / sh:construct to materialise derived state
+    # for each maintenance order into the RuleEngineResult container in CDF
+    # Records API. Both rules share one NodeShape so sh:order governs execution
+    # sequence and dqs:dependsOn is verifiable at deploy time.
+    #
+    # MO_Criticality (order 1) — classifies priority into a criticality label.
+    # MO_Overdue     (order 2) — flags open orders past their scheduled end time;
+    #                            links back to the criticality result via causedBy.
+    # ==============================================================================
+    sp:MaintenanceOrderInferenceRules
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgMaintenanceOrder ;
+
+        sh:rule [
+            a sh:SPARQLRule ;
+            sh:order 1 ;
+            dqs:ruleId "MO_Criticality" ;
+            sh:construct """
+                PREFIX sp:  <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+                PREFIX dqs: <http://purl.org/cognite/dqs#>
+                CONSTRUCT {
+                    ?result a dqs:RuleEngineResult ;
+                            dqs:focusNode    $this ;
+                            dqs:ruleId       "MO_Criticality" ;
+                            dqs:resultType   "Inference" ;
+                            dqs:resultValue  ?critLabel ;
+                            dqs:resultPayload ?payload .
+                }
+                WHERE {
+                    $this sp:priority ?priority .
+                    BIND(
+                        IF(?priority <= 2, "Critical",
+                        IF(?priority = 3, "High", "Normal")) AS ?critLabel
+                    )
+                    BIND(CONCAT('{"priority":', STR(?priority), ',"criticality":"', ?critLabel, '"}') AS ?payload)
+                    BIND(IRI(CONCAT("urn:dqs:mo:criticality:", STR($this))) AS ?result)
+                }
+            """ ;
+        ] ;
+
+        sh:rule [
+            a sh:SPARQLRule ;
+            sh:order 2 ;
+            dqs:ruleId    "MO_Overdue" ;
+            dqs:dependsOn "MO_Criticality" ;
+            sh:construct """
+                PREFIX sp:  <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgMaintenanceOrder/>
+                PREFIX dqs: <http://purl.org/cognite/dqs#>
+                PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                CONSTRUCT {
+                    ?result a dqs:RuleEngineResult ;
+                            dqs:focusNode    $this ;
+                            dqs:ruleId       "MO_Overdue" ;
+                            dqs:resultType   "Inference" ;
+                            dqs:resultValue  "Overdue" ;
+                            dqs:resultPayload ?payload ;
+                            dqs:causedBy     ?critResult .
+                }
+                WHERE {
+                    $this sp:status ?status ;
+                          sp:scheduledEndTime ?endTime .
+                    FILTER(?status IN ("CREATED", "IN_PROGRESS"))
+                    FILTER(xsd:dateTime(?endTime) < NOW())
+                    OPTIONAL {
+                        ?critResult a dqs:RuleEngineResult ;
+                                    dqs:focusNode $this ;
+                                    dqs:ruleId "MO_Criticality" .
+                    }
+                    BIND(CONCAT('{"status":"', ?status, '","scheduledEndTime":"', STR(?endTime), '"}') AS ?payload)
+                    BIND(IRI(CONCAT("urn:dqs:mo:overdue:", STR($this))) AS ?result)
+                }
+            """ ;
+        ] .

--- a/modules/common/cdf_dq_runtime/rulesets/notification_shacl_rules.RuleSet.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/notification_shacl_rules.RuleSet.yaml
@@ -1,0 +1,2 @@
+externalId: notification_shacl_rules
+name: YourOrgNotification SHACL Rules

--- a/modules/common/cdf_dq_runtime/rulesets/notification_shacl_rules.RuleSetVersion.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/notification_shacl_rules.RuleSetVersion.yaml
@@ -1,0 +1,59 @@
+ruleSetExternalId: notification_shacl_rules
+version: "1.0.0"
+rules:
+  - |
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dq: <http://example.org/dataquality/> .
+    @prefix dqs: <http://purl.org/cognite/dqs#> .
+    @prefix sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgNotification/> .
+
+    # YourOrgNotification SHACL Rules for Data Quality Validation
+    # Testing integer field partitioning with priority field
+
+    <#NotificationShape>
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgNotification ;
+        sh:name "Notification Validation" ;
+        sh:description "SHACL validation rules for YourOrgNotification - testing integer field handling" ;
+
+        # Priority must be present and valid
+        sh:property [
+            sh:path sp:priority ;
+            dq:dimension "Completeness" ;
+            sh:name "Priority" ;
+            sh:description "Priority must be 1, 2, or 3" ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:datatype xsd:integer ;
+            sh:minInclusive 1 ;
+            sh:maxInclusive 3 ;
+            sh:severity sh:Violation ;
+            sh:message "Notification must have a priority value between 1 and 3" ;
+        ] ;
+
+        # Name should be present
+        sh:property [
+            sh:path sp:name ;
+            sh:name "Name" ;
+            sh:description "Notification should have a name" ;
+            sh:minCount 1 ;
+            sh:datatype xsd:string ;
+            sh:severity sh:Warning ;
+            sh:message "Notification should have a name" ;
+        ] .
+
+    # ==============================================================================
+    # Uniqueness Rule: Notification name must be unique
+    # ==============================================================================
+    <#NotificationNameUniqueness>
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgNotification ;
+        sh:name "Notification Name Uniqueness Validation" ;
+        sh:description "Ensures notification names are unique across the target class." ;
+        sh:severity sh:Violation ;
+        dqs:uniquenessConstraint [
+            dqs:property "name" ;
+        ] .

--- a/modules/common/cdf_dq_runtime/rulesets/operation_shacl_rules.RuleSet.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/operation_shacl_rules.RuleSet.yaml
@@ -1,0 +1,2 @@
+externalId: operation_shacl_rules
+name: YourOrgOperation SHACL Rules

--- a/modules/common/cdf_dq_runtime/rulesets/operation_shacl_rules.RuleSetVersion.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/operation_shacl_rules.RuleSetVersion.yaml
@@ -1,0 +1,337 @@
+ruleSetExternalId: operation_shacl_rules
+version: "1.0.0"
+rules:
+  - |
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dqs: <http://purl.org/cognite/dqs#> .
+
+    # Namespace for the data model
+    @prefix sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgOperation/> .
+    @prefix dq: <http://example.org/dataquality/> .
+
+    # =============================================================================
+    # SHACL Rules for YourOrgOperation
+    # =============================================================================
+    # This rule set validates Operations and includes cross-reference validation
+    # to check that Operation tags match the tags of related Equipment.
+    # =============================================================================
+
+    # =============================================================================
+    # Equipment Shape (for sh:node reference - triggers auto-loading)
+    # =============================================================================
+    sp:EquipmentShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgEquipment ;
+        sh:name "Equipment Shape" ;
+        sh:description "Shape for validating Equipment instances referenced by Operations" ;
+
+        # Equipment should have a name
+        sh:property [
+            sh:path sp:name ;
+            dq:dimension "Completeness" ;
+            sh:minCount 1 ;
+            sh:datatype xsd:string ;
+            sh:message "Equipment must have a name" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # Equipment tags (for cross-reference validation)
+        sh:property [
+            sh:path sp:tags ;
+            sh:datatype xsd:string ;
+            sh:message "Equipment tags must be strings" ;
+            sh:severity sh:Warning ;
+        ] .
+
+
+    # =============================================================================
+    # Operation Shape - Main Validation Rules
+    # =============================================================================
+    sp:OperationShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgOperation ;
+        sh:name "Operation Validation" ;
+        sh:description "Validates YourOrgOperation instances including relationship constraints" ;
+
+        # ===========================================================================
+        # REQUIRED FIELDS
+        # ===========================================================================
+
+        # Name is required
+        sh:property [
+            sh:path sp:name ;
+            dq:dimension "Completeness" ;
+            sh:minCount 1 ;
+            sh:datatype xsd:string ;
+            sh:message "Operation must have a name" ;
+            sh:severity sh:Violation ;
+        ] ;
+
+        # Maintenance order reference is required
+        sh:property [
+            sh:path sp:maintenanceOrder ;
+            dq:dimension "Completeness" ;
+            sh:minCount 1 ;
+            sh:message "Operation must be linked to a maintenance order" ;
+            sh:severity sh:Violation ;
+        ] ;
+
+        # ===========================================================================
+        # OPTIONAL FIELDS WITH CONSTRAINTS
+        # ===========================================================================
+
+        # Description (optional)
+        sh:property [
+            sh:path sp:description ;
+            dq:dimension "Validity" ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "Description must be a string if provided" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # Status (optional)
+        sh:property [
+            sh:path sp:status ;
+            dq:dimension "Validity" ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "Status must be a string" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # Phase (optional)
+        sh:property [
+            sh:path sp:phase ;
+            dq:dimension "Validity" ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:message "Phase must be a string" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # Sequence (optional, but if present must be non-negative)
+        sh:property [
+            sh:path sp:sequence ;
+            dq:dimension "Validity" ;
+            sh:datatype xsd:integer ;
+            sh:minInclusive 0 ;
+            sh:maxCount 1 ;
+            sh:message "Sequence must be a non-negative integer" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # Person hours (optional, but if present must be positive)
+        sh:property [
+            sh:path sp:personHours ;
+            dq:dimension "Validity" ;
+            sh:minExclusive 0 ;
+            sh:maxCount 1 ;
+            sh:message "Person hours must be a positive number" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # Number of main discipline (optional, but if present must be positive)
+        sh:property [
+            sh:path sp:numberOfMainDiscipline ;
+            dq:dimension "Validity" ;
+            sh:datatype xsd:integer ;
+            sh:minInclusive 1 ;
+            sh:maxCount 1 ;
+            sh:message "Number of main discipline must be at least 1" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # ===========================================================================
+        # EQUIPMENT REFERENCE WITH sh:node (TRIGGERS AUTO-LOADING!)
+        # ===========================================================================
+
+        # Equipment list - uses sh:node to reference EquipmentShape
+        # This will trigger NEAT to auto-load the Equipment instances from DMS
+        sh:property [
+            sh:path sp:equipment ;
+            dq:dimension "Conformity" ;
+            sh:node sp:EquipmentShape ;
+            sh:message "Related equipment must conform to EquipmentShape" ;
+            sh:severity sh:Warning ;
+        ] ;
+
+        # ===========================================================================
+        # CROSS-REFERENCE VALIDATION: Operation tags must match Equipment tags
+        # ===========================================================================
+        # This SPARQL constraint checks that:
+        # - For each tag on the Operation
+        # - At least one related Equipment has that same tag
+        # ===========================================================================
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Operation tag '{?operationTag}' is not found on any related equipment" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgOperation/>
+
+                SELECT $this ?operationTag
+                WHERE {
+                    # Get operation's tags
+                    $this sp:tags ?operationTag .
+
+                    # Get related equipment
+                    $this sp:equipment ?equipment .
+
+                    # Check if ANY equipment has this tag
+                    # VIOLATION: No equipment has the operation's tag
+                    FILTER NOT EXISTS {
+                        ?equipment sp:tags ?equipmentTag .
+                        FILTER(?operationTag = ?equipmentTag)
+                    }
+                }
+            """ ;
+        ] ;
+
+        # ===========================================================================
+        # REVERSE CHECK: Equipment tags should be on Operation
+        # ===========================================================================
+        # This validates that if equipment has tags, those tags should also
+        # be present on the operation (ensuring consistency)
+        # ===========================================================================
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Equipment tag '{?equipmentTag}' from equipment '{?equipmentId}' is not on the operation" ;
+            sh:severity sh:Info ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgOperation/>
+
+                SELECT $this ?equipmentTag ?equipmentId
+                WHERE {
+                    # Get related equipment and its tags
+                    $this sp:equipment ?equipment .
+                    ?equipment sp:tags ?equipmentTag .
+
+                    # Get equipment ID for the message
+                    BIND(STR(?equipment) AS ?equipmentId)
+
+                    # Check if operation has this tag
+                    # VIOLATION: Operation doesn't have the equipment's tag
+                    FILTER NOT EXISTS {
+                        $this sp:tags ?operationTag .
+                        FILTER(?operationTag = ?equipmentTag)
+                    }
+                }
+            """ ;
+        ] .
+
+
+    # =============================================================================
+    # Operation with Equipment - Strict Tag Matching
+    # =============================================================================
+    # This shape enforces that Operations MUST have equipment assigned
+    # and their tags MUST match exactly
+    # =============================================================================
+
+    sp:OperationWithEquipmentTagMatchingShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgOperation ;
+        sh:name "Operation-Equipment Tag Matching (Strict)" ;
+        sh:description "Strict validation that operation tags match equipment tags exactly" ;
+
+        # Must have at least one equipment
+        sh:property [
+            sh:path sp:equipment ;
+            dq:dimension "Completeness" ;
+            sh:minCount 1 ;
+            sh:node sp:EquipmentShape ;  # This triggers auto-loading!
+            sh:message "Operation must have at least one equipment assigned" ;
+            sh:severity sh:Violation ;
+        ] ;
+
+        # All operation tags must exist on at least one equipment
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "STRICT: Operation tag '{?tag}' not found on any related equipment. Tags must match!" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgOperation/>
+
+                SELECT $this ?tag
+                WHERE {
+                    # Operation has tags
+                    $this sp:tags ?tag .
+
+                    # Has equipment
+                    $this sp:equipment ?equipment .
+
+                    # But no equipment has this tag
+                    FILTER NOT EXISTS {
+                        ?equipment sp:tags ?tag .
+                    }
+                }
+            """ ;
+        ] .
+
+
+    # =============================================================================
+    # TIME VALIDATION
+    # =============================================================================
+
+    sp:OperationTimeValidationShape
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgOperation ;
+        sh:name "Operation Time Validation" ;
+        sh:description "Validates time constraints for operations" ;
+
+        # End time must be after start time
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Operation end time must be after start time" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgOperation/>
+                PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+                SELECT $this ?startTime ?endTime
+                WHERE {
+                    $this sp:startTime ?startTime ;
+                          sp:endTime ?endTime .
+
+                    FILTER(xsd:dateTime(?endTime) <= xsd:dateTime(?startTime))
+                }
+            """ ;
+        ] ;
+
+        # Scheduled end time must be after scheduled start time
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Scheduled end time must be after scheduled start time" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX sp: <http://purl.org/cognite/sp_enterprise_process_industry/YourOrgOperation/>
+                PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+                SELECT $this ?schedStart ?schedEnd
+                WHERE {
+                    $this sp:scheduledStartTime ?schedStart ;
+                          sp:scheduledEndTime ?schedEnd .
+
+                    FILTER(xsd:dateTime(?schedEnd) <= xsd:dateTime(?schedStart))
+                }
+            """ ;
+        ] .
+
+
+    # =============================================================================
+    # Uniqueness Rule: Operation name must be unique
+    # =============================================================================
+    sp:OperationNameUniqueness
+        a sh:NodeShape ;
+        sh:targetClass sp:YourOrgOperation ;
+        sh:name "Operation Name Uniqueness Validation" ;
+        sh:description "Ensures operation names are unique across the target class." ;
+        sh:severity sh:Violation ;
+        dqs:uniquenessConstraint [
+            dqs:property "name" ;
+        ] .

--- a/modules/common/cdf_dq_runtime/rulesets/timeseries_quality_rules.RuleSet.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/timeseries_quality_rules.RuleSet.yaml
@@ -1,0 +1,2 @@
+externalId: timeseries_quality_rules
+name: YourOrgTimeSeries SHACL Rules

--- a/modules/common/cdf_dq_runtime/rulesets/timeseries_quality_rules.RuleSetVersion.yaml
+++ b/modules/common/cdf_dq_runtime/rulesets/timeseries_quality_rules.RuleSetVersion.yaml
@@ -1,0 +1,416 @@
+ruleSetExternalId: timeseries_quality_rules
+version: "1.0.0"
+rules:
+  - |
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    @prefix cdm_ts: <http://purl.org/cognite/cdf_cdm/CogniteTimeSeries/> .
+    @prefix cdf_sdk: <https://cognite.com/cdf/sdk/> .
+    @prefix cdf_indsl: <https://cognite.com/cdf/indsl/> .
+
+    # Cog-ai Time Series Quality SHACL rules
+    # - Ensures recent data and minimum datapoint count (>=50 over 60m)
+    # - Flags gaps using 5x normal interval (for 1-min data: gaps >5 min)
+    # - Outlier detection via INDSL extreme_outliers
+    # - Value range checks and existence check
+    # - The "unexpected decreases" shape is commented out; enable only for cumulative counters
+
+    # ==============================================================================
+    # Time Series Quality Validation Rules
+    # 
+    # Schedule: Every 60 minutes at XX:02
+    # Time Window: Exact 60 minutes, aligned to hour boundaries
+    #
+    # These rules use CDF SPARQL functions to check time series data quality:
+    # - cdf_sdk: functions call the Cognite Python SDK
+    # - cdf_indsl: functions call the Industrial Data Science Library (INDSL)
+    #
+    # IMPORTANT: "60m-ago" and "now" are replaced with actual timestamps at runtime
+    # to ensure exact, non-overlapping windows (e.g., 06:00-07:00, 07:00-08:00).
+    #
+    # Available functions:
+    #   cdf_sdk:datapoints_count(?ts, start, end) - Count datapoints in range
+    #   cdf_sdk:datapoints_average(?ts, start, end) - Average value in range
+    #   cdf_sdk:datapoints_min(?ts, start, end) - Minimum value in range
+    #   cdf_sdk:datapoints_max(?ts, start, end) - Maximum value in range
+    #   cdf_sdk:timeseries_exists(?ts) - Check if time series exists
+    #   cdf_indsl:extreme_outliers(?ts, alpha) - Count extreme outliers
+    #   cdf_indsl:gaps_identification(?ts, cutoff) - Count gaps in data
+    #   cdf_indsl:value_decrease_check(?ts) - Count unexpected value decreases
+    # ==============================================================================
+
+    # ==============================================================================
+    # Shape: Time Series Must Have Recent Data
+    # Checks that time series has at least some data in the time window
+    # ==============================================================================
+    cdm_ts:HasRecentDataShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_ts:CogniteTimeSeries ;
+        sh:name "Time Series Has Recent Data" ;
+        sh:description "Validates that time series has data in the last 90 minutes." ;
+        sh:severity sh:Violation ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Time series has no data in the time window (count: {?count})" ;
+            sh:severity sh:Violation ;
+            sh:prefixes [
+                sh:declare [
+                    sh:prefix "cdf_sdk" ;
+                    sh:namespace "https://cognite.com/cdf/sdk/"^^xsd:anyURI ;
+                ] ;
+            ] ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?count
+                WHERE {
+                    BIND(cdf_sdk:datapoints_count($this, "60m-ago", "now") AS ?count)
+                    FILTER(?count = 0)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Shape: Time Series Must Have Minimum Data Points
+    # For 60-min window with 1-min data, expect ~60 points, allow 50 as minimum
+    # ==============================================================================
+    cdm_ts:MinimumDataPointsShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_ts:CogniteTimeSeries ;
+        sh:name "Minimum Data Points Check" ;
+        sh:description "Validates that time series has sufficient data points." ;
+        sh:severity sh:Warning ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Time series has insufficient data points: {?count} (expected >= 50)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?count
+                WHERE {
+                    BIND(cdf_sdk:datapoints_count($this, "60m-ago", "now") AS ?count)
+                    FILTER(?count < 50 && ?count > 0)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Shape: Detect Extreme Outliers
+    # Uses INDSL extreme_outliers to find anomalous values
+    # Returns count of outliers (0 = no outliers)
+    # ==============================================================================
+    cdm_ts:NoExtremeOutliersShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_ts:CogniteTimeSeries ;
+        sh:name "No Extreme Outliers" ;
+        sh:description "Validates that time series has no extreme outlier values." ;
+        sh:severity sh:Warning ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Time series contains {?outlierCount} extreme outliers" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_indsl: <https://cognite.com/cdf/indsl/>
+
+                SELECT $this ?outlierCount
+                WHERE {
+                    BIND(cdf_indsl:extreme_outliers($this, 0.05) AS ?outlierCount)
+                    FILTER(?outlierCount > 0)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Shape: Detect Gaps in Time Series Data
+    # Uses INDSL gaps_identification to find missing data periods
+    # cutoff_multiple=5.0 means gaps > 5x the median interval are flagged
+    # For 1-min data, this would flag gaps > 5 minutes
+    # ==============================================================================
+    cdm_ts:NoGapsShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_ts:CogniteTimeSeries ;
+        sh:name "No Data Gaps" ;
+        sh:description "Validates that time series has no significant gaps." ;
+        sh:severity sh:Warning ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Time series has {?gapCount} data gaps (> 5x normal interval)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_indsl: <https://cognite.com/cdf/indsl/>
+
+                SELECT $this ?gapCount
+                WHERE {
+                    BIND(cdf_indsl:gaps_identification($this, 5.0) AS ?gapCount)
+                    FILTER(?gapCount > 0)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Shape: Detect Unexpected Value Decreases
+    # Uses INDSL value_decrease_check for cumulative metrics ONLY
+    # NOTE: Disabled by default - only enable for cumulative counter time series
+    #       Regular time series naturally fluctuate up and down
+    # ==============================================================================
+    # cdm_ts:NoUnexpectedDecreasesShape
+    #     a sh:NodeShape ;
+    #     sh:targetClass cdm_ts:CogniteTimeSeries ;
+    #     sh:name "No Unexpected Decreases" ;
+    #     sh:description "Validates that cumulative time series values don't decrease." ;
+    #     sh:severity sh:Violation ;
+    #     
+    #     sh:sparql [
+    #         a sh:SPARQLConstraint ;
+    #         sh:message "Time series has {?decreaseCount} unexpected value decreases" ;
+    #         sh:severity sh:Violation ;
+    #         sh:select """
+    #             PREFIX cdf_indsl: <https://cognite.com/cdf/indsl/>
+    #             
+    #             SELECT $this ?decreaseCount
+    #             WHERE {
+    #                 BIND(cdf_indsl:value_decrease_check($this, 0.0) AS ?decreaseCount)
+    #                 FILTER(?decreaseCount > 0)
+    #             }
+    #         """ ;
+    #     ] .
+
+    # ==============================================================================
+    # Shape: Value Range Check (using SDK aggregations)
+    # Checks that values are within expected min/max bounds
+    # ==============================================================================
+    cdm_ts:ValueRangeCheckShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_ts:CogniteTimeSeries ;
+        sh:name "Value Range Check" ;
+        sh:description "Validates that time series min/max values are within bounds." ;
+        sh:severity sh:Warning ;
+
+        # Check for suspiciously low minimum (potential sensor failure)
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Minimum value ({?minVal}) is suspiciously low (< -1000)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?minVal
+                WHERE {
+                    BIND(cdf_sdk:datapoints_min($this, "60m-ago", "now") AS ?minVal)
+                    FILTER(?minVal < -1000)
+                }
+            """ ;
+        ] ;
+
+        # Check for suspiciously high maximum (potential sensor failure)
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Maximum value ({?maxVal}) is suspiciously high (> 10000)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?maxVal
+                WHERE {
+                    BIND(cdf_sdk:datapoints_max($this, "60m-ago", "now") AS ?maxVal)
+                    FILTER(?maxVal > 10000)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Shape: Time Series Exists
+    # Basic check that the time series actually exists in CDF
+    # ==============================================================================
+    cdm_ts:TimeSeriesExistsShape
+        a sh:NodeShape ;
+        sh:targetClass cdm_ts:CogniteTimeSeries ;
+        sh:name "Time Series Exists" ;
+        sh:description "Validates that the time series exists in CDF." ;
+        sh:severity sh:Violation ;
+
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Time series does not exist in CDF" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this
+                WHERE {
+                    BIND(cdf_sdk:timeseries_exists($this) AS ?exists)
+                    FILTER(?exists = false)
+                }
+            """ ;
+        ] .
+
+    # ==============================================================================
+    # Additional YourOrgTimeSeries datapoint examples (cog-ai)
+    # - stale latest datapoint
+    # - value range bounds
+    # - flatline detection
+    # - cross-signal consistency
+    # These are concrete examples for specific series and run on the same hourly
+    # schedule/window as the other rules in this file.
+    # ==============================================================================
+
+    cdm_ts:YourOrgStaleLatestDatapointShape
+        a sh:NodeShape ;
+        sh:targetNode <http://purl.org/cognite/springfield_instances/pi:160554> ;
+        sh:name "YourOrg Stale Latest Datapoint" ;
+        sh:description "Flags stale series with no datapoints in the active window." ;
+        sh:severity sh:Violation ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "No datapoints in the last hour for stale-check target (count: {?count})" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?count
+                WHERE {
+                    BIND(cdf_sdk:datapoints_count($this, "60m-ago", "now") AS ?count)
+                    FILTER(?count = 0)
+                }
+            """ ;
+        ] .
+
+    cdm_ts:YourOrgValueRangeBoundsShape
+        a sh:NodeShape ;
+        sh:targetNode <http://purl.org/cognite/springfield_instances/pi:160245> ;
+        sh:name "YourOrg Value Range Bounds" ;
+        sh:description "Example min/max bounds checks for a concrete time series." ;
+        sh:severity sh:Warning ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Minimum value ({?minVal}) below expected floor (-1000)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?minVal
+                WHERE {
+                    BIND(cdf_sdk:datapoints_min($this, "60m-ago", "now") AS ?minVal)
+                    FILTER(?minVal < -1000)
+                }
+            """ ;
+        ] ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Maximum value ({?maxVal}) above expected ceiling (10000)" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?maxVal
+                WHERE {
+                    BIND(cdf_sdk:datapoints_max($this, "60m-ago", "now") AS ?maxVal)
+                    FILTER(?maxVal > 10000)
+                }
+            """ ;
+        ] .
+
+    cdm_ts:YourOrgFlatlineDetectionShape
+        a sh:NodeShape ;
+        sh:targetNode <http://purl.org/cognite/springfield_instances/pi:160554> ;
+        sh:name "YourOrg Flatline Detection" ;
+        sh:description "Flags near-flat signal behavior in the active window." ;
+        sh:severity sh:Warning ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Potential flatline detected (span: {?span}, count: {?count})" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?span ?count
+                WHERE {
+                    BIND(cdf_sdk:datapoints_min($this, "60m-ago", "now") AS ?minVal)
+                    BIND(cdf_sdk:datapoints_max($this, "60m-ago", "now") AS ?maxVal)
+                    BIND(cdf_sdk:datapoints_count($this, "60m-ago", "now") AS ?count)
+                    BIND((?maxVal - ?minVal) AS ?span)
+                    FILTER(?count >= 2 && ?span <= 0.001)
+                }
+            """ ;
+        ] .
+
+    cdm_ts:YourOrgCrossSignalConsistencyShape
+        a sh:NodeShape ;
+        sh:targetNode <http://purl.org/cognite/springfield_instances/pi:160245> ;
+        sh:name "YourOrg Cross-Signal Consistency" ;
+        sh:description "Compares one signal's average to a reference signal in the same window." ;
+        sh:severity sh:Warning ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Cross-signal average mismatch delta={?delta} exceeds threshold" ;
+            sh:severity sh:Warning ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?avgA ?avgB ?delta
+                WHERE {
+                    BIND(cdf_sdk:datapoints_average($this, "60m-ago", "now") AS ?avgA)
+                    BIND(cdf_sdk:datapoints_average(
+                        <http://purl.org/cognite/springfield_instances/pi:160554>, "60m-ago", "now"
+                    ) AS ?avgB)
+                    BIND(ABS(?avgA - ?avgB) AS ?delta)
+                    FILTER(?delta > 1.0)
+                }
+            """ ;
+        ] .
+
+    # Canary checks for deployment validation:
+    # - strict cross-signal mismatch threshold
+    # - strict datapoint count threshold for stale target
+    cdm_ts:YourOrgCanaryCrossSignalStrictShape
+        a sh:NodeShape ;
+        sh:targetNode <http://purl.org/cognite/springfield_instances/pi:160245> ;
+        sh:name "YourOrg Canary Cross-Signal Strict" ;
+        sh:description "Canary rule to force detectable cross-signal mismatch failures." ;
+        sh:severity sh:Violation ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Canary cross-signal delta={?delta} exceeds strict threshold 0.01" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?avgA ?avgB ?delta
+                WHERE {
+                    BIND(cdf_sdk:datapoints_average($this, "60m-ago", "now") AS ?avgA)
+                    BIND(cdf_sdk:datapoints_average(
+                        <http://purl.org/cognite/springfield_instances/pi:160554>, "60m-ago", "now"
+                    ) AS ?avgB)
+                    BIND(ABS(?avgA - ?avgB) AS ?delta)
+                    FILTER(?delta > 0.01)
+                }
+            """ ;
+        ] .
+
+    cdm_ts:YourOrgCanaryMinimumCountShape
+        a sh:NodeShape ;
+        sh:targetNode <http://purl.org/cognite/springfield_instances/pi:160554> ;
+        sh:name "YourOrg Canary Minimum Count" ;
+        sh:description "Canary rule to force datapoint count failures for the stale example series." ;
+        sh:severity sh:Violation ;
+        sh:sparql [
+            a sh:SPARQLConstraint ;
+            sh:message "Canary count check failed: expected >= 1 datapoint, got {?count}" ;
+            sh:severity sh:Violation ;
+            sh:select """
+                PREFIX cdf_sdk: <https://cognite.com/cdf/sdk/>
+
+                SELECT $this ?count
+                WHERE {
+                    BIND(cdf_sdk:datapoints_count($this, "60m-ago", "now") AS ?count)
+                    FILTER(?count < 1)
+                }
+            """ ;
+        ] .

--- a/modules/common/cdf_dq_runtime/scripts/_cli.py
+++ b/modules/common/cdf_dq_runtime/scripts/_cli.py
@@ -1,0 +1,327 @@
+"""Shared CLI helpers for the Data Quality Toolkit module scripts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_PLACEHOLDER = re.compile(r"\{\{\s*([a-zA-Z0-9_]+)\s*\}\}")
+
+
+def module_root() -> Path:
+    """Return the Toolkit module directory that contains this scripts folder."""
+    return Path(__file__).resolve().parents[1]
+
+
+def _stringify_leaves(mapping: dict[str, object]) -> dict[str, str]:
+    return {str(key): "" if value is None else str(value) for key, value in mapping.items()}
+
+
+def flatten_toolkit_variables(config: dict[str, object]) -> dict[str, str]:
+    """Flatten Toolkit config.<env>.yaml variables to {{ key }} names."""
+    variables = config.get("variables")
+    if not isinstance(variables, dict):
+        return {}
+
+    flattened: dict[str, str] = {}
+
+    def walk(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        leaf_values = {key: value for key, value in node.items() if not isinstance(value, dict)}
+        nested = {key: value for key, value in node.items() if isinstance(value, dict)}
+        if leaf_values and not nested:
+            flattened.update(_stringify_leaves(leaf_values))
+            return
+        if nested:
+            for child in nested.values():
+                walk(child)
+        if leaf_values:
+            flattened.update(_stringify_leaves(leaf_values))
+
+    top_level = {key: value for key, value in variables.items() if key != "modules"}
+    walk(top_level)
+
+    modules = variables.get("modules")
+    if isinstance(modules, dict):
+        walk(modules)
+    elif modules is not None:
+        flattened["modules"] = str(modules)
+
+    return flattened
+
+
+def load_default_pack_variables(module_dir: Path) -> dict[str, str]:
+    """Load placeholder defaults from the module default.config.yaml."""
+    path = module_dir / "default.config.yaml"
+    if not path.is_file():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a mapping in {path}")
+    return _stringify_leaves(data)
+
+
+def substitute_placeholders(text: str, variables: dict[str, str]) -> str:
+    """Replace ``{{ name }}`` tokens. Unknown names are left unchanged."""
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name in variables:
+            return variables[name]
+        return match.group(0)
+
+    return _PLACEHOLDER.sub(replace, text)
+
+
+def unresolved_placeholders(text: str) -> list[str]:
+    """Return unique placeholder names still present in *text*."""
+    return sorted(set(_PLACEHOLDER.findall(text)))
+
+
+def materialize_pack_yaml(
+    source_dir: Path,
+    dest_dir: Path,
+    variables: dict[str, str],
+    *,
+    require_resolved: bool = True,
+) -> Path:
+    """Copy pack YAML into dest_dir with Toolkit placeholders substituted."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    unresolved: list[str] = []
+    for src in sorted(source_dir.rglob("*")):
+        if not src.is_file():
+            continue
+        if src.suffix.lower() not in {".yaml", ".yml", ".ttl"}:
+            continue
+        rel = src.relative_to(source_dir)
+        if rel.parts and rel.parts[0] == "scripts":
+            continue
+        dest = dest_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        rendered = substitute_placeholders(src.read_text(encoding="utf-8"), variables)
+        leftover = unresolved_placeholders(rendered)
+        if leftover:
+            unresolved.extend(f"{rel}: {name}" for name in leftover)
+        dest.write_text(rendered, encoding="utf-8")
+    if require_resolved and unresolved:
+        details = "; ".join(unresolved)
+        raise ValueError(f"Unresolved Toolkit placeholders after materialize: {details}")
+    return dest_dir
+
+
+def load_variables(toolkit_config: Path | None) -> dict[str, str]:
+    """Merge default.config.yaml with an optional Toolkit config.<env>.yaml."""
+    variables = load_default_pack_variables(module_root())
+    if toolkit_config is None:
+        return variables
+    config_path = Path(toolkit_config)
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Toolkit config not found: {config_path}")
+    loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected a mapping in {config_path}")
+    variables.update(flatten_toolkit_variables(loaded))
+    return variables
+
+
+def load_settings_raw(settings_path: Path) -> dict[str, object]:
+    """Load settings.yaml as a plain dict."""
+    data = yaml.safe_load(settings_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a mapping in {settings_path}")
+    return data
+
+
+def data_quality_space(settings_raw: dict[str, object]) -> str:
+    """Resolve DMS space for DataQualitySettings / HistoricJobQueue."""
+    config_space = settings_raw.get("config_space")
+    if config_space:
+        return str(config_space)
+    records = settings_raw.get("records") or {}
+    if isinstance(records, dict) and records.get("space"):
+        return str(records["space"])
+    raise ValueError("settings.yaml must set config_space or records.space for historic enqueue")
+
+
+def function_secrets_from_toml(toml_path: Path, section: str = "cognite") -> dict[str, str] | None:
+    """Build function secret dict from a Toolkit config.toml credentials file."""
+    try:
+        import toml
+    except ImportError:  # pragma: no cover
+        import tomli as toml  # type: ignore[no-redef]
+
+    if not toml_path.is_file():
+        return None
+    data = toml.load(toml_path)
+    cog = data.get(section, data) if section else data
+    if not isinstance(cog, dict):
+        return None
+    client_id = cog.get("client_id")
+    client_secret = cog.get("client_secret")
+    if client_id and client_secret:
+        return {"client-id": str(client_id), "client-secret": str(client_secret)}
+    return None
+
+
+def resolve_function_secrets(config_toml: Path) -> dict[str, str] | None:
+    """Resolve orchestrator function secrets from TOML, then environment variables."""
+    secrets = function_secrets_from_toml(config_toml)
+    if secrets:
+        return secrets
+    client_id = os.getenv("COGNITE_CLIENT_ID") or os.getenv("IDP_CLIENT_ID")
+    client_secret = os.getenv("COGNITE_CLIENT_SECRET") or os.getenv("IDP_CLIENT_SECRET")
+    if client_id and client_secret:
+        return {"client-id": client_id, "client-secret": client_secret}
+    return None
+
+
+def create_client_from_env():
+    """Create a Cognite client from environment variables.
+
+    Matches ``data-quality-validation-deploy/scripts/shared.py:create_client`` and
+    supports Toolkit CI naming (``CDF_*`` / ``IDP_*``) as well as legacy ``COGNITE_*``.
+    """
+    from cognite.client import ClientConfig, CogniteClient
+    from cognite.client.credentials import OAuthClientCredentials
+
+    cluster = os.environ.get("CDF_CLUSTER") or os.environ.get("COGNITE_CLUSTER", "api")
+    project = os.environ.get("CDF_PROJECT") or os.environ.get("COGNITE_PROJECT")
+    client_id = os.environ.get("IDP_CLIENT_ID") or os.environ.get("COGNITE_CLIENT_ID")
+    client_secret = os.environ.get("IDP_CLIENT_SECRET") or os.environ.get("COGNITE_CLIENT_SECRET")
+    base_url = (
+        os.environ.get("CDF_URL")
+        or os.environ.get("COGNITE_BASE_URL")
+        or f"https://{cluster}.cognitedata.com"
+    )
+
+    token_url = os.environ.get("IDP_TOKEN_URL") or os.environ.get("COGNITE_TOKEN_URL")
+    tenant_id = os.environ.get("IDP_TENANT_ID") or os.environ.get("AZURE_TENANT_ID")
+
+    if not all([project, client_id, client_secret]):
+        raise ValueError(
+            "Missing credentials in environment. Set CDF_PROJECT/COGNITE_PROJECT, "
+            "IDP_CLIENT_ID/COGNITE_CLIENT_ID, and IDP_CLIENT_SECRET/COGNITE_CLIENT_SECRET."
+        )
+
+    if token_url:
+        oauth_url = token_url
+    elif tenant_id:
+        oauth_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    else:
+        raise ValueError("Missing IDP_TOKEN_URL, COGNITE_TOKEN_URL, or IDP_TENANT_ID/AZURE_TENANT_ID")
+
+    scopes_env = os.environ.get("IDP_SCOPES")
+    if scopes_env:
+        scopes = [scope.strip() for scope in scopes_env.split() if scope.strip()]
+    else:
+        scopes = [f"https://{cluster}.cognitedata.com/.default"]
+
+    credentials = OAuthClientCredentials(
+        token_url=oauth_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        scopes=scopes,
+    )
+    config = ClientConfig(
+        client_name="dq-toolkit-runtime",
+        project=project,
+        credentials=credentials,
+        base_url=base_url,
+    )
+    return CogniteClient(config)
+
+
+def resolve_cognite_client(config_toml: Path | str):
+    """Load client from optional TOML, otherwise from environment (deploy-repo / CI default)."""
+    path = Path(config_toml)
+    if path.is_file():
+        from cognite_data_quality import load_cognite_client_from_toml
+
+        return load_cognite_client_from_toml(path)
+    return create_client_from_env()
+
+
+@dataclass(frozen=True)
+class MaterializedPack:
+    """Paths to materialized module YAML used by deploy scripts."""
+
+    settings_path: Path
+    views_dir: Path | None
+    timeseries_dir: Path | None
+    variables: dict[str, str]
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    """Add flags shared by deploy_infrastructure.py and deploy_pipeline.py."""
+    parser.add_argument(
+        "--config-toml",
+        default="config.toml",
+        help=(
+            "Optional local TOML credentials file. When missing, uses environment variables "
+            "(COGNITE_* / IDP_* / CDF_* — same as data-quality-validation-deploy and Toolkit CI)"
+        ),
+    )
+    parser.add_argument(
+        "--toolkit-config",
+        default=None,
+        help="Optional Toolkit config.<env>.yaml used to override default.config.yaml placeholders",
+    )
+    parser.add_argument(
+        "--settings-path",
+        default=None,
+        help="Override settings.yaml (already substituted). Skips pack materialize when set.",
+    )
+    parser.add_argument(
+        "--views-dir",
+        default=None,
+        help="Override views directory (already substituted). Used with --settings-path.",
+    )
+    parser.add_argument(
+        "--timeseries-dir",
+        default=None,
+        help="Override timeseries directory (already substituted). Used with --settings-path.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview CDF writes without applying them")
+    parser.add_argument("--force", action="store_true", help="Force redeployment of function and workflows")
+    parser.add_argument("--force-function", action="store_true", help="Force function redeploy only")
+    parser.add_argument("--force-workflows", action="store_true", help="Force workflow redeploy only")
+
+
+def resolve_materialized_pack(args: argparse.Namespace, dest_dir: Path) -> MaterializedPack:
+    """Materialize pack YAML and return settings, views, and timeseries directories."""
+    if args.settings_path:
+        settings_path = Path(args.settings_path)
+        views_dir = Path(args.views_dir) if args.views_dir else None
+        timeseries_dir = Path(args.timeseries_dir) if args.timeseries_dir else None
+        if timeseries_dir is None:
+            candidate = settings_path.parent / "timeseries"
+            timeseries_dir = candidate if candidate.is_dir() else None
+        if views_dir is None:
+            candidate = settings_path.parent / "views"
+            views_dir = candidate if candidate.is_dir() else None
+        return MaterializedPack(settings_path, views_dir, timeseries_dir, {})
+
+    variables = load_variables(Path(args.toolkit_config) if args.toolkit_config else None)
+    materialize_pack_yaml(module_root(), dest_dir, variables)
+    views = dest_dir / "views"
+    timeseries = dest_dir / "timeseries"
+    return MaterializedPack(
+        settings_path=dest_dir / "settings.yaml",
+        views_dir=views if views.is_dir() else None,
+        timeseries_dir=timeseries if timeseries.is_dir() else None,
+        variables=variables,
+    )
+
+
+def resolve_settings_and_views(
+    args: argparse.Namespace, dest_dir: Path
+) -> tuple[Path, Path | None, dict[str, str]]:
+    """Backward-compatible wrapper around :func:`resolve_materialized_pack`."""
+    pack = resolve_materialized_pack(args, dest_dir)
+    return pack.settings_path, pack.views_dir, pack.variables

--- a/modules/common/cdf_dq_runtime/scripts/_cli.py
+++ b/modules/common/cdf_dq_runtime/scripts/_cli.py
@@ -3,14 +3,89 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
 
 _PLACEHOLDER = re.compile(r"\{\{\s*([a-zA-Z0-9_]+)\s*\}\}")
+_ENV_LOADED_FROM: Path | None = None
+
+
+def find_toolkit_project_root(start: Path | None = None) -> Path | None:
+    """Return the nearest ancestor directory that contains ``cdf.toml``."""
+    current = (start or Path.cwd()).resolve()
+    for directory in (current, *current.parents):
+        if (directory / "cdf.toml").is_file():
+            return directory
+    return None
+
+
+def resolve_env_file_path(env_file: Path | str | None = None) -> Path | None:
+    """Resolve a Toolkit ``.env`` file path.
+
+    Resolution order:
+    1. Explicit ``--env-file`` path
+    2. ``.env`` next to ``cdf.toml`` (walk up from cwd)
+    3. Nearest ``.env`` walking up from cwd
+    """
+    if env_file is not None:
+        path = Path(env_file).expanduser().resolve()
+        return path if path.is_file() else None
+
+    project_root = find_toolkit_project_root()
+    if project_root is not None:
+        candidate = project_root / ".env"
+        if candidate.is_file():
+            return candidate
+
+    current = Path.cwd().resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / ".env"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped.removeprefix("export ").lstrip()
+    key, _, value = stripped.partition("=")
+    key = key.strip()
+    if not key:
+        return None
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        value = value[1:-1]
+    return key, value
+
+
+def load_project_env(env_file: Path | str | None = None) -> Path | None:
+    """Load Toolkit ``.env`` values into ``os.environ`` without overriding existing keys."""
+    global _ENV_LOADED_FROM
+    path = resolve_env_file_path(env_file)
+    if path is None:
+        return None
+    if _ENV_LOADED_FROM == path:
+        return path
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parsed = _parse_env_line(line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if key not in os.environ:
+            os.environ[key] = value
+
+    _ENV_LOADED_FROM = path
+    return path
 
 
 def module_root() -> Path:
@@ -257,8 +332,157 @@ class MaterializedPack:
     variables: dict[str, str]
 
 
+def configure_deploy_cli() -> None:
+    """Reduce noisy third-party warnings for operator-facing deploy scripts."""
+    warnings.filterwarnings(
+        "ignore",
+        message=".*httpx module is deprecated.*",
+        category=DeprecationWarning,
+    )
+    warnings.filterwarnings("ignore", module=r"authlib\..*", category=DeprecationWarning)
+    try:
+        from cognite.client.config import global_config
+
+        global_config.disable_pypi_version_check = True
+    except ImportError:
+        pass
+
+
+def print_deploy_context(
+    *,
+    project: str | None,
+    package_version: str,
+    credentials_source: str | None,
+    toolkit_config: Path | str | None,
+    data_product_sync_cron: str | None = None,
+) -> None:
+    """Print a compact pre-deploy context block."""
+    print("Data quality deploy")
+    if project:
+        print(f"  Project:     {project}")
+    print(f"  Package:     cognite-data-quality=={package_version}")
+    if credentials_source:
+        print(f"  Credentials: {credentials_source}")
+    if toolkit_config:
+        print(f"  Toolkit:     {toolkit_config}")
+    if data_product_sync_cron:
+        print(f"  DP sync:     cron {data_product_sync_cron}")
+
+
+def _workflow_status_counts(workflows: list[object]) -> tuple[int, int]:
+    deployed = 0
+    skipped = 0
+    for item in workflows:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status", "")).lower()
+        if status == "deployed":
+            deployed += 1
+        elif status == "skipped":
+            skipped += 1
+    return deployed, skipped
+
+
+def _print_workflow_group(label: str, workflows: list[object]) -> None:
+    if not workflows:
+        return
+    deployed, skipped = _workflow_status_counts(workflows)
+    print(f"\n{label}: {len(workflows)}")
+    print(f"  deployed: {deployed}")
+    if skipped:
+        print(f"  skipped:  {skipped}")
+    for item in workflows:
+        if not isinstance(item, dict):
+            continue
+        workflow_id = item.get("workflow_external_id") or item.get("workflow")
+        trigger = item.get("trigger")
+        status = str(item.get("status", "unknown")).lower()
+        if workflow_id:
+            line = f"  - {workflow_id} ({status})"
+            if trigger:
+                line += f", trigger {trigger}"
+            print(line)
+
+
+def print_infrastructure_summary(results: dict[str, object], *, dry_run: bool = False) -> None:
+    """Print a human-readable deployment summary."""
+    print(f"\n{'=' * 60}")
+    print("DEPLOYMENT SUMMARY")
+    print(f"{'=' * 60}")
+
+    function_results = results.get("functions", {})
+    if isinstance(function_results, dict):
+        func_result = function_results.get("function", {})
+        if isinstance(func_result, dict):
+            name = func_result.get("function", "N/A")
+            status = str(func_result.get("status", "unknown")).lower()
+            print(f"\nFunction: {name} ({status})")
+
+    external = results.get("external_dataproduct_workflows", [])
+    if isinstance(external, list) and external:
+        print("\nExternal DataProducts:")
+        for item in external:
+            if not isinstance(item, dict):
+                continue
+            dp_name = item.get("dataProduct", "unknown")
+            dp_version = item.get("version", "?")
+            status = str(item.get("status", "unknown")).lower()
+            views = item.get("views")
+            views_suffix = f", {views} views" if views is not None else ""
+            print(f"  - {dp_name} @ {dp_version} ({status}{views_suffix})")
+            nested = item.get("workflows", [])
+            if isinstance(nested, list):
+                for workflow in nested:
+                    if not isinstance(workflow, dict):
+                        continue
+                    for key, label in (
+                        ("workflow_external_id", "sync-cursor"),
+                        ("uniqueness_workflow_external_id", "uniqueness"),
+                        ("edge_existence_workflow_external_id", "edge-existence"),
+                    ):
+                        workflow_id = workflow.get(key)
+                        if workflow_id:
+                            print(f"      {label}: {workflow_id}")
+
+    for label, key in (
+        ("Instance workflows", "workflows"),
+        ("Time series workflows", "timeseries_workflows"),
+        ("Rule engine sync", "rule_engine_result_sync_workflows"),
+        ("RAW table workflows", "raw_tables"),
+    ):
+        workflows = results.get(key, [])
+        if isinstance(workflows, list):
+            _print_workflow_group(label, workflows)
+
+    _print_workflow_group("data_product_sync", results.get("data_product_sync", []))
+    _print_workflow_group("historic_queue_manager", results.get("historic_queue_manager", []))
+
+    historic_enqueue = results.get("historic_enqueue")
+    if isinstance(historic_enqueue, dict):
+        print(
+            f"\nHistoric enqueue: {historic_enqueue.get('total_enqueued', 0)} enqueued, "
+            f"{historic_enqueue.get('total_skipped', 0)} skipped"
+        )
+
+    if dry_run:
+        print("\n[DRY RUN] No changes were made")
+
+
+def print_verbose_results(results: dict[str, object]) -> None:
+    """Print full deployment results as formatted JSON."""
+    print(json.dumps(results, indent=2, default=str))
+
+
 def add_common_args(parser: argparse.ArgumentParser) -> None:
     """Add flags shared by deploy_infrastructure.py and deploy_pipeline.py."""
+    parser.add_argument(
+        "--env-file",
+        default=None,
+        help=(
+            "Optional .env file with CDF credentials (default: .env next to cdf.toml, "
+            "or nearest .env walking up from cwd). Existing environment variables win."
+        ),
+    )
     parser.add_argument(
         "--config-toml",
         default="config.toml",
@@ -291,6 +515,11 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--force", action="store_true", help="Force redeployment of function and workflows")
     parser.add_argument("--force-function", action="store_true", help="Force function redeploy only")
     parser.add_argument("--force-workflows", action="store_true", help="Force workflow redeploy only")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print materialized pack paths and full JSON results",
+    )
 
 
 def resolve_materialized_pack(args: argparse.Namespace, dest_dir: Path) -> MaterializedPack:

--- a/modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py
+++ b/modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Deploy data quality validation infrastructure (Toolkit pack).
+
+Mirrors ``data-quality-validation-deploy/scripts/deploy_infrastructure.py``:
+function, instance workflows (via external DataProducts), time-series workflows,
+``data_product_sync``, and historic queue manager.
+
+Install the PyPI pin from ``default.config.yaml`` (``dq_pypi_version``), then::
+
+    python scripts/deploy_infrastructure.py --toolkit-config config.dev.yaml --dry-run
+    python scripts/deploy_infrastructure.py --toolkit-config config.dev.yaml
+    python scripts/deploy_infrastructure.py --toolkit-config config.dev.yaml --enqueue-historic
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from _cli import (
+    add_common_args,
+    data_quality_space,
+    load_settings_raw,
+    resolve_cognite_client,
+    resolve_function_secrets,
+    resolve_materialized_pack,
+)
+
+
+def _print_summary(results: dict[str, object], *, dry_run: bool) -> None:
+    print(f"\n{'=' * 60}")
+    print("DEPLOYMENT SUMMARY")
+    print(f"{'=' * 60}\n")
+
+    function_results = results.get("functions", {})
+    if isinstance(function_results, dict):
+        func_result = function_results.get("function", {})
+        if isinstance(func_result, dict):
+            print(f"Function: {func_result.get('function', 'N/A')}")
+            print(f"  Status: {str(func_result.get('status', 'unknown')).upper()}")
+
+    for label, key in (
+        ("Instance validation (external DataProducts)", "external_dataproduct_workflows"),
+        ("Instance validation", "workflows"),
+    ):
+        workflows = results.get(key, [])
+        if isinstance(workflows, list) and workflows:
+            deployed = sum(1 for w in workflows if isinstance(w, dict) and w.get("status") == "deployed")
+            skipped = sum(1 for w in workflows if isinstance(w, dict) and w.get("status") == "skipped")
+            print(f"\n{label}: {len(workflows)} total")
+            print(f"  Deployed: {deployed}")
+            print(f"  Skipped (up to date): {skipped}")
+
+    ts_workflows = results.get("timeseries_workflows", [])
+    if isinstance(ts_workflows, list) and ts_workflows:
+        deployed_ts = sum(1 for w in ts_workflows if isinstance(w, dict) and w.get("status") == "deployed")
+        skipped_ts = sum(1 for w in ts_workflows if isinstance(w, dict) and w.get("status") == "skipped")
+        print(f"\nTime series validation workflows: {len(ts_workflows)} total")
+        print(f"  Deployed: {deployed_ts}")
+        print(f"  Skipped (up to date): {skipped_ts}")
+
+    dp_sync = results.get("data_product_sync", [])
+    if isinstance(dp_sync, list) and dp_sync:
+        print(f"\ndata_product_sync workflows: {len(dp_sync)}")
+
+    historic_enqueue = results.get("historic_enqueue")
+    if isinstance(historic_enqueue, dict):
+        print(
+            f"\nHistoric enqueue: {historic_enqueue.get('total_enqueued', 0)} enqueued, "
+            f"{historic_enqueue.get('total_skipped', 0)} skipped"
+        )
+
+    if dry_run:
+        print("\n[DRY RUN] No changes were made")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Deploy function, containers, external-DataProduct workflows, and timeseries workflows."""
+    parser = argparse.ArgumentParser(
+        description="Deploy data-quality function, containers, sync workflows, and timeseries validation",
+    )
+    add_common_args(parser)
+    parser.add_argument(
+        "--enqueue-historic",
+        action="store_true",
+        help="Enqueue historic jobs on HistoricJobQueue after deploy (same as deploy repo)",
+    )
+    parser.add_argument("--output", type=str, help="Write JSON deployment results to this file")
+    args = parser.parse_args(argv)
+
+    try:
+        from cognite_data_quality import (
+            deploy_validation_infrastructure,
+            enqueue_historic_validation,
+        )
+    except ModuleNotFoundError:
+        print(
+            "cognite-data-quality is not installed. "
+            "pip install 'cognite-data-quality==<dq_pypi_version from default.config.yaml>'",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        installed_version = version("cognite-data-quality")
+    except PackageNotFoundError:
+        installed_version = "unknown"
+    print(f"Using cognite-data-quality=={installed_version}")
+
+    config_toml = Path(args.config_toml)
+    client = None if args.dry_run else resolve_cognite_client(config_toml)
+    if client is not None:
+        print(f"Connected to project: {client.config.project}")
+
+    function_secrets = resolve_function_secrets(config_toml)
+    if function_secrets:
+        print("Function secrets: configured (orchestrator can create triggers)")
+    else:
+        print("Warning: function secrets missing (orchestrator triggers may fail)")
+        print(
+            "  Set COGNITE_CLIENT_ID/COGNITE_CLIENT_SECRET or IDP_CLIENT_ID/IDP_CLIENT_SECRET "
+            "(or client_id/client_secret in --config-toml for local use)"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="dq-toolkit-pack-") as tmp:
+        pack = resolve_materialized_pack(args, Path(tmp))
+        if not pack.settings_path.is_file():
+            raise FileNotFoundError(f"settings.yaml not found: {pack.settings_path}")
+
+        settings_raw = load_settings_raw(pack.settings_path)
+        print(f"\nsettings_path={pack.settings_path}")
+        if pack.views_dir is not None:
+            print(f"views_dir={pack.views_dir}")
+        if pack.timeseries_dir is not None:
+            print(f"timeseries_dir={pack.timeseries_dir}")
+
+        deploy_kwargs: dict[str, object] = {
+            "client": client,
+            "settings_path": pack.settings_path,
+            "views_dir": pack.views_dir,
+            "timeseries_dir": pack.timeseries_dir,
+            "function_secrets": function_secrets,
+            "force": args.force,
+            "force_workflows": args.force_workflows,
+            "dry_run": args.dry_run,
+        }
+        if args.force_function:
+            deploy_kwargs["force_function"] = True
+
+        if settings_raw.get("config_source") == "dataproduct":
+            dp_sync_cron = settings_raw.get("data_product_sync_cron", "13 * * * *")
+            deploy_kwargs["deploy_data_product_sync"] = True
+            deploy_kwargs["data_product_sync_cron"] = dp_sync_cron
+            print(f"data_product_sync: enabled (cron: {dp_sync_cron})")
+
+        print(f"\n{'=' * 60}")
+        print("DEPLOYING DATA QUALITY VALIDATION INFRASTRUCTURE")
+        print(f"{'=' * 60}\n")
+
+        results = deploy_validation_infrastructure(**deploy_kwargs)
+
+        if args.enqueue_historic and not args.dry_run and client is not None:
+            dq_space = data_quality_space(settings_raw)
+            print(f"\n{'=' * 60}")
+            print("ENQUEUE HISTORIC VALIDATION JOBS")
+            print(f"{'=' * 60}\n")
+            print(f"  data_quality_space: {dq_space}")
+            enqueue_result = enqueue_historic_validation(
+                client,
+                data_quality_space=dq_space,
+                trigger_queue_manager=True,
+            )
+            results["historic_enqueue"] = enqueue_result.to_dict()
+            print(
+                f"  Enqueued: {enqueue_result.total_enqueued}, "
+                f"skipped: {enqueue_result.total_skipped}, "
+                f"warnings: {len(enqueue_result.warnings)}"
+            )
+
+    _print_summary(results, dry_run=args.dry_run)
+
+    if args.output:
+        with Path(args.output).open("w", encoding="utf-8") as handle:
+            json.dump(results, handle, indent=2)
+        print(f"\nResults written to: {args.output}")
+
+    print(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py
+++ b/modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py
@@ -9,7 +9,9 @@ Install the PyPI pin from ``default.config.yaml`` (``dq_pypi_version``), then::
 
     python scripts/deploy_infrastructure.py --toolkit-config config.dev.yaml --dry-run
     python scripts/deploy_infrastructure.py --toolkit-config config.dev.yaml
-    python scripts/deploy_infrastructure.py --toolkit-config config.dev.yaml --enqueue-historic
+
+Credentials are read from the Toolkit project ``.env`` (next to ``cdf.toml``) when present,
+then from environment variables or optional ``--config-toml``.
 """
 
 from __future__ import annotations
@@ -23,63 +25,23 @@ from pathlib import Path
 
 from _cli import (
     add_common_args,
+    configure_deploy_cli,
     data_quality_space,
+    load_project_env,
     load_settings_raw,
+    print_deploy_context,
+    print_infrastructure_summary,
+    print_verbose_results,
     resolve_cognite_client,
     resolve_function_secrets,
     resolve_materialized_pack,
 )
 
 
-def _print_summary(results: dict[str, object], *, dry_run: bool) -> None:
-    print(f"\n{'=' * 60}")
-    print("DEPLOYMENT SUMMARY")
-    print(f"{'=' * 60}\n")
-
-    function_results = results.get("functions", {})
-    if isinstance(function_results, dict):
-        func_result = function_results.get("function", {})
-        if isinstance(func_result, dict):
-            print(f"Function: {func_result.get('function', 'N/A')}")
-            print(f"  Status: {str(func_result.get('status', 'unknown')).upper()}")
-
-    for label, key in (
-        ("Instance validation (external DataProducts)", "external_dataproduct_workflows"),
-        ("Instance validation", "workflows"),
-    ):
-        workflows = results.get(key, [])
-        if isinstance(workflows, list) and workflows:
-            deployed = sum(1 for w in workflows if isinstance(w, dict) and w.get("status") == "deployed")
-            skipped = sum(1 for w in workflows if isinstance(w, dict) and w.get("status") == "skipped")
-            print(f"\n{label}: {len(workflows)} total")
-            print(f"  Deployed: {deployed}")
-            print(f"  Skipped (up to date): {skipped}")
-
-    ts_workflows = results.get("timeseries_workflows", [])
-    if isinstance(ts_workflows, list) and ts_workflows:
-        deployed_ts = sum(1 for w in ts_workflows if isinstance(w, dict) and w.get("status") == "deployed")
-        skipped_ts = sum(1 for w in ts_workflows if isinstance(w, dict) and w.get("status") == "skipped")
-        print(f"\nTime series validation workflows: {len(ts_workflows)} total")
-        print(f"  Deployed: {deployed_ts}")
-        print(f"  Skipped (up to date): {skipped_ts}")
-
-    dp_sync = results.get("data_product_sync", [])
-    if isinstance(dp_sync, list) and dp_sync:
-        print(f"\ndata_product_sync workflows: {len(dp_sync)}")
-
-    historic_enqueue = results.get("historic_enqueue")
-    if isinstance(historic_enqueue, dict):
-        print(
-            f"\nHistoric enqueue: {historic_enqueue.get('total_enqueued', 0)} enqueued, "
-            f"{historic_enqueue.get('total_skipped', 0)} skipped"
-        )
-
-    if dry_run:
-        print("\n[DRY RUN] No changes were made")
-
-
 def main(argv: list[str] | None = None) -> int:
     """Deploy function, containers, external-DataProduct workflows, and timeseries workflows."""
+    configure_deploy_cli()
+
     parser = argparse.ArgumentParser(
         description="Deploy data-quality function, containers, sync workflows, and timeseries validation",
     )
@@ -91,6 +53,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--output", type=str, help="Write JSON deployment results to this file")
     args = parser.parse_args(argv)
+
+    env_path = load_project_env(args.env_file)
+    if args.env_file and env_path is None:
+        print(f"Warning: --env-file not found: {args.env_file}", file=sys.stderr)
 
     try:
         from cognite_data_quality import (
@@ -109,21 +75,18 @@ def main(argv: list[str] | None = None) -> int:
         installed_version = version("cognite-data-quality")
     except PackageNotFoundError:
         installed_version = "unknown"
-    print(f"Using cognite-data-quality=={installed_version}")
 
     config_toml = Path(args.config_toml)
     client = None if args.dry_run else resolve_cognite_client(config_toml)
-    if client is not None:
-        print(f"Connected to project: {client.config.project}")
+    project = client.config.project if client is not None else None
 
     function_secrets = resolve_function_secrets(config_toml)
-    if function_secrets:
-        print("Function secrets: configured (orchestrator can create triggers)")
-    else:
-        print("Warning: function secrets missing (orchestrator triggers may fail)")
+    if not function_secrets:
+        print("Warning: function secrets missing (orchestrator triggers may fail)", file=sys.stderr)
         print(
             "  Set COGNITE_CLIENT_ID/COGNITE_CLIENT_SECRET or IDP_CLIENT_ID/IDP_CLIENT_SECRET "
-            "(or client_id/client_secret in --config-toml for local use)"
+            "(or client_id/client_secret in --config-toml for local use)",
+            file=sys.stderr,
         )
 
     with tempfile.TemporaryDirectory(prefix="dq-toolkit-pack-") as tmp:
@@ -132,11 +95,25 @@ def main(argv: list[str] | None = None) -> int:
             raise FileNotFoundError(f"settings.yaml not found: {pack.settings_path}")
 
         settings_raw = load_settings_raw(pack.settings_path)
-        print(f"\nsettings_path={pack.settings_path}")
-        if pack.views_dir is not None:
-            print(f"views_dir={pack.views_dir}")
-        if pack.timeseries_dir is not None:
-            print(f"timeseries_dir={pack.timeseries_dir}")
+        dp_sync_cron = None
+        if settings_raw.get("config_source") == "dataproduct":
+            dp_sync_cron = str(settings_raw.get("data_product_sync_cron", "13 * * * *"))
+
+        credentials_source = str(env_path) if env_path is not None else None
+        print_deploy_context(
+            project=project,
+            package_version=installed_version,
+            credentials_source=credentials_source,
+            toolkit_config=args.toolkit_config,
+            data_product_sync_cron=dp_sync_cron,
+        )
+
+        if args.verbose:
+            print(f"\nsettings_path={pack.settings_path}")
+            if pack.views_dir is not None:
+                print(f"views_dir={pack.views_dir}")
+            if pack.timeseries_dir is not None:
+                print(f"timeseries_dir={pack.timeseries_dir}")
 
         deploy_kwargs: dict[str, object] = {
             "client": client,
@@ -151,11 +128,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.force_function:
             deploy_kwargs["force_function"] = True
 
-        if settings_raw.get("config_source") == "dataproduct":
-            dp_sync_cron = settings_raw.get("data_product_sync_cron", "13 * * * *")
+        if dp_sync_cron is not None:
             deploy_kwargs["deploy_data_product_sync"] = True
             deploy_kwargs["data_product_sync_cron"] = dp_sync_cron
-            print(f"data_product_sync: enabled (cron: {dp_sync_cron})")
 
         print(f"\n{'=' * 60}")
         print("DEPLOYING DATA QUALITY VALIDATION INFRASTRUCTURE")
@@ -181,14 +156,17 @@ def main(argv: list[str] | None = None) -> int:
                 f"warnings: {len(enqueue_result.warnings)}"
             )
 
-    _print_summary(results, dry_run=args.dry_run)
+    print_infrastructure_summary(results, dry_run=args.dry_run)
 
     if args.output:
         with Path(args.output).open("w", encoding="utf-8") as handle:
-            json.dump(results, handle, indent=2)
+            json.dump(results, handle, indent=2, default=str)
         print(f"\nResults written to: {args.output}")
 
-    print(results)
+    if args.verbose:
+        print()
+        print_verbose_results(results)
+
     return 0
 
 

--- a/modules/common/cdf_dq_runtime/scripts/deploy_pipeline.py
+++ b/modules/common/cdf_dq_runtime/scripts/deploy_pipeline.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Run historic validation after DQS infrastructure is deployed.
+
+Same modes as ``data-quality-validation-deploy`` pipeline helpers::
+
+    python scripts/deploy_pipeline.py --historic-mode enqueue
+    python scripts/deploy_pipeline.py --view-external-id YourOrgAsset --historic-mode orchestrator
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+from _cli import add_common_args, resolve_cognite_client, resolve_materialized_pack
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Enqueue or orchestrate historic validation for DataProduct views."""
+    parser = argparse.ArgumentParser(description="Historic validation pipeline / enqueue")
+    add_common_args(parser)
+    parser.add_argument(
+        "--view-external-id",
+        default=None,
+        help="View external ID to validate. Omit to run all views in the DataProduct.",
+    )
+    parser.add_argument("--view-space", default=None, help="View space when external ID is ambiguous")
+    parser.add_argument(
+        "--data-product-external-id",
+        default=None,
+        help="DataProduct external ID. Defaults to settings.external_dataproducts[0] when omitted.",
+    )
+    parser.add_argument(
+        "--historic-mode",
+        choices=("enqueue", "orchestrator"),
+        default="enqueue",
+        help="enqueue (sequential queue, default) or orchestrator (parallel partitions)",
+    )
+    parser.add_argument(
+        "--trigger-queue-manager",
+        action="store_true",
+        help="Trigger historic_queue_manager after enqueue (enqueue mode only)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        from cognite_data_quality import deploy_validation_pipeline
+        from cognite_data_quality.deploy import load_settings
+    except ModuleNotFoundError:
+        print(
+            "cognite-data-quality is not installed. "
+            "pip install 'cognite-data-quality==<dq_pypi_version from default.config.yaml>'",
+            file=sys.stderr,
+        )
+        return 1
+
+    client = resolve_cognite_client(args.config_toml)
+
+    with tempfile.TemporaryDirectory(prefix="dq-toolkit-pack-") as tmp:
+        pack = resolve_materialized_pack(args, Path(tmp))
+        settings = load_settings(pack.settings_path)
+        data_product_external_id = args.data_product_external_id
+        if not data_product_external_id and settings.external_dataproducts:
+            data_product_external_id = settings.external_dataproducts[0].external_id
+        result = deploy_validation_pipeline(
+            client,
+            settings_path=str(pack.settings_path),
+            view_external_id=args.view_external_id,
+            view_space=args.view_space,
+            data_product_external_id=data_product_external_id,
+            data_quality_space=settings.effective_config_space,
+            historic_mode=args.historic_mode,
+            trigger_queue_manager=args.trigger_queue_manager,
+            wait=args.historic_mode == "orchestrator",
+        )
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/common/cdf_dq_runtime/scripts/deploy_pipeline.py
+++ b/modules/common/cdf_dq_runtime/scripts/deploy_pipeline.py
@@ -10,15 +10,43 @@ Same modes as ``data-quality-validation-deploy`` pipeline helpers::
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 import tempfile
 from pathlib import Path
 
-from _cli import add_common_args, resolve_cognite_client, resolve_materialized_pack
+from _cli import (
+    add_common_args,
+    configure_deploy_cli,
+    load_project_env,
+    print_verbose_results,
+    resolve_cognite_client,
+    resolve_materialized_pack,
+)
+
+
+def _print_pipeline_summary(result: object) -> None:
+    if isinstance(result, dict):
+        print("\nHistoric pipeline")
+        for key in (
+            "status",
+            "historic_mode",
+            "view_external_id",
+            "data_product_external_id",
+            "total_enqueued",
+            "total_skipped",
+            "execution_id",
+        ):
+            if key in result and result[key] is not None:
+                print(f"  {key}: {result[key]}")
+        return
+    print(f"\nHistoric pipeline: {result}")
 
 
 def main(argv: list[str] | None = None) -> int:
     """Enqueue or orchestrate historic validation for DataProduct views."""
+    configure_deploy_cli()
+
     parser = argparse.ArgumentParser(description="Historic validation pipeline / enqueue")
     add_common_args(parser)
     parser.add_argument(
@@ -43,7 +71,10 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Trigger historic_queue_manager after enqueue (enqueue mode only)",
     )
+    parser.add_argument("--output", type=str, help="Write JSON pipeline results to this file")
     args = parser.parse_args(argv)
+
+    load_project_env(args.env_file)
 
     try:
         from cognite_data_quality import deploy_validation_pipeline
@@ -57,6 +88,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     client = resolve_cognite_client(args.config_toml)
+    print(f"Connected to project: {client.config.project}")
 
     with tempfile.TemporaryDirectory(prefix="dq-toolkit-pack-") as tmp:
         pack = resolve_materialized_pack(args, Path(tmp))
@@ -75,7 +107,25 @@ def main(argv: list[str] | None = None) -> int:
             trigger_queue_manager=args.trigger_queue_manager,
             wait=args.historic_mode == "orchestrator",
         )
-    print(result)
+
+    if hasattr(result, "to_dict"):
+        payload = result.to_dict()
+    elif isinstance(result, dict):
+        payload = result
+    else:
+        payload = {"result": str(result)}
+
+    _print_pipeline_summary(payload)
+
+    if args.output:
+        with Path(args.output).open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, default=str)
+        print(f"\nResults written to: {args.output}")
+
+    if args.verbose:
+        print()
+        print_verbose_results(payload)
+
     return 0
 
 

--- a/modules/common/cdf_dq_runtime/settings.yaml
+++ b/modules/common/cdf_dq_runtime/settings.yaml
@@ -1,0 +1,43 @@
+# Runtime settings for deploy_validation_infrastructure().
+# Mirrors config/environments/cog-ai/settings.yaml in data-quality-validation-deploy.
+# RuleSets and DataProducts are published by Toolkit (cdf deploy); this file lists
+# them as external_dataproducts so Python deploy does not republish.
+
+workflow:
+  external_id_prefix: dq-shacl
+  version: "1"
+  task:
+    retries: 3
+    timeout: 600
+    on_failure: abortWorkflow
+
+timeseries_workflow:
+  external_id_prefix: dq-ts-shacl
+  version: "1"
+  task:
+    retries: 3
+    timeout: 1800
+    on_failure: abortWorkflow
+
+trigger:
+  external_id_prefix: dq-shacl-trigger
+  batch_size: 10
+  batch_timeout: 60
+
+records:
+  space: dataQuality
+  stream_id: test_stream_1
+
+config_space: dataQuality
+
+function_code_dataset_external_id: dq_shacl_rules
+
+config_source: dataproduct
+data_product_sync_cron: "13 * * * *"
+
+timeseries:
+  config_dir: timeseries
+
+external_dataproducts:
+  - external_id: enterprise-process-industry
+    version: "1.1.10"

--- a/modules/common/cdf_dq_runtime/timeseries/yourorg_timeseries_quality.yaml
+++ b/modules/common/cdf_dq_runtime/timeseries/yourorg_timeseries_quality.yaml
@@ -1,0 +1,29 @@
+# data-quality-validation-deploy/config/environments/cog-ai/timeseries/yourorg_timeseries_quality.yaml
+# SHACL is published by Toolkit (timeseries_quality_rules RuleSet).
+
+name: yourorg_timeseries_quality
+description: "YourOrgTimeSeries datapoint quality rules (hourly)"
+
+schedule:
+  cron: "2 * * * *"
+
+filter:
+  space: springfield_instances
+  external_id_prefix: "pi:"
+
+datamodel:
+  space: sp_enterprise_process_industry
+  external_id: YourOrgTimeSeries
+  version: v1
+
+shacl_rules:
+  ruleset_references:
+    - externalId: timeseries_quality_rules
+      version: "1.0.0"
+
+validation:
+  verbose: true
+
+records:
+  rule_set_id: YourOrgTimeSeriesSHACL
+  rule_set_version: "1.1.9"

--- a/modules/common/cdf_dq_runtime/views/yourorg_asset.yaml
+++ b/modules/common/cdf_dq_runtime/views/yourorg_asset.yaml
@@ -1,0 +1,14 @@
+view:
+  space: sp_enterprise_process_industry
+  external_id: YourOrgAsset
+  version: v1
+instance_spaces:
+  - springfield_instances
+validation:
+  auto_load_depth: 2
+  verbose: true
+partition_count: 10
+partition_field: lastUpdatedTime
+sync_batch_size: 1000
+use_sync_cursor_mode: true
+max_concurrent_executions: 1

--- a/modules/common/cdf_dq_runtime/views/yourorg_equipment.yaml
+++ b/modules/common/cdf_dq_runtime/views/yourorg_equipment.yaml
@@ -1,0 +1,16 @@
+view:
+  space: sp_enterprise_process_industry
+  external_id: YourOrgEquipment
+  version: v1
+instance_spaces:
+  - springfield_instances
+validation:
+  auto_load_depth: 2
+  verbose: true
+partition_count: 10
+partition_field: lastUpdatedTime
+chunk_size: 100
+sync_batch_size: 1000
+use_sync_cursor_mode: true
+max_concurrent_executions: 1
+uniqueness_cron: "0 */4 * * *"

--- a/modules/common/cdf_dq_runtime/views/yourorg_maintenance_order.yaml
+++ b/modules/common/cdf_dq_runtime/views/yourorg_maintenance_order.yaml
@@ -1,0 +1,15 @@
+view:
+  space: sp_enterprise_process_industry
+  external_id: YourOrgMaintenanceOrder
+  version: v1
+instance_spaces:
+  - test_data_pumps
+validation:
+  auto_load_depth: 2
+  verbose: true
+partition_count: 10
+partition_field: lastUpdatedTime
+sync_batch_size: 1000
+use_sync_cursor_mode: true
+max_concurrent_executions: 1
+uniqueness_cron: "2 * * * *"

--- a/modules/common/cdf_dq_runtime/views/yourorg_maintenance_order_rule_logic_test.yaml
+++ b/modules/common/cdf_dq_runtime/views/yourorg_maintenance_order_rule_logic_test.yaml
@@ -1,0 +1,16 @@
+view:
+  space: sp_enterprise_process_industry
+  external_id: YourOrgMaintenanceOrder
+  version: v1
+instance_spaces:
+  - springfield_instances
+validation:
+  auto_load_depth: 2
+  verbose: true
+partition_count: 10
+partition_field: lastUpdatedTime
+sync_batch_size: 1000
+use_sync_cursor_mode: true
+max_concurrent_executions: 1
+workflow_external_id: dq-shacl-yourorgmaintenanceorder-rule-logic-test
+trigger_external_id: dq-shacl-trigger-yourorgmaintenanceorder-rule-logic-test

--- a/modules/common/cdf_dq_runtime/views/yourorg_notification.yaml
+++ b/modules/common/cdf_dq_runtime/views/yourorg_notification.yaml
@@ -1,0 +1,14 @@
+view:
+  space: sp_enterprise_process_industry
+  external_id: YourOrgNotification
+  version: v1
+instance_spaces:
+  - test_data_pumps
+validation:
+  auto_load_depth: 2
+  verbose: true
+partition_count: 10
+partition_field: lastUpdatedTime
+sync_batch_size: 1000
+use_sync_cursor_mode: true
+max_concurrent_executions: 1

--- a/modules/common/cdf_dq_runtime/views/yourorg_operation.yaml
+++ b/modules/common/cdf_dq_runtime/views/yourorg_operation.yaml
@@ -1,0 +1,14 @@
+view:
+  space: sp_enterprise_process_industry
+  external_id: YourOrgOperation
+  version: v1
+instance_spaces:
+  - test_data_pumps
+validation:
+  auto_load_depth: 2
+  verbose: true
+partition_count: 10
+partition_field: lastUpdatedTime
+sync_batch_size: 1000
+use_sync_cursor_mode: true
+max_concurrent_executions: 1

--- a/modules/packages.toml
+++ b/modules/packages.toml
@@ -136,6 +136,15 @@ modules = [
     "dashboards/context_quality",
 ]
 
+[packages.data_quality]
+id = "dp:data_quality"
+title = "Data Quality Validation"
+description = "Data quality validation for Data Products."
+canCherryPick = true
+modules = [
+    "common/cdf_dq_runtime",
+]
+
 [packages.tools]
 id = "tool"
 title = "Tools and Accelerators"

--- a/tests/test_cdf_dq_runtime.py
+++ b/tests/test_cdf_dq_runtime.py
@@ -1,0 +1,80 @@
+"""Tests for the Data Quality Toolkit module scripts."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = (
+    Path(__file__).resolve().parents[1] / "modules" / "common" / "cdf_dq_runtime" / "scripts"
+)
+_MODULE = _SCRIPTS.parent
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location("cdf_dq_runtime_cli", _SCRIPTS / "_cli.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def cli():
+    return _load_cli()
+
+
+def test_flatten_keeps_global_and_module_variables(cli) -> None:
+    config = {
+        "variables": {
+            "global_var": "global_val",
+            "modules": {
+                "data_quality": {
+                    "cdf_dq_runtime": {
+                        "dq_pypi_version": "0.4.9",
+                    }
+                }
+            },
+        }
+    }
+    flat = cli.flatten_toolkit_variables(config)
+    assert flat["global_var"] == "global_val"
+    assert flat["dq_pypi_version"] == "0.4.9"
+
+
+def test_materialize_cog_ai_yourorg_sample(cli, tmp_path: Path) -> None:
+    variables = cli.load_default_pack_variables(_MODULE)
+    assert variables == {"dq_pypi_version": "0.4.9"}
+    dest = cli.materialize_pack_yaml(_MODULE, tmp_path / "out", variables)
+    settings = (dest / "settings.yaml").read_text(encoding="utf-8")
+    assert "enterprise-process-industry" in settings
+    assert "timeseries:" in settings
+    assert "data_product_sync_cron" in settings
+    assert "dq-ts-shacl" in settings
+    assert "{{" not in settings
+    version_yaml = (
+        dest / "data_products" / "enterprise_process_industry.DataProductVersion.yaml"
+    ).read_text(encoding="utf-8")
+    for view in (
+        "YourOrgAsset",
+        "YourOrgEquipment",
+        "YourOrgMaintenanceOrder",
+        "YourOrgNotification",
+        "YourOrgOperation",
+        "YourOrgTimeSeries",
+    ):
+        assert view in version_yaml
+    assert len(list((dest / "views").glob("yourorg_*.yaml"))) == 6
+    assert (dest / "timeseries" / "yourorg_timeseries_quality.yaml").is_file()
+    assert not (dest / "timeseries" / "demo_timeseries_quality.yaml").exists()
+    ts_yaml = (dest / "timeseries" / "yourorg_timeseries_quality.yaml").read_text(encoding="utf-8")
+    assert "ruleset_references" in ts_yaml
+
+
+def test_data_quality_space_from_settings(cli, tmp_path: Path) -> None:
+    settings = tmp_path / "settings.yaml"
+    settings.write_text("config_space: dataQuality\n", encoding="utf-8")
+    assert cli.data_quality_space(cli.load_settings_raw(settings)) == "dataQuality"

--- a/tests/test_cdf_dq_runtime.py
+++ b/tests/test_cdf_dq_runtime.py
@@ -1,6 +1,7 @@
 """Tests for the Data Quality Toolkit module scripts."""
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -24,7 +25,9 @@ def _load_cli():
 
 @pytest.fixture
 def cli():
-    return _load_cli()
+    module = _load_cli()
+    module._ENV_LOADED_FROM = None
+    return module
 
 
 def test_flatten_keeps_global_and_module_variables(cli) -> None:
@@ -78,3 +81,72 @@ def test_data_quality_space_from_settings(cli, tmp_path: Path) -> None:
     settings = tmp_path / "settings.yaml"
     settings.write_text("config_space: dataQuality\n", encoding="utf-8")
     assert cli.data_quality_space(cli.load_settings_raw(settings)) == "dataQuality"
+
+
+def test_load_project_env_uses_cdf_toml_root(cli, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    project = tmp_path / "toolkit-project"
+    project.mkdir()
+    (project / "cdf.toml").write_text("[cdf]\n", encoding="utf-8")
+    (project / ".env").write_text(
+        "CDF_PROJECT=from-env\nIDP_CLIENT_ID=client-id\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("CDF_PROJECT", raising=False)
+    monkeypatch.setenv("IDP_CLIENT_ID", "already-set")
+
+    loaded = cli.load_project_env()
+    assert loaded == project / ".env"
+    assert os.environ["CDF_PROJECT"] == "from-env"
+    assert os.environ["IDP_CLIENT_ID"] == "already-set"
+
+
+def test_load_project_env_honors_explicit_path(cli, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env_file = tmp_path / "custom.env"
+    env_file.write_text("COGNITE_PROJECT=custom-project\n", encoding="utf-8")
+    monkeypatch.delenv("COGNITE_PROJECT", raising=False)
+
+    loaded = cli.load_project_env(env_file)
+    assert loaded == env_file.resolve()
+    assert os.environ["COGNITE_PROJECT"] == "custom-project"
+
+
+def test_print_infrastructure_summary_formats_external_dataproducts(cli, capsys) -> None:
+    results = {
+        "functions": {"function": {"function": "data-quality-validation", "status": "deployed"}},
+        "external_dataproduct_workflows": [
+            {
+                "dataProduct": "enterprise-process-industry",
+                "version": "1.1.10",
+                "status": "deployed",
+                "views": 5,
+                "workflows": [
+                    {
+                        "workflow_external_id": "dq-shacl-enterprise-process-industry",
+                        "uniqueness_workflow_external_id": "dq-shacl-enterprise-process-industry-uniqueness",
+                        "edge_existence_workflow_external_id": "dq-shacl-enterprise-process-industry-edge-existence",
+                    }
+                ],
+            }
+        ],
+        "data_product_sync": [
+            {
+                "workflow_external_id": "dq-data-product-sync",
+                "trigger": "dq-data-product-sync-trigger",
+                "status": "deployed",
+            }
+        ],
+        "historic_queue_manager": [
+            {
+                "workflow_external_id": "dq-historic-queue-manager",
+                "trigger": "dq-historic-queue-manager-trigger",
+                "status": "deployed",
+            }
+        ],
+    }
+    cli.print_infrastructure_summary(results)
+    output = capsys.readouterr().out
+    assert "enterprise-process-industry @ 1.1.10" in output
+    assert "sync-cursor: dq-shacl-enterprise-process-industry" in output
+    assert "dq-data-product-sync (deployed)" in output
+    assert "dq-historic-queue-manager (deployed)" in output


### PR DESCRIPTION
## Summary

Add a cherry-pickable Cognite Toolkit pack (`dp:data_quality` / `cdf_dq_runtime`) so Data Quality Validation can be added with `cdf modules add`, the same path as Foundation and Qualitizer.

- **Toolkit `cdf deploy`:** dedicated schema space, RuleSet / RuleSetVersion (SHACL), DataProduct / DataProductVersion (`views` + `quality.rules`, `status: published`).
- **Module scripts:** `deploy_infrastructure.py` calls `deploy_validation_infrastructure()` with `external_dataproducts` so Toolkit-owned products are not republished. `deploy_pipeline.py` handles historic enqueue.
- **Function handlers stay on PyPI** (`cognite-data-quality==dq_pypi_version`). There is no Toolkit `functions/` copy of handler code.
- **Engine pin:** `dq_pypi_version` in `default.config.yaml`. Historic `--force` (enqueue only) matches cognite-data-quality 0.4.11.

Requires Toolkit `>= 0.7.207` and `[alpha_flags] data-products = true`.

Engine: [cognitedata/data-quality-validation](https://github.com/cognitedata/data-quality-validation). This supersedes packaging as an ISC offering repo (data-quality-validation#363).

## Operator flow

```text
cdf modules add dp:data_quality
# edit config.<env>.yaml
cdf build && cdf deploy
pip install "cognite-data-quality==<dq_pypi_version>"
python modules/common/cdf_dq_runtime/scripts/deploy_infrastructure.py --toolkit-config config.dev.yaml
```

`<dq_pypi_version>` comes from `default.config.yaml` (copied into `config.<env>.yaml`).

## Test plan

- [ ] `python validate_packages.py` (CI)
- [ ] `uv run pytest tests/test_cdf_dq_runtime.py`
- [ ] Confirm `cdf modules add` lists **Data Quality Validation** (`dp:data_quality`) after this pack is in a library release
- [ ] `cdf build && cdf deploy --dry-run` in a Toolkit project with `data-products = true`
- [ ] `deploy_infrastructure.py --dry-run` after installing `cognite-data-quality` at `dq_pypi_version`

Made with [Cursor](https://cursor.com)