### PR TITLE
File annotation module's variable list update in foundation DP setup script

### DIFF
--- a/modules/common/cdf_project_foundation/scripts/setup_project.py
+++ b/modules/common/cdf_project_foundation/scripts/setup_project.py
@@ -179,6 +179,7 @@ CONTEXTUALIZATION_VARIABLES: dict[str, dict[str, dict]] = {
             "targetEntitySchemaSpace": "dm_dom_isa_manufacturing",
             "targetEntityInstanceSpace": None,
             "targetEntityExternalId": "ISAAsset",
+            "cdmDataModelExternalId": "ISA_Manufacturing_DOM",
         },
     },
     "cfihos_oil_and_gas_extension": {
@@ -205,6 +206,7 @@ CONTEXTUALIZATION_VARIABLES: dict[str, dict[str, dict]] = {
             "targetEntitySchemaSpace": "dm_dom_oil_and_gas",
             "targetEntityInstanceSpace": None,
             "targetEntityExternalId": "Tag",
+            "cdmDataModelExternalId": "dm_oil_and_gas_domain_model",
         },
     },
 }


### PR DESCRIPTION
Fix applied in setup_project.py:
- *ISA variant (cdf_file_annotation block)*: added `"cdmDataModelExternalId": "ISA_Manufacturing_DOM"` 
- *CFIHOS variant*: added `"cdmDataModelExternalId": "dm_oil_and_gas_domain_model"`

`resolve_contextualization_variables()` writes any key present in the per-variant dict, so no other logic changes were needed because of parent PR #405 changes.