### PR TITLE
Log update of Alias Update function

### DIFF
--- a/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/README.md
+++ b/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/README.md
@@ -123,7 +123,7 @@ before this setting existed keeps behaving the same.
 When no pattern extracts anything from a name, **no alias is produced**. The `aliases`
 property is then written as null, which clears whatever was stored — an empty list would
 leave the old values in place, so `removeOldAliases` would not remove anything. Instances
-that had no aliases to begin with are left untouched. The run logs `No alias extracted based on input regular expression for name: …` for
+that had no aliases to begin with are left untouched. The run logs `No alias extracted based on configured <view> regular expression for name: …` for
 the first ten such names, then counts the rest and reports the total once at the end. A run
 full of those warnings means the pattern does not match your names, not that the data is
 wrong.
@@ -431,12 +431,19 @@ data = {
 
 ### Performance Logs
 
+At **INFO**, expect startup, extraction pipeline id, loaded configuration summary, per-view progress, batch apply counts, and processing stats. Timing, memory, and performance summaries are **DEBUG** only.
+
 ```
-🚀 Starting OPTIMIZED metadata update with loglevel = INFO
-📝 Reading parameters from extraction pipeline config: ep_ctx_aliases_update
-⏱️ Time: Configuration processing took 0.12 seconds
+Starting Aliases Update with loglevel = INFO
+Reading parameters from extraction pipeline config: ep_ctx_aliases_update
+Configuration loading took 0.13s
+Loaded extraction pipeline configuration:
+  parameters:
+    debug: False
+    runAll: True
+    ...
 📊 Processing Stats: 1000 processed, 800 updated, 80.00% update rate
-🎉 Optimized metadata update completed successfully!
+Aliases Update completed successfully!
 ```
 
 ## 🤝 Contributing

--- a/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/alias_optimizations.py
+++ b/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/alias_optimizations.py
@@ -66,7 +66,7 @@ def time_operation(operation_name: str, logger: CogniteFunctionLogger):
         yield
     finally:
         duration = time.time() - start
-        logger.info(f"⏱️ {operation_name} took {duration:.2f} seconds")
+        logger.debug(f"⏱️ {operation_name} took {duration:.2f} seconds")
 
 
 def monitor_memory_usage(logger: CogniteFunctionLogger, operation_name: str = ""):
@@ -74,7 +74,7 @@ def monitor_memory_usage(logger: CogniteFunctionLogger, operation_name: str = ""
     try:
         process = Process()
         memory_mb = process.memory_info().rss / 1024 / 1024
-        logger.info(f"📊 Memory: {operation_name} - {memory_mb:.1f} MB")
+        logger.debug(f"📊 Memory: {operation_name} - {memory_mb:.1f} MB")
     except Exception as e:
         logger.debug(f"Could not monitor memory: {e}")
 
@@ -360,16 +360,20 @@ class OptimizedMetadataProcessor:
             'names_without_alias': 0,
         }
 
-    def _warn_name_without_alias(self, name: str) -> None:
+    def _warn_name_without_alias(self, name: str, entity_label: str) -> None:
         """Note a name no pattern reads, warning about only the first few.
 
         Every such name is counted, so `log_missing_alias_summary` can report the total
         once the run is over.
+
+        Args:
+            name: Instance name property value that did not match any pattern.
+            entity_label: Human-readable view kind, e.g. ``Configured timeseries``.
         """
         self.stats['names_without_alias'] += 1
         if self.stats['names_without_alias'] <= _MAX_MISSING_ALIAS_WARNINGS:
             self.logger.warning(
-                "No alias extracted based on input regular expression "
+                f"No alias extracted based on {entity_label} regular expression "
                 f"for name: {name}"
             )
 
@@ -425,7 +429,7 @@ class OptimizedMetadataProcessor:
                 )
             )
             if name and not upd_aliases and not _generated_aliases(name, self.timeseries_alias_rule):
-                self._warn_name_without_alias(name)
+                self._warn_name_without_alias(name, "Configured timeseries")
 
             upd_aliases = _dedupe_preserve_order(upd_aliases)
 
@@ -498,7 +502,7 @@ class OptimizedMetadataProcessor:
                 )
             )
             if name and not upd_aliases and not _generated_aliases(name, self.asset_alias_rule):
-                self._warn_name_without_alias(name)
+                self._warn_name_without_alias(name, "Configured asset")
 
             upd_aliases = _dedupe_preserve_order(upd_aliases)
 
@@ -578,7 +582,7 @@ class OptimizedMetadataProcessor:
             )
 
             if name and not upd_aliases and not _generated_aliases(name, self.file_alias_rule):
-                self._warn_name_without_alias(name)
+                self._warn_name_without_alias(name, "Configured file")
 
             upd_aliases = _dedupe_preserve_order(upd_aliases)
 
@@ -669,7 +673,7 @@ class PerformanceBenchmark:
                 self.benchmarks[name] = []
             
             self.benchmarks[name].append(duration)
-            self.logger.info(f"🚀 {name} took {duration:.2f}s")
+            self.logger.debug(f"🚀 {name} took {duration:.2f}s")
             
             return result
         except Exception as e:
@@ -682,11 +686,11 @@ class PerformanceBenchmark:
         if not self.benchmarks:
             return
         
-        self.logger.info("📊 Performance Summary:")
+        self.logger.debug("📊 Performance Summary:")
         for name, times in self.benchmarks.items():
             avg_time = sum(times) / len(times)
             total_time = sum(times)
-            self.logger.info(f"  {name}: {len(times)} calls, avg {avg_time:.2f}s, total {total_time:.2f}s")
+            self.logger.debug(f"  {name}: {len(times)} calls, avg {avg_time:.2f}s, total {total_time:.2f}s")
 
 
 def optimize_metadata_processing():

--- a/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/config.py
+++ b/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/config.py
@@ -89,6 +89,39 @@ class Config(BaseModel, alias_generator=to_camel):
     data: ConfigData
 
 
+def _format_view_block(label: str, view: ViewPropertyConfig | None) -> list[str]:
+    if view is None:
+        return [f"    {label}: (not configured — skipped)"]
+    pattern_display = view.alias_patterns if len(view.alias_patterns) > 1 else view.alias_patterns[0]
+    return [
+        f"    {label}:",
+        f"      view: {view.external_id} ({view.schema_space}/{view.version})",
+        f"      instanceSpace: {view.instance_spaces}",
+        f"      aliasPattern: {pattern_display}",
+        f"      aliasSelection: {view.alias_selection}",
+    ]
+
+
+def format_config_for_log(config: Config) -> str:
+    """Return a multi-line summary of the loaded extraction pipeline configuration."""
+    params = config.parameters
+    lines = [
+        "Loaded extraction pipeline configuration:",
+        "  parameters:",
+        f"    debug: {params.debug}",
+        f"    runAll: {params.run_all}",
+        f"    updateAll: {params.update_all}",
+        f"    removeOldAliases: {params.remove_old_aliases}",
+        f"    rawDb: {params.raw_db}",
+        f"    rawTableState: {params.raw_table_state}",
+        "  data.job:",
+    ]
+    lines.extend(_format_view_block("timeseriesView", config.data.job.timeseries_view))
+    lines.extend(_format_view_block("assetView", config.data.job.asset_view))
+    lines.extend(_format_view_block("fileView", config.data.job.file_view))
+    return "\n".join(lines)
+
+
 def load_config_parameters(client: CogniteClient, function_data: dict[str, Any]) -> Config:
     """Retrieves the configuration parameters from the function data and loads the configuration from CDF."""
     if "ExtractionPipelineExtId" not in function_data:

--- a/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/handler.py
+++ b/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/handler.py
@@ -7,6 +7,7 @@ performance monitoring, error handling, and logging as the default implementatio
 
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +23,7 @@ from alias_optimizations import (
     optimize_metadata_processing,
     time_operation,
 )
-from config import load_config_parameters
+from config import format_config_for_log, load_config_parameters
 from logger import CogniteFunctionLogger
 from pipeline import metadata_update
 
@@ -82,19 +83,18 @@ def handle(data: dict[str, Any], client: CogniteClient) -> dict[str, Any]:
         logger = CogniteFunctionLogger(loglevel)
         benchmark = PerformanceBenchmark(logger)
         
-        logger.info(f"🚀 Starting OPTIMIZED metadata update with loglevel = {loglevel}")
-        logger.info(f"📝 Reading parameters from extraction pipeline config: {data.get('ExtractionPipelineExtId')}")
+        logger.info(f"Starting Aliases Update with loglevel = {loglevel}")
+        pipeline_ext_id = data.get("ExtractionPipelineExtId")
+        logger.info(f"Reading parameters from extraction pipeline config: {pipeline_ext_id}")
         
         # Monitor initial memory usage
         monitor_memory_usage(logger, "Handler start")
         
-        # Load configuration with timing
-        config = benchmark.benchmark_function(
-            "Configuration loading",
-            load_config_parameters,
-            client, data
-        )
-        logger.debug("✅ Configuration loaded successfully")
+        load_start = time.time()
+        config = load_config_parameters(client, data)
+        load_duration = time.time() - load_start
+        logger.info(f"Configuration loading took {load_duration:.2f}s")
+        logger.info(format_config_for_log(config))
         
         # Execute optimized metadata update pipeline
         with time_operation("Complete metadata update pipeline", logger):
@@ -112,11 +112,11 @@ def handle(data: dict[str, Any], client: CogniteClient) -> dict[str, Any]:
         if benchmark:
             benchmark.log_summary()
         
-        logger.info("🎉 Optimized metadata update completed successfully!")
+        logger.info("Aliases Update completed successfully!")
         return {"status": "succeeded", "data": data}
         
     except Exception as e:
-        message = f"Optimized metadata update failed: {e!s}"
+        message = f"Aliases Update failed: {e!s}"
         
         if logger:
             logger.error(message)

--- a/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/pipeline.py
+++ b/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/pipeline.py
@@ -213,7 +213,7 @@ def metadata_update(
         benchmark.log_summary()
         
     except Exception as e:
-        msg = f"Optimized metadata update failed: {e!s}, traceback:\n{traceback.format_exc()}"
+        msg = f"Aliases Update failed: {e!s}, traceback:\n{traceback.format_exc()}"
         logger.error(msg)
         update_pipeline_run(client, logger, pipeline_ext_id, "failure", msg)
         raise

--- a/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/test_pipeline.py
+++ b/modules/contextualization/cdf_entity_matching/functions/fn_dm_context_aliases_update/test_pipeline.py
@@ -11,7 +11,7 @@ from cognite.client import data_modeling as dm
 from cognite.client.exceptions import CogniteAPIError, CogniteConnectionError
 from pydantic import ValidationError
 
-from config import Config, ConfigData, JobConfig, Parameters, ViewPropertyConfig  # isort: skip
+from config import Config, ConfigData, JobConfig, Parameters, ViewPropertyConfig, format_config_for_log  # isort: skip
 from constants import DEFAULT_ALIAS_PATTERN, TS_NODE  # isort: skip
 from logger import CogniteFunctionLogger  # isort: skip
 from pipeline import (  # isort: skip
@@ -76,6 +76,14 @@ class TestPipelineHelpers(unittest.TestCase):
                 )
             ),
         )
+
+    def test_format_config_for_log_includes_parameters_and_views(self) -> None:
+        summary = format_config_for_log(self._config(run_all=True, update_all=False))
+        self.assertIn("runAll: True", summary)
+        self.assertIn("updateAll: False", summary)
+        self.assertIn("timeseriesView:", summary)
+        self.assertIn("CogniteTimeSeries", summary)
+        self.assertIn("assetView:", summary)
 
     def test_file_view_is_optional(self) -> None:
         """A config written before file support existed must still load."""


### PR DESCRIPTION
Updated startup and runtime logging for fn_dm_context_aliases_update as follows.

Startup (INFO)
“Starting Aliases Update with loglevel = …” (replaces “OPTIMIZED metadata update”). Extraction pipeline id unchanged in spirit: Reading parameters from extraction pipeline config: ep_ctx_aliases_update. Configuration loading took X.XXs plus a multi-line format_config_for_log() dump (config.py): parameters (debug, runAll, updateAll, removeOldAliases, RAW keys) and each configured view (timeseriesView, assetView, fileView with view id, spaces, aliasPattern, aliasSelection). Moved to DEBUG
Memory lines (Handler start/end, Pipeline start/end). All time_operation timings (fetch/process/batches, pipeline sections). PerformanceBenchmark per-step timings and both Performance Summary blocks (handler + pipeline). Warnings
Missing-alias text is now view-specific, e.g. No alias extracted based on Configured asset regular expression for name: … (timeseries / file variants use Configured timeseries / Configured file). Other
Success/failure: “Aliases Update completed successfully!” / “Aliases Update failed: …”. README log section updated; test_format_config_for_log_includes_parameters_and_views added. 88 tests passing.
Set logLevel: DEBUG on the function invocation when you want timings, memory, and performance summaries in the run log.