### PR TITLE
[AT-115] (fix): Pin foundation DP Github actions from versions to SHA digest 🕵🏻‍♂️

### DIFF
--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -36,7 +36,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
       - name: Remove local .env
         run: rm -f .env
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -28,12 +28,12 @@ jobs:
       PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}
       IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Remove local .env
         run: rm -f .env
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -34,9 +34,9 @@ jobs:
     name: Lint (workflow YAML)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
@@ -120,12 +120,12 @@ jobs:
       PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}
       IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Remove local .env
         run: rm -f .env
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
 
@@ -146,7 +146,7 @@ jobs:
 
       - name: Comment PR with dry-run output
         if: always() && github.event_name == 'pull_request' && (steps.build.outcome == 'success' || steps.build.outcome == 'failure')
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -463,6 +463,26 @@ environment:
     )
 
 
+def test_generate_actions_force_regenerates_tag_pinned_workflows_to_digests(tmp_path: Path) -> None:
+    """An existing customer repo generated before actions were digest-pinned must get
+    digest-pinned workflows after re-running the generator with --force."""
+    _scaffold_dev_only_project(tmp_path)
+    workflows_dir = tmp_path / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    (workflows_dir / "dry-run.yml").write_text(
+        "        - uses: actions/checkout@v4\n        - uses: actions/setup-python@v5\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run([sys.executable, str(GENERATE_ACTIONS), "--force"], check=True, cwd=tmp_path)
+
+    regenerated = (workflows_dir / "dry-run.yml").read_text(encoding="utf-8")
+    assert "actions/checkout@v4\n" not in regenerated
+    assert "actions/setup-python@v5\n" not in regenerated
+    assert "actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4" in regenerated
+    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5" in regenerated
+
+
 def test_generate_actions_explicit_provider_github_is_byte_identical_to_default(tmp_path: Path) -> None:
     default_dir = tmp_path / "default"
     explicit_dir = tmp_path / "explicit"


### PR DESCRIPTION
- Pins `actions/checkout`, `actions/setup-python`, and `actions/github-script` to SHA digests (with `# vX` comments) in the Foundation Deployment Pack's workflow templates (`deploy.yml`, `deploy-prod.yml`, `dry-run.yml`), closing the tag-mutation supply-chain risk flagged by Security ahead of the Sep 7 enforcement deadline.

- Existing customer repos generated before this fix are unaffected until someone re-runs `generate_actions.py --force` in that repo and this will update the `vX` version tagging to SHA digests.

## Test plan

- [x] `uv run pytest tests/test_foundation_cicd_generator.py -q` — 16 passed, including a new test (`test_generate_actions_force_regenerates_tag_pinned_workflows_to_digests`) that simulates an existing customer repo with old tag-pinned workflows and asserts `--force` regenerates them as digest-pinned.
- [x] `uv run pytest -q` — full suite, 249 passed.