### PR TITLE
feat(foundation-cicd): pass PROVIDER to workflows 

### DIFF
--- a/modules/common/cdf_project_foundation/templates/ado/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/ado/FOUNDATION_CICD.md
@@ -43,8 +43,8 @@ Each `-toolkit-config` group needs these **variables**:
 - `CDF_CLUSTER`
 - `CDF_PROJECT` (must match `config.<env>.yaml`)
 - `LOGIN_FLOW` (typically `client_credentials`)
+- `PROVIDER` (only for a non-Entra identity provider — see below)
 - `IDP_TENANT_ID`
-- `IDP_TOKEN_URL` — token URL for non-Entra identity providers; for Entra ID, use the standard Entra configuration and `IDP_TENANT_ID`.
 - `IDP_CLIENT_ID`
 - `ADMIN_SOURCE_ID`
 - `CONSUMER_SOURCE_ID`
@@ -53,6 +53,21 @@ Each `-toolkit-config` group needs these **variables**:
 Each `-toolkit-credentials` group needs only this **secret** (mark it secret in the Library UI):
 
 - `IDP_CLIENT_SECRET`
+
+### Identity provider
+
+`PROVIDER` tells the Toolkit which identity provider to authenticate against. Leave it out
+of the group for Entra ID — the Toolkit already defaults to `entra_id`.
+
+| Identity provider | `PROVIDER` | `IDP_TENANT_ID` | `IDP_TOKEN_URL` |
+|-------------------|------------|-----------------|-----------------|
+| Microsoft Entra ID | `entra_id` (or unset) | required | not used |
+| Cognite IdP (CogIdP) | `cdf` | not used | not used — the Toolkit authenticates against `https://auth.cognite.com/oauth2/token` |
+| Other OIDC provider | `other` | not used | required, together with `IDP_AUDIENCE` |
+
+Azure DevOps exports every non-secret variable-group value to the pipeline, so the third row
+needs no pipeline change: add `IDP_TOKEN_URL` and `IDP_AUDIENCE` to the `-toolkit-config`
+group and they reach `cdf build` and `cdf deploy` on their own.
 
 ## Pipelines to register
 

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -35,6 +35,7 @@ Each environment needs these **variables**:
 - `CDF_CLUSTER`
 - `CDF_PROJECT` (must match `config.<env>.yaml`)
 - `LOGIN_FLOW` (typically `client_credentials`)
+- `PROVIDER` (only for a non-Entra identity provider — see below)
 - `IDP_TENANT_ID`
 - `IDP_CLIENT_ID`
 - `ADMIN_SOURCE_ID`
@@ -44,6 +45,21 @@ Each environment needs these **variables**:
 And this **secret**:
 
 - `IDP_CLIENT_SECRET`
+
+### Identity provider
+
+`PROVIDER` tells the Toolkit which identity provider to authenticate against. The generated
+workflows default it to `entra_id`, so Entra ID projects can leave the variable unset.
+
+| Identity provider | `PROVIDER` | `IDP_TENANT_ID` | `IDP_TOKEN_URL` |
+|-------------------|------------|-----------------|-----------------|
+| Microsoft Entra ID | `entra_id` (or unset) | required | not used |
+| Cognite IdP (CogIdP) | `cdf` | not used | not used — the Toolkit authenticates against `https://auth.cognite.com/oauth2/token` |
+| Other OIDC provider | `other` | not used | required, together with `IDP_AUDIENCE` |
+
+The generated workflows do not pass `IDP_TOKEN_URL` or `IDP_AUDIENCE`, so the third row
+needs a change to the workflow templates — raise it in
+[#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX).
 
 ## Toolkit configs
 

--- a/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
+++ b/modules/common/cdf_project_foundation/templates/github/FOUNDATION_CICD.md
@@ -58,8 +58,7 @@ workflows default it to `entra_id`, so Entra ID projects can leave the variable 
 | Other OIDC provider | `other` | not used | required, together with `IDP_AUDIENCE` |
 
 The generated workflows do not pass `IDP_TOKEN_URL` or `IDP_AUDIENCE`, so the third row
-needs a change to the workflow templates — raise it in
-[#topic-deployment-packs](https://cognitedata.slack.com/archives/C098QJ09YKX).
+needs a change to the workflow templates.
 
 ## Toolkit configs
 

--- a/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy-prod.yml
@@ -21,6 +21,7 @@ jobs:
       CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
       CDF_PROJECT: ${{ vars.CDF_PROJECT }}
       LOGIN_FLOW: ${{ vars.LOGIN_FLOW }}
+      PROVIDER: ${{ vars.PROVIDER || 'entra_id' }}
       IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
       IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
       ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}

--- a/modules/common/cdf_project_foundation/templates/github/deploy.yml
+++ b/modules/common/cdf_project_foundation/templates/github/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
       CDF_PROJECT: ${{ vars.CDF_PROJECT }}
       LOGIN_FLOW: ${{ vars.LOGIN_FLOW }}
+      PROVIDER: ${{ vars.PROVIDER || 'entra_id' }}
       IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
       IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
       ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}

--- a/modules/common/cdf_project_foundation/templates/github/dry-run.yml
+++ b/modules/common/cdf_project_foundation/templates/github/dry-run.yml
@@ -113,6 +113,7 @@ jobs:
       CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
       CDF_PROJECT: ${{ vars.CDF_PROJECT }}
       LOGIN_FLOW: ${{ vars.LOGIN_FLOW }}
+      PROVIDER: ${{ vars.PROVIDER || 'entra_id' }}
       IDP_TENANT_ID: ${{ vars.IDP_TENANT_ID }}
       IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
       ADMIN_SOURCE_ID: ${{ vars.ADMIN_SOURCE_ID }}

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -142,6 +142,11 @@ environment:
         "setup_project.py --check"
     ) in deploy_prod
 
+    provider_env = "PROVIDER: ${{ vars.PROVIDER || 'entra_id' }}"
+    assert provider_env in dry_run
+    assert provider_env in deploy_dev
+    assert provider_env in deploy_prod
+
     cicd_docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
     assert "`acme-dev`" in cicd_docs
     assert "`acme-test`" in cicd_docs
@@ -151,6 +156,8 @@ environment:
     assert "`PRODUCER_SOURCE_ID`" in cicd_docs
     assert "skips the pre-commit config lint step" in cicd_docs
     assert "ruff check` and `pyright`" in cicd_docs
+    assert "`PROVIDER`" in cicd_docs
+    assert "Cognite IdP" in cicd_docs
 
 
 def test_generate_actions_validates_environment_name(tmp_path: Path) -> None:
@@ -740,6 +747,8 @@ def test_generate_actions_ado_writes_pipelines_and_docs(tmp_path: Path) -> None:
     assert "Allow access to all pipelines" in docs
     assert "toolkit-config" in docs
     assert "IDP_TOKEN_URL" in docs
+    assert "`PROVIDER`" in docs
+    assert "Cognite IdP" in docs
     assert "GitHub Release" not in docs
     # ADO's Build Validation policy references a pipeline, not a job display name
     # inside it — the branch-protection table must not carry over GitHub wording.

--- a/tests/test_foundation_cicd_generator.py
+++ b/tests/test_foundation_cicd_generator.py
@@ -1,6 +1,7 @@
 """Tests for Foundation Deployment Pack CI/CD generator (cdf_project_foundation)."""
 
-
+import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -99,9 +100,7 @@ environment:
     assert (tmp_path / ".github" / "workflows" / "deploy-prod.yml").is_file()
     assert (tmp_path / "docs" / "FOUNDATION_CICD.md").is_file()
 
-    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(
-        encoding="utf-8"
-    )
+    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(encoding="utf-8")
     assert "'industrial/config*.yaml'" in dry_run
     assert "'industrial/modules/sourcesystem/cdf_pi_extractor/'" not in dry_run
     assert "No .pre-commit-config.yaml found; skipping pre-commit config lint." in dry_run
@@ -111,16 +110,11 @@ environment:
     assert "cdf build --env dev" in dry_run
     assert "cdf deploy --dry-run | tee dryrun-output.txt" in dry_run
     assert "cdf deploy --dry-run --env" not in dry_run
-    assert (
-        "run: python industrial/modules/common/cdf_project_foundation/scripts/"
-        "setup_project.py --check"
-    ) in dry_run
+    assert ("run: python industrial/modules/common/cdf_project_foundation/scripts/setup_project.py --check") in dry_run
     # The check step must run before the "cdf build" step, not after.
     assert dry_run.index("Verify project config is in sync") < dry_run.index("- name: cdf build")
 
-    deploy_dev = (tmp_path / ".github" / "workflows" / "deploy-dev.yml").read_text(
-        encoding="utf-8"
-    )
+    deploy_dev = (tmp_path / ".github" / "workflows" / "deploy-dev.yml").read_text(encoding="utf-8")
     assert "name: Deploy to acme-dev" in deploy_dev
     assert "run: cdf build --env dev" in deploy_dev
     assert "run: cdf deploy" in deploy_dev
@@ -129,17 +123,13 @@ environment:
     assert "CONSUMER_SOURCE_ID: ${{ vars.CONSUMER_SOURCE_ID }}" in deploy_dev
     assert "PRODUCER_SOURCE_ID: ${{ vars.PRODUCER_SOURCE_ID }}" in deploy_dev
     assert (
-        "run: python industrial/modules/common/cdf_project_foundation/scripts/"
-        "setup_project.py --check"
+        "run: python industrial/modules/common/cdf_project_foundation/scripts/setup_project.py --check"
     ) in deploy_dev
     assert deploy_dev.index("Verify project config is in sync") < deploy_dev.index("- name: cdf build")
 
-    deploy_prod = (tmp_path / ".github" / "workflows" / "deploy-prod.yml").read_text(
-        encoding="utf-8"
-    )
+    deploy_prod = (tmp_path / ".github" / "workflows" / "deploy-prod.yml").read_text(encoding="utf-8")
     assert (
-        "run: python industrial/modules/common/cdf_project_foundation/scripts/"
-        "setup_project.py --check"
+        "run: python industrial/modules/common/cdf_project_foundation/scripts/setup_project.py --check"
     ) in deploy_prod
 
     provider_env = "PROVIDER: ${{ vars.PROVIDER || 'entra_id' }}"
@@ -158,6 +148,56 @@ environment:
     assert "ruff check` and `pyright`" in cicd_docs
     assert "`PROVIDER`" in cicd_docs
     assert "Cognite IdP" in cicd_docs
+
+
+def _parse_github_workflow(text: str) -> dict[str, object]:
+    """Quote ${{ }} expressions so PyYAML can load GitHub workflow YAML."""
+    quoted = re.sub(r"\$\{\{.*?\}\}", lambda m: json.dumps(m.group(0)), text)
+    loaded = yaml.safe_load(quoted)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_github_cdf_jobs_pass_provider_so_cogidp_can_authenticate(tmp_path: Path) -> None:
+    """GitHub Actions only injects env vars listed on the job.
+
+    Without PROVIDER the Toolkit stays on entra_id and a CogIdP project fails at
+    auth. An empty value is also invalid — the fallback must be the literal entra_id.
+    IDP_TOKEN_URL is unused when PROVIDER=cdf; do not plumb it.
+    """
+    _scaffold_project_with_envs(tmp_path, ("dev", "test", "prod"))
+    subprocess.run(
+        [sys.executable, str(GENERATE_ACTIONS), "--force"],
+        check=True,
+        cwd=tmp_path,
+    )
+
+    provider = "${{ vars.PROVIDER || 'entra_id' }}"
+    cdf_jobs = 0
+    workflows = sorted((tmp_path / ".github" / "workflows").glob("*.yml"))
+    assert workflows, "generator wrote no GitHub workflows"
+    for path in workflows:
+        parsed = _parse_github_workflow(path.read_text(encoding="utf-8"))
+        jobs = parsed["jobs"]
+        assert isinstance(jobs, dict)
+        for job in jobs.values():
+            assert isinstance(job, dict)
+            steps = job.get("steps", [])
+            assert isinstance(steps, list)
+            runs_cdf = any(isinstance(step, dict) and "cdf " in str(step.get("run", "")) for step in steps)
+            if not runs_cdf:
+                continue
+            cdf_jobs += 1
+            env = job.get("env", {})
+            assert isinstance(env, dict)
+            assert env.get("PROVIDER") == provider, f"{path.name} cdf job is missing PROVIDER"
+            assert "IDP_TOKEN_URL" not in env
+            assert "IDP_AUDIENCE" not in env
+    # dry-run + deploy-dev + deploy-test + deploy-prod
+    assert cdf_jobs == 4
+
+    docs = (tmp_path / "docs" / "FOUNDATION_CICD.md").read_text(encoding="utf-8")
+    assert "| Cognite IdP (CogIdP) | `cdf`" in docs
 
 
 def test_generate_actions_validates_environment_name(tmp_path: Path) -> None:
@@ -239,18 +279,14 @@ environment:
         cwd=tmp_path,
     )
 
-    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(
-        encoding="utf-8"
-    )
+    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(encoding="utf-8")
     assert "cdf build -c industrial/config.dev.yaml" in dry_run
     assert "cdf build -c industrial/config.test.yaml" in dry_run
     assert 'case "$GITHUB_BASE_REF" in' in dry_run
     assert "Unsupported base branch $GITHUB_BASE_REF" in dry_run
     assert "cdf build --env" not in dry_run
 
-    deploy_prod = (tmp_path / ".github" / "workflows" / "deploy-prod.yml").read_text(
-        encoding="utf-8"
-    )
+    deploy_prod = (tmp_path / ".github" / "workflows" / "deploy-prod.yml").read_text(encoding="utf-8")
     assert "run: cdf build -c industrial/config.prod.yaml" in deploy_prod
     assert "run: cdf deploy" in deploy_prod
     assert "cdf deploy --env" not in deploy_prod
@@ -302,9 +338,7 @@ environment:
     assert not stale_test_workflow.exists()
     assert (tmp_path / ".github" / "workflows" / "deploy-prod.yml").is_file()
 
-    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(
-        encoding="utf-8"
-    )
+    dry_run = (tmp_path / ".github" / "workflows" / "dry-run.yml").read_text(encoding="utf-8")
     assert "      - dev" in dry_run
     assert "      - main" not in dry_run
     assert "deploy-test.yml" not in dry_run
@@ -859,8 +893,7 @@ def test_generate_actions_ado_dev_only_has_branch_condition(tmp_path: Path) -> N
 
     dry_run_dev_job = next(job for job in dry_run_yaml["jobs"] if job["job"] == "dry_run_dev")
     assert dry_run_dev_job["condition"] == (
-        "and(succeeded(), "
-        "in(variables['System.PullRequest.TargetBranch'], 'refs/heads/dev', 'dev'))"
+        "and(succeeded(), in(variables['System.PullRequest.TargetBranch'], 'refs/heads/dev', 'dev'))"
     )
     # No test/main branch configured, so the promotion-flow guard job is never
     # generated at all -- the target-branch check lives inside lint regardless.
@@ -891,14 +924,12 @@ def test_generate_actions_ado_test_only_promotion_guard_skips_non_pr_runs(tmp_pa
     dry_run_yaml = yaml.safe_load(dry_run_path.read_text(encoding="utf-8"))
     dry_run_test_job = next(job for job in dry_run_yaml["jobs"] if job["job"] == "dry_run_test")
     assert dry_run_test_job["condition"] == (
-        "and(succeeded(), "
-        "in(variables['System.PullRequest.TargetBranch'], 'refs/heads/main', 'main'))"
+        "and(succeeded(), in(variables['System.PullRequest.TargetBranch'], 'refs/heads/main', 'main'))"
     )
     assert set(dry_run_test_job["dependsOn"]) == {"lint", "source_branch_guard"}
     source_branch_guard_job = next(job for job in dry_run_yaml["jobs"] if job["job"] == "source_branch_guard")
     assert source_branch_guard_job["condition"] == (
-        "and(succeeded(), "
-        "in(variables['System.PullRequest.TargetBranch'], 'refs/heads/main', 'main'))"
+        "and(succeeded(), in(variables['System.PullRequest.TargetBranch'], 'refs/heads/main', 'main'))"
     )
 
     dry_run_text = dry_run_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Generated GitHub workflows only passed **Entra**-shaped auth vars, so a **CogIdP** project stayed on the Toolkit default (entra_id) and failed at auth.

Workflows now set PROVIDER: ${{ vars.PROVIDER || 'entra_id' }} on every job that runs cdf. The fallback is the literal entra_id because an empty value makes the Toolkit raise Invalid provider. IDP_TOKEN_URL is not plumbed: with PROVIDER=cdf the Toolkit uses https://auth.cognite.com/oauth2/token.

Docs (GitHub + ADO) spell out Entra / CogIdP / other OIDC. ADO needs no YAML change — variable groups already export non-secret values.

**Test plan**

- uv run pytest tests/test_foundation_cicd_generator.py -q
- Confirm test_github_cdf_jobs_pass_provider_so_cogidp_can_authenticate passes: all 4 cdf jobs (dry-run, deploy-dev, deploy-test, deploy-prod) have PROVIDER with the entra_id fallback, and none pass IDP_TOKEN_URL / IDP_AUDIENCE
- Entra project: leave PROVIDER unset, regenerate workflows, cdf build / cdf deploy --dry-run still authenticate
- CogIdP project: set GitHub Environment variable PROVIDER=cdf, regenerate, auth succeeds against Cognite IdP
- ADO: add PROVIDER=cdf to the -toolkit-config group only — no pipeline YAML change required