### PR TITLE
fix(foundation-cicd): lint only team-authored function code

### DIFF
--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -154,7 +154,7 @@ def function_lint_exclude(repo_root: Path, org_dir: str | None) -> str:
     their requirements.txt files would otherwise be installed on every PR.
     """
     modules_root = resolve_modules_root(repo_root, org_dir).relative_to(repo_root).as_posix()
-    return f"{modules_root}/({'|'.join(PACK_MODULE_DOMAINS)})/"
+    return f"^{modules_root}/({'|'.join(PACK_MODULE_DOMAINS)})/"
 
 
 def parse_version(version: str) -> tuple[int, int, int]:

--- a/modules/common/cdf_project_foundation/scripts/generate_actions.py
+++ b/modules/common/cdf_project_foundation/scripts/generate_actions.py
@@ -39,6 +39,19 @@ DEPLOY_BRANCHES = {"dev": "dev", "test": "main"}
 ENV_LABELS = {"dev": "Dev", "test": "Test"}
 CONFIG_FLAG_MIN_VERSION = (0, 8, 0)
 
+# Module domains vendored in by the deployment packs. modules/custom/ is deliberately
+# absent — that is where team-authored modules live, and their code must stay linted.
+PACK_MODULE_DOMAINS = (
+    "atlas_ai",
+    "common",
+    "contextualization",
+    "dashboards",
+    "datamodels",
+    "solutions",
+    "sourcesystem",
+    "tools",
+)
+
 PROVIDERS = ("github", "ado")
 DEFAULT_PROVIDER = "github"
 PROVIDER_WORKFLOWS_DIR = {
@@ -131,6 +144,17 @@ def build_lint_paths(org_dir: str | None, provider: str) -> str:
     else:
         entries.insert(0, "'config*.yaml'")
     return " \\\n            ".join(entries)
+
+
+def function_lint_exclude(repo_root: Path, org_dir: str | None) -> str:
+    """Extended-regex alternation matching every vendored pack module tree.
+
+    ruff and pyright should only judge code the team wrote. Modules installed by a
+    deployment pack ship function code the destination repository cannot fix, and
+    their requirements.txt files would otherwise be installed on every PR.
+    """
+    modules_root = resolve_modules_root(repo_root, org_dir).relative_to(repo_root).as_posix()
+    return f"{modules_root}/({'|'.join(PACK_MODULE_DOMAINS)})/"
 
 
 def parse_version(version: str) -> tuple[int, int, int]:
@@ -925,6 +949,7 @@ def main() -> None:
         "TOOLKIT_VERSION": str(toolkit_version),
         "LINT_PATHS": build_lint_paths(org_dir, args.provider),
         "SETUP_PROJECT_CHECK_CMD": setup_check_cmd,
+        "FUNCTION_LINT_EXCLUDE": function_lint_exclude(repo_root, org_dir),
     }
 
     if args.provider == "github":

--- a/modules/common/cdf_project_foundation/templates/ado/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/ado/FOUNDATION_CICD.md
@@ -81,10 +81,11 @@ CI validates the committed configs as-is; it does not regenerate them.
 If the repository does not have a root `.pre-commit-config.yaml`, the generated
 PR pipeline skips the pre-commit config lint step.
 
-If any CDF Function under a `functions/` folder has Python source, the PR pipeline
-also runs `ruff check` and `pyright` against it, installing each function's
-`requirements.txt` first so imports resolve. Projects with no `functions/` Python
-code skip this step.
+If a team-authored module has Python source under a `functions/` folder, the PR pipeline
+also runs `ruff check` and `pyright` against it, installing that function's
+`requirements.txt` first so imports resolve. Modules installed by a deployment pack are
+excluded — their code is not the team's to fix — so a project whose only functions come
+from packs skips this step.
 
 ## Regenerate pipelines
 

--- a/modules/common/cdf_project_foundation/templates/ado/dry-run-pipeline.yml
+++ b/modules/common/cdf_project_foundation/templates/ado/dry-run-pipeline.yml
@@ -50,13 +50,14 @@ jobs:
 
       - bash: |
           set -euo pipefail
-          mapfile -t PY_FILES < <(git ls-files | grep -E '/functions/.*\.py$' || true)
+          EXCLUDE='{{FUNCTION_LINT_EXCLUDE}}'
+          mapfile -t PY_FILES < <(git ls-files | grep -E '/functions/.*\.py$' | grep -Ev "$EXCLUDE" || true)
           if [ "${#PY_FILES[@]}" -eq 0 ]; then
-            echo "No Python found under functions/; skipping ruff and pyright."
+            echo "No team-authored Python under functions/; skipping ruff and pyright."
             exit 0
           fi
           pip install ruff pyright
-          mapfile -t REQS < <(git ls-files | grep -E '/functions/.*requirements\.txt$' || true)
+          mapfile -t REQS < <(git ls-files | grep -E '/functions/.*requirements\.txt$' | grep -Ev "$EXCLUDE" || true)
           for req in "${REQS[@]}"; do
             pip install -r "$req"
           done

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -62,10 +62,11 @@ CI validates the committed configs as-is; it does not regenerate them.
 If the repository does not have a root `.pre-commit-config.yaml`, the generated
 PR workflow skips the pre-commit config lint step.
 
-If any CDF Function under a `functions/` folder has Python source, the PR workflow
-also runs `ruff check` and `pyright` against it, installing each function's
-`requirements.txt` first so imports resolve. Projects with no `functions/` Python
-code skip this step.
+If a team-authored module has Python source under a `functions/` folder, the PR workflow
+also runs `ruff check` and `pyright` against it, installing that function's
+`requirements.txt` first so imports resolve. Modules installed by a deployment pack are
+excluded — their code is not the team's to fix — so a project whose only functions come
+from packs skips this step.
 
 ## Regenerate workflows
 

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -76,13 +76,14 @@ jobs:
       - name: Lint functions (ruff, pyright)
         run: |
           set -euo pipefail
-          mapfile -t PY_FILES < <(git ls-files | grep -E '/functions/.*\.py$' || true)
+          EXCLUDE='{{FUNCTION_LINT_EXCLUDE}}'
+          mapfile -t PY_FILES < <(git ls-files | grep -E '/functions/.*\.py$' | grep -Ev "$EXCLUDE" || true)
           if [ "${#PY_FILES[@]}" -eq 0 ]; then
-            echo "No Python found under functions/; skipping ruff and pyright."
+            echo "No team-authored Python under functions/; skipping ruff and pyright."
             exit 0
           fi
           pip install ruff pyright
-          mapfile -t REQS < <(git ls-files | grep -E '/functions/.*requirements\.txt$' || true)
+          mapfile -t REQS < <(git ls-files | grep -E '/functions/.*requirements\.txt$' | grep -Ev "$EXCLUDE" || true)
           for req in "${REQS[@]}"; do
             pip install -r "$req"
           done

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -107,7 +107,12 @@ environment:
     assert "No .pre-commit-config.yaml found; skipping pre-commit config lint." in dry_run
     assert "ruff check" in dry_run
     assert "pyright --pythonversion 3.13" in dry_run
-    assert "No Python found under functions/; skipping ruff and pyright." in dry_run
+    assert "No team-authored Python under functions/; skipping ruff and pyright." in dry_run
+    # Vendored pack modules are excluded from ruff/pyright; modules/custom/ — where
+    # team-authored modules live — must stay linted.
+    assert "EXCLUDE='industrial/modules/(atlas_ai|" in dry_run
+    assert "|sourcesystem|tools)/'" in dry_run
+    assert "custom" not in dry_run
     assert "cdf build --env dev" in dry_run
     assert "cdf deploy --dry-run | tee dryrun-output.txt" in dry_run
     assert "cdf deploy --dry-run --env" not in dry_run
@@ -635,6 +640,11 @@ def test_generate_actions_ado_writes_pipelines_and_docs(tmp_path: Path) -> None:
     assert "IDP_CLIENT_SECRET" not in dry_run_text
     assert "cdf deploy --dry-run" not in dry_run_text
     assert "cdf build" in dry_run_text
+    # The lint step is shared with the GitHub template: vendored pack modules are
+    # excluded from ruff/pyright, modules/custom/ is not.
+    assert "No team-authored Python under functions/; skipping ruff and pyright." in dry_run_text
+    assert "EXCLUDE='modules/(atlas_ai|" in dry_run_text
+    assert "custom" not in dry_run_text
     # Azure's script: task runs cmd.exe on a Windows agent; these scripts rely on
     # bash-only syntax ([[ ]], set -euo pipefail), so they must use bash: instead.
     assert "- script:" not in dry_run_text
@@ -1009,3 +1019,28 @@ def test_setup_project_check_cmd_modules_nested_under_org_dir(tmp_path: Path) ->
 
     cmd = generate_actions.setup_project_check_cmd(tmp_path, "industrial")
     assert cmd == "python industrial/modules/common/cdf_project_foundation/scripts/setup_project.py --check"
+
+
+def test_function_lint_exclude_org_dir_set_but_modules_at_repo_root(tmp_path: Path) -> None:
+    """Same trap as setup_project_check_cmd: org_dir in cdf.toml doesn't mean
+    modules/ is nested under it. A blindly prefixed exclude would match nothing
+    and lint the vendored pack modules anyway."""
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    _make_foundation_module(tmp_path / "modules")
+
+    exclude = generate_actions.function_lint_exclude(tmp_path, "industrial")
+    assert exclude == "modules/(atlas_ai|common|contextualization|dashboards|datamodels|solutions|sourcesystem|tools)/"
+    assert "custom" not in exclude
+
+
+def test_function_lint_exclude_modules_nested_under_org_dir(tmp_path: Path) -> None:
+    sys.path.insert(0, str(MODULE_ROOT / "scripts"))
+    import generate_actions  # pyright: ignore[reportMissingImports]
+
+    _make_foundation_module(tmp_path / "industrial" / "modules")
+
+    exclude = generate_actions.function_lint_exclude(tmp_path, "industrial")
+    assert exclude.startswith("industrial/modules/(atlas_ai|")
+    assert exclude.endswith("|sourcesystem|tools)/")

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -110,7 +110,7 @@ environment:
     assert "No team-authored Python under functions/; skipping ruff and pyright." in dry_run
     # Vendored pack modules are excluded from ruff/pyright; modules/custom/ — where
     # team-authored modules live — must stay linted.
-    assert "EXCLUDE='industrial/modules/(atlas_ai|" in dry_run
+    assert "EXCLUDE='^industrial/modules/(atlas_ai|" in dry_run
     assert "|sourcesystem|tools)/'" in dry_run
     assert "custom" not in dry_run
     assert "cdf build --env dev" in dry_run
@@ -643,7 +643,7 @@ def test_generate_actions_ado_writes_pipelines_and_docs(tmp_path: Path) -> None:
     # The lint step is shared with the GitHub template: vendored pack modules are
     # excluded from ruff/pyright, modules/custom/ is not.
     assert "No team-authored Python under functions/; skipping ruff and pyright." in dry_run_text
-    assert "EXCLUDE='modules/(atlas_ai|" in dry_run_text
+    assert "EXCLUDE='^modules/(atlas_ai|" in dry_run_text
     assert "custom" not in dry_run_text
     # Azure's script: task runs cmd.exe on a Windows agent; these scripts rely on
     # bash-only syntax ([[ ]], set -euo pipefail), so they must use bash: instead.
@@ -1031,7 +1031,7 @@ def test_function_lint_exclude_org_dir_set_but_modules_at_repo_root(tmp_path: Pa
     _make_foundation_module(tmp_path / "modules")
 
     exclude = generate_actions.function_lint_exclude(tmp_path, "industrial")
-    assert exclude == "modules/(atlas_ai|common|contextualization|dashboards|datamodels|solutions|sourcesystem|tools)/"
+    assert exclude == "^modules/(atlas_ai|common|contextualization|dashboards|datamodels|solutions|sourcesystem|tools)/"
     assert "custom" not in exclude
 
 
@@ -1042,5 +1042,5 @@ def test_function_lint_exclude_modules_nested_under_org_dir(tmp_path: Path) -> N
     _make_foundation_module(tmp_path / "industrial" / "modules")
 
     exclude = generate_actions.function_lint_exclude(tmp_path, "industrial")
-    assert exclude.startswith("industrial/modules/(atlas_ai|")
+    assert exclude.startswith("^industrial/modules/(atlas_ai|")
     assert exclude.endswith("|sourcesystem|tools)/")


### PR DESCRIPTION
The PR lint step ran ruff and pyright over every */functions/*.py in the repository, including the deployment-pack modules and pip-installed each of their requirements.txt files on every run. Both globs now exclude the vendored pack module trees; modules/custom/, where team-authored modules live, stays linted.

The exclude is built off resolve_modules_root so it works whether modules/ sits at the repo root or under the organization directory.